### PR TITLE
logging: fix no result displayed problem when searching deleted pods' logs by workload name

### DIFF
--- a/pkg/apiserver/logging/logging.go
+++ b/pkg/apiserver/logging/logging.go
@@ -140,9 +140,9 @@ func logQuery(level log.LogQueryLevel, request *restful.Request) *es.QueryResult
 			param.NamespaceFilled, param.Namespaces = log.MatchNamespace(request.QueryParameter("namespaces"), param.NamespaceFilled, param.Namespaces)
 			param.NamespaceFilled, param.NamespaceWithCreationTime = log.GetNamespaceCreationTimeMap(param.Namespaces)
 			param.NamespaceQuery = request.QueryParameter("namespace_query")
-			param.PodFilled, param.Pods = log.QueryWorkload(request.QueryParameter("workloads"), request.QueryParameter("workload_query"), param.Namespaces)
+			param.WorkloadFilled, param.Workloads = log.QueryWorkload(request.QueryParameter("workloads"))
 			param.PodFilled, param.Pods = log.MatchPod(request.QueryParameter("pods"), param.PodFilled, param.Pods)
-			param.PodQuery = request.QueryParameter("pod_query")
+			param.PodQuery = log.QueryPod(request.QueryParameter("pod_query"), request.QueryParameter("workload_query"))
 			param.ContainerFilled, param.Containers = log.MatchContainer(request.QueryParameter("containers"))
 			param.ContainerQuery = request.QueryParameter("container_query")
 		}
@@ -152,9 +152,9 @@ func logQuery(level log.LogQueryLevel, request *restful.Request) *es.QueryResult
 			param.NamespaceFilled, param.Namespaces = log.MatchNamespace(request.QueryParameter("namespaces"), param.NamespaceFilled, param.Namespaces)
 			param.NamespaceFilled, param.NamespaceWithCreationTime = log.GetNamespaceCreationTimeMap(param.Namespaces)
 			param.NamespaceQuery = request.QueryParameter("namespace_query")
-			param.PodFilled, param.Pods = log.QueryWorkload(request.QueryParameter("workloads"), request.QueryParameter("workload_query"), param.Namespaces)
+			param.WorkloadFilled, param.Workloads = log.QueryWorkload(request.QueryParameter("workloads"))
 			param.PodFilled, param.Pods = log.MatchPod(request.QueryParameter("pods"), param.PodFilled, param.Pods)
-			param.PodQuery = request.QueryParameter("pod_query")
+			param.PodQuery = log.QueryPod(request.QueryParameter("pod_query"), request.QueryParameter("workload_query"))
 			param.ContainerFilled, param.Containers = log.MatchContainer(request.QueryParameter("containers"))
 			param.ContainerQuery = request.QueryParameter("container_query")
 		}
@@ -162,9 +162,9 @@ func logQuery(level log.LogQueryLevel, request *restful.Request) *es.QueryResult
 		{
 			param.NamespaceFilled, param.Namespaces = log.MatchNamespace(request.PathParameter("namespace"), false, nil)
 			param.NamespaceFilled, param.NamespaceWithCreationTime = log.GetNamespaceCreationTimeMap(param.Namespaces)
-			param.PodFilled, param.Pods = log.QueryWorkload(request.QueryParameter("workloads"), request.QueryParameter("workload_query"), param.Namespaces)
+			param.WorkloadFilled, param.Workloads = log.QueryWorkload(request.QueryParameter("workloads"))
 			param.PodFilled, param.Pods = log.MatchPod(request.QueryParameter("pods"), param.PodFilled, param.Pods)
-			param.PodQuery = request.QueryParameter("pod_query")
+			param.PodQuery = log.QueryPod(request.QueryParameter("pod_query"), request.QueryParameter("workload_query"))
 			param.ContainerFilled, param.Containers = log.MatchContainer(request.QueryParameter("containers"))
 			param.ContainerQuery = request.QueryParameter("container_query")
 		}
@@ -172,7 +172,7 @@ func logQuery(level log.LogQueryLevel, request *restful.Request) *es.QueryResult
 		{
 			param.NamespaceFilled, param.Namespaces = log.MatchNamespace(request.PathParameter("namespace"), false, nil)
 			param.NamespaceFilled, param.NamespaceWithCreationTime = log.GetNamespaceCreationTimeMap(param.Namespaces)
-			param.PodFilled, param.Pods = log.QueryWorkload(request.PathParameter("workload"), "", param.Namespaces)
+			param.WorkloadFilled, param.Workloads = log.QueryWorkload(request.QueryParameter("workloads"))
 			param.PodFilled, param.Pods = log.MatchPod(request.QueryParameter("pods"), param.PodFilled, param.Pods)
 			param.PodQuery = request.QueryParameter("pod_query")
 			param.ContainerFilled, param.Containers = log.MatchContainer(request.QueryParameter("containers"))

--- a/pkg/models/log/logcollector.go
+++ b/pkg/models/log/logcollector.go
@@ -214,85 +214,25 @@ func GetNamespaceCreationTimeMap(namespaces []string) (bool, map[string]string) 
 	return true, namespaceWithCreationTime
 }
 
