### PR TITLE
fix-devops-api-get-pipelines-404

### DIFF
--- a/pkg/apiserver/devops/devops.go
+++ b/pkg/apiserver/devops/devops.go
@@ -29,8 +29,8 @@ import (
 const jenkinsHeaderPre = "X-"
 
 func GetPipeline(req *restful.Request, resp *restful.Response) {
-	projectName := req.PathParameter("projectName")
-	pipelineName := req.PathParameter("pipelineName")
+	projectName := req.PathParameter("devops")
+	pipelineName := req.PathParameter("pipelines")
 
 	res, err := devops.GetPipeline(projectName, pipelineName, req.Request)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: runzexia <runzexia@yunify.com>
PR #475 In order to avoid the equivalent path, the name of the parameter is modified, which will cause the code to fail to get the parameter.