### PR TITLE
api: update descriptions and change path for monitoring apis

### DIFF
--- a/pkg/apis/monitoring/v1alpha2/register.go
+++ b/pkg/apis/monitoring/v1alpha2/register.go
@@ -6,7 +6,7 @@
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+ http://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
@@ -45,10 +45,10 @@ func addWebService(c *restful.Container) error {
 	ws.Route(ws.GET("/cluster").To(monitoring.MonitorCluster).
 		Doc("Get cluster-level metrics.").
 		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. cluster_cpu|cluster_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step. eg. 10m.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. eg. 1559762729.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "cluster"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -61,9 +61,9 @@ func addWebService(c *restful.Container) error {
 		Param(ws.QueryParameter("resources_filter", "Node filter in regexp pattern, eg. i-caojnter|i-cmu82ogj.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_metric", "Sort nodes by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "The number of paged results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
+		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
 		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation to the result. One of rank, statistics.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank nodes.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "node"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -74,10 +74,10 @@ func addWebService(c *restful.Container) error {
 		Doc("Get specific node metrics.").
 		Param(ws.PathParameter("node", "Specify the target node.").DataType("string").Required(true)).
 		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. node_cpu|node_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step. eg. 10m.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. eg. 1559762729.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "node"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -90,9 +90,9 @@ func addWebService(c *restful.Container) error {
 		Param(ws.QueryParameter("resources_filter", "Namespace filter in regexp pattern, eg. namespace-1|namespace-2.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_metric", "Sort namespaces by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "The number of paged results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
+		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
 		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation to the result. One of rank, statistics.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank namespaces.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "namespace"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -103,10 +103,10 @@ func addWebService(c *restful.Container) error {
 		Doc("Get specific namespace metrics.").
 		Param(ws.PathParameter("namespace", "Specify the target namespace.").DataType("string").Required(true)).
 		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. namespace_cpu|namespace_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step. eg. 10m.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. eg. 1559762729.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "namespace"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -120,9 +120,9 @@ func addWebService(c *restful.Container) error {
 		Param(ws.QueryParameter("resources_filter", "Pods filter in regexp pattern, eg. coredns-77b8449dc9-hd6gd|coredns-77b8449dc9-b4n74.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_metric", "Sort pods by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "The number of paged results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
+		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
 		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation to the result. One of rank, statistics.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank pods.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "pod"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -130,14 +130,14 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/namespaces/{namespace}/pods/{pod}").To(monitoring.MonitorSpecificPodOfSpecificNamespace).
-		Doc("Get specific pod metrics.").
+		Doc("Get specific pod metrics of a given namespace.").
 		Param(ws.PathParameter("namespace", "Specify the target namespace.").DataType("string").Required(true)).
 		Param(ws.PathParameter("pod", "Specify the target pod.").DataType("string").Required(true)).
 		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. pod_cpu|pod_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step. eg. 10m.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. eg. 1559762729.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "pod"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -151,9 +151,9 @@ func addWebService(c *restful.Container) error {
 		Param(ws.QueryParameter("resources_filter", "Pod filter in regexp pattern, eg. coredns-77b8449dc9-hd6gd|coredns-77b8449dc9-b4n74.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_metric", "Sort pods by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "The number of paged results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
+		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
 		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation to the result. One of rank, statistics.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank pods.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "pod"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -165,10 +165,10 @@ func addWebService(c *restful.Container) error {
 		Param(ws.PathParameter("node", "Specify the target node.").DataType("string").Required(true)).
 		Param(ws.PathParameter("pod", "Specify the target pod.").DataType("string").Required(true)).
 		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. pod_cpu|pod_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step. eg. 10m.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. eg. 1559762729.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "pod"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -176,16 +176,16 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/nodes/{node}/pods/{pod}/containers").To(monitoring.MonitorAllContainersOnSpecificNode).
-		Doc("Get container-level metrics under a given node and pod.").
+		Doc("Get container-level metrics of a specific pod on a node.").
 		Param(ws.PathParameter("node", "Specify the target node.").DataType("string").Required(true)).
 		Param(ws.PathParameter("pod", "Specify the target pod.").DataType("string").Required(true)).
 		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. container_cpu|container_memory.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("resources_filter", "Container filter in regexp pattern.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_metric", "Sort containers by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "The number of paged results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
+		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
 		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation to the result. One of rank, statistics.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank containers.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "container"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -200,9 +200,9 @@ func addWebService(c *restful.Container) error {
 		Param(ws.QueryParameter("resources_filter", "Container filter in regexp pattern.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_metric", "Sort containers by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "The number of paged results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
+		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
 		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation to the result. One of rank, statistics.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank containers.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "container"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -215,29 +215,31 @@ func addWebService(c *restful.Container) error {
 		Param(ws.PathParameter("pod", "Specify the target pod.").DataType("string").Required(true)).
 		Param(ws.PathParameter("container", "Specify the target container.").DataType("string").Required(true)).
 		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. container_cpu|container_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step. eg. 10m.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. eg. 1559762729.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "container"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
 		Consumes(restful.MIME_JSON, restful.MIME_XML).
 		Produces(restful.MIME_JSON)
 
-	// Only use this api to monitor status of pods under the {workload}
+	// Only use this api to monitor pod status of a {workload}
 	// To monitor a specific workload, try the next two apis with "resources_filter"
-	ws.Route(ws.GET("/namespaces/{namespace}/workloads/{kind}/{workload}").To(monitoring.MonitorSpecificWorkload).
-		Doc("Get specific workload metrics under a given namespace.").
+	ws.Route(ws.GET("/namespaces/{namespace}/workloads/{kind}/{workload}/pods").To(monitoring.MonitorSpecificWorkload).
+		Doc("Get all pod-level metrics of a workload.").
 		Param(ws.PathParameter("namespace", "Specify the target namespace.").DataType("string").Required(true)).
-		Param(ws.PathParameter("kind", "Specify the target workload kind. One of deployment, daemonset, statefulset. Other values will be interpreted as any of three.").DataType("string").Required(true).DefaultValue("(.*)")).
+		Param(ws.PathParameter("kind", "Specify the target workload kind. One of deployment, daemonset, statefulset.").DataType("string").Required(true).DefaultValue("(.*)")).
 		Param(ws.PathParameter("workload", "Specify the target workload.").DataType("string").Required(true)).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. workload_cpu|workload_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step. eg. 10m.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. eg. 1559762729.").DataType("string").Required(false)).
-		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "workload"}).
+		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. pod_cpu|pod_memory.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("resources_filter", "Pod filter in regexp pattern.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank pods.").DataType("string").Required(false)).
+		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "pod"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
 		Consumes(restful.MIME_JSON, restful.MIME_XML).
@@ -248,12 +250,12 @@ func addWebService(c *restful.Container) error {
 		Param(ws.PathParameter("namespace", "Specify the target namespace.").DataType("string").Required(true)).
 		Param(ws.PathParameter("kind", "Specify the target workload kind. One of deployment, daemonset, statefulset. Other values will be interpreted as any of three.").DataType("string").Required(true).DefaultValue("(.*)")).
 		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. node_cpu|node_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("resources_filter", "Workload filter in regexp pattern.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("resources_filter", "Workload filter, separated by vertical bar. eg. fluent-bit|elasticsearch-logging-data. The workload filter does not support regexp so far.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_metric", "Sort workloads by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "The number of paged results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
+		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
 		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation to the result. One of rank, statistics.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank workloads.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "workload"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -264,12 +266,12 @@ func addWebService(c *restful.Container) error {
 		Doc("Get all workload-level metrics of a given namespace.").
 		Param(ws.PathParameter("namespace", "Specify the target namespace.").DataType("string").Required(true)).
 		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. workload_cpu|workload_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("resources_filter", "Workload filter in regexp pattern.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("resources_filter", "Workload filter, separated by vertical bar. eg. fluent-bit|elasticsearch-logging-data. The workload filter does not support regexp so far.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_metric", "Sort workloads by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "The number of paged results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
+		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
 		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation to the result. One of rank, statistics.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank workloads.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "workload"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -281,10 +283,11 @@ func addWebService(c *restful.Container) error {
 		Doc("Get specific workspace metrics.").
 		Param(ws.PathParameter("workspace", "Specify the target workspace.").DataType("string").Required(true)).
 		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. workspace_cpu|workspace_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step. eg. 10m.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. eg. 1559762729.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is statistics. Use statistics to get total number of namespaces, devops projects, users and roles in this workspace.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "workspace"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -297,9 +300,9 @@ func addWebService(c *restful.Container) error {
 		Param(ws.QueryParameter("resources_filter", "Workspace filter in regexp pattern, eg. workspace_1|workspace_2.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_metric", "Sort workspaces by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
 		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "The number of paged results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
+		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
 		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation to the result. One of rank, statistics.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("type", "Additional operation. Currently supported types are rank and statistics. Use rank with sort_metric and sort_type to rank workspaces. Use statistics to get total number of workspaces, devops projects, namespaces, users in the cluster.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "workspace"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -307,13 +310,13 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/components/{component}").To(monitoring.MonitorComponent).
-		Doc("Get service component-level metrics.").
+		Doc("Get component-level metrics.").
 		Param(ws.PathParameter("component", "Specify the target component. One of etcd, apiserver, scheduler, controller_manager, coredns, prometheus.").DataType("string").Required(true)).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. etcd_server_list|coredns_proxy.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step. eg. 10m.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End time of query range. eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. eg. 1559762729.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. etcd_server_list|etcd_mvcc_db_size.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "component"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).

--- a/pkg/models/metrics/metrics.go
+++ b/pkg/models/metrics/metrics.go
@@ -47,18 +47,18 @@ const (
 )
 
 type FormatedLevelMetric struct {
-	MetricsLevel string           `json:"metrics_level" description:"metrics level, eg. cluster"`
+	MetricsLevel string           `json:"metrics_level" description:"metric level, eg. cluster"`
 	Results      []FormatedMetric `json:"results" description:"actual array of results"`
 }
 
 type FormatedMetric struct {
-	MetricName string             `json:"metric_name,omitempty" description:"metrics name, eg. scheduler_up_sum"`
+	MetricName string             `json:"metric_name,omitempty" description:"metric name, eg. scheduler_up_sum"`
 	Status     string             `json:"status" description:"result status, one of error, success"`
-	Data       FormatedMetricData `json:"data,omitempty" description:"actual metrics result"`
+	Data       FormatedMetricData `json:"data,omitempty" description:"actual metric result"`
 }
 
 type FormatedMetricData struct {
-	Result     []map[string]interface{} `json:"result" description:"result presenting metric labels, a series of time points and their instant values"`
+	Result     []map[string]interface{} `json:"result" description:"result including metric labels, time points and values"`
 	ResultType string                   `json:"resultType" description:"result type, one of matrix, vector"`
 }
 


### PR DESCRIPTION
Change the path from `/namespaces/{namespace}/workloads/{kind}/{workload}` to `/namespaces/{namespace}/workloads/{kind}/{workload}/pods` because the function of this api is actually to retrive pod-level metrics of a workload.

Other changes include adding date format descriptions, correct the description of `type`.

Signed-off-by: huanggze <loganhuang@yunify.com>