### PR TITLE
recover from panic

### DIFF
--- a/cmd/ks-apiserver/app/server.go
+++ b/cmd/ks-apiserver/app/server.go
@@ -71,6 +71,7 @@ func Run(s *options.ServerRunOptions) error {
 	waitForResourceSync()
 
 	container := runtime.Container
+	container.DoNotRecover(false)
 	container.Filter(filter.Logging)
 
 	for _, webservice := range container.RegisteredWebServices() {

--- a/cmd/ks-iam/app/server.go
+++ b/cmd/ks-iam/app/server.go
@@ -83,6 +83,7 @@ func Run(s *options.ServerRunOptions) error {
 
 	container := runtime.Container
 	container.Filter(filter.Logging)
+	container.DoNotRecover(false)
 
 	for _, webservice := range container.RegisteredWebServices() {
 		for _, route := range webservice.Routes() {


### PR DESCRIPTION
Signed-off-by: runzexia <runzexia@yunify.com>

use go restful panic recover to return http error
https://github.com/emicklei/go-restful#features