-func QueryWorkload(workloadMatch string, workloadQuery string, namespaces []string) (bool, []string) {
-	if workloadMatch == "" && workloadQuery == "" {
+func QueryWorkload(workloadMatch string) (bool, []string) {
+	if workloadMatch == "" {
 		return false, nil
 	}
 
-	podLister := informers.SharedInformerFactory().Core().V1().Pods().Lister()
-	podList, err := podLister.List(labels.Everything())
-	if err != nil {
-		glog.Error("failed to list pods, error: ", err)
-		return true, nil
-	}
+	return true, strings.Split(workloadMatch, ",")
+}
 
-	var pods []string
+func QueryPod(podQuery string, workloadQuery string) string {
 
-	var hasMatch = false
-	var workloadsMatch []string
-	if workloadMatch != "" {
-		workloadsMatch = strings.Split(strings.Replace(workloadMatch, ",", " ", -1), " ")
-		hasMatch = true
-	}
-
-	var hasQuery = false
-	var workloadsQuery []string
 	if workloadQuery != "" {
-		workloadsQuery = strings.Split(strings.ToLower(strings.Replace(workloadQuery, ",", " ", -1)), " ")
-		hasQuery = true
-	}
-
-	if namespaces == nil {
-		for _, pod := range podList {
-			/*if len(pod.ObjectMeta.OwnerReferences) > 0 {
-				glog.Infof("List Pod %v:%v:%v", pod.Name, pod.ObjectMeta.OwnerReferences[0].Name, pod.ObjectMeta.OwnerReferences[0].Kind)
-			}*/
-			if len(pod.ObjectMeta.OwnerReferences) > 0 {
-				var podCanAppend = true
-				workloadName := getWorkloadName(pod.ObjectMeta.OwnerReferences[0].Name, pod.ObjectMeta.OwnerReferences[0].Kind)
-				if hasMatch {
-					if !matchLabel(workloadName, workloadsMatch) {
-						podCanAppend = false
-					}
-				}
-				if hasQuery {
-					if !queryLabel(strings.ToLower(workloadName), workloadsQuery) {
-						podCanAppend = false
-					}
-				}
-
-				if podCanAppend {
-					pods = append(pods, pod.Name)
-				}
-			}
-		}
-	} else {
-		for _, pod := range podList {
-			/*if len(pod.ObjectMeta.OwnerReferences) > 0 {
-				glog.Infof("List Pod %v:%v:%v", pod.Name, pod.ObjectMeta.OwnerReferences[0].Name, pod.ObjectMeta.OwnerReferences[0].Kind)
-			}*/
-			if len(pod.ObjectMeta.OwnerReferences) > 0 && in(pod.Namespace, namespaces) >= 0 {
-				var podCanAppend = true
-				workloadName := getWorkloadName(pod.ObjectMeta.OwnerReferences[0].Name, pod.ObjectMeta.OwnerReferences[0].Kind)
-				if hasMatch {
-					if !matchLabel(workloadName, workloadsMatch) {
-						podCanAppend = false
-					}
-				}
-				if hasQuery {
-					if !queryLabel(strings.ToLower(workloadName), workloadsQuery) {
-						podCanAppend = false
-					}
-				}
-
-				if podCanAppend {
-					pods = append(pods, pod.Name)
-				}
-			}
+		if podQuery != "" {
+			return podQuery + "," + workloadQuery
+		} else {
+			return workloadQuery
 		}
 	}
 
-	return true, pods
+	return podQuery
 }
 
 func MatchPod(podMatch string, podFilled bool, pods []string) (bool, []string) {


### PR DESCRIPTION
There is a problem when searching logs of deleted pods, such as completed jobs, by workload name, issue [#1001](https://git.internal.yunify.com/KubeSphere/kubesphere-console/issues/1001). It is because we currently leverage SharedInformerFactory to list pods. Deleted pods may be removed out from the list dynamically.

The fix uses regexp to filter pods by constructing pod full name based on workload name instead. However, it would be better if fluent bit can gather pod's owner information as collecting logs, then we just filter workload name directly rather than wrting regexp. But we cannot do much now until the upstream project makes a change.

Signed-off-by: huanggze <loganhuang@yunify.com>