### PR TITLE
fix: fill empty metrics data with zeros

### DIFF
--- a/pkg/models/metrics/metricsruleconst.go
+++ b/pkg/models/metrics/metricsruleconst.go
@@ -13,6 +13,10 @@ limitations under the License.
 
 package metrics
 
+import (
+	"fmt"
+)
+
 const (
 	ResultTypeVector             = "vector"
 	ResultTypeMatrix             = "matrix"
@@ -730,4 +734,12 @@ var RulePromQLTmplMap = MetricMap{
 
 	"prometheus_up_sum":                          `prometheus:up:sum`,
 	"prometheus_tsdb_head_samples_appended_rate": `prometheus:prometheus_tsdb_head_samples_appended:sum_rate`,
+}
+
+func init() {
+	for metric, promql := range RulePromQLTmplMap {
+
+		// Use absent() to fill missing data with zero
+		RulePromQLTmplMap[metric] = fmt.Sprintf("%s or absent(%s)-1", promql, promql)
+	}
 }


### PR DESCRIPTION
Filling empty metrics data with zeros brings a lot of convenience for data visualization. issue [#905
](https://git.internal.yunify.com/KubeSphere/kubesphere-console/issues/905)

Signed-off-by: huanggze <loganhuang@yunify.com>