### PR TITLE
fix: limit PromQL range query start time

### DIFF
--- a/pkg/simple/client/prometheus/prometheusclient.go
+++ b/pkg/simple/client/prometheus/prometheusclient.go
@@ -20,6 +20,7 @@ package prometheus
 import (
 	"flag"
 	"io/ioutil"
+	"kubesphere.io/kubesphere/pkg/informers"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -145,6 +146,18 @@ func ParseMonitoringRequestParams(request *restful.Request) *MonitoringRequestPa
 	u := url.Values{}
 
 	if start != "" && end != "" {
+
+		// range query start time must be greater than the namespace creation time
+		if nsName != "" {
+			nsLister := informers.SharedInformerFactory().Core().V1().Namespaces().Lister()
+			ns, err := nsLister.Get(nsName)
+			if err != nil {
+				glog.Error("failed to get namespace, error: ", err)
+			} else {
+				start = strconv.FormatInt(ns.CreationTimestamp.Unix(), 10)
+			}
+		}
+
 		u.Set("start", convertTimeGranularity(start))
 		u.Set("end", convertTimeGranularity(end))
 		u.Set("step", step)


### PR DESCRIPTION
Currently, the monitoring model doesn't well distinguish metrics from a deleted namespace and a re-created one of the same name. So users may find a new created namespace has histroy metrics, even if no wordload added

Note that the commit is a workaround solution for now 

Signed-off-by: huanggze <loganhuang@yunify.com>