### PR TITLE
api: refine monitoring api docs

### DIFF
--- a/pkg/apis/monitoring/v1alpha2/register.go
+++ b/pkg/apis/monitoring/v1alpha2/register.go
@@ -43,12 +43,12 @@ func addWebService(c *restful.Container) error {
 	ws := runtime.NewWebService(GroupVersion)
 
 	ws.Route(ws.GET("/cluster").To(monitoring.MonitorCluster).
-		Doc("Get cluster-level metrics.").
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. cluster_cpu|cluster_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
+		Doc("Get cluster-level metric data.").
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both cluster CPU usage and disk usage: `cluster_cpu_usage|cluster_disk_size_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "cluster"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -56,14 +56,17 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/nodes").To(monitoring.MonitorAllNodes).
-		Doc("Get all nodes' metrics.").
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. node_cpu|node_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("resources_filter", "Node filter in regexp pattern, eg. i-caojnter|i-cmu82ogj.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_metric", "Sort nodes by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
-		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank nodes.").DataType("string").Required(false)).
+		Doc("Get node-level metric data of all nodes.").
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both node CPU usage and disk usage: `node_cpu_usage|node_disk_size_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("resources_filter", "The node filter consists of a regexp pattern. It specifies which node data to return. For example, the following filter matches both node i-caojnter and i-cmu82ogj: `i-caojnter|i-cmu82ogj`.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_metric", "Sort nodes by the specified metric. Not applicable if **start** and **end** are provided.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_type", "Direction of the sort. One of asc, desc.").DefaultValue("desc.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("page", "The page number. This field paginates result data of each metric, then returns a specific page. For example, setting **page** to 2 returns the second page. It only applies to sorted metric data.").DataType("integer").Required(false)).
+		Param(ws.QueryParameter("limit", "Page size, the maximum number of results in a single page. Defaults to 5.").DataType("integer").Required(false).DefaultValue("5")).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "node"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -71,13 +74,13 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/nodes/{node}").To(monitoring.MonitorSpecificNode).
-		Doc("Get specific node metrics.").
-		Param(ws.PathParameter("node", "Specify the target node.").DataType("string").Required(true)).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. node_cpu|node_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
+		Doc("Get node-level metric data of a specific node.").
+		Param(ws.PathParameter("node", "Specify the monitored node.").DataType("string").Required(true)).
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both node CPU usage and disk usage: `node_cpu_usage|node_disk_size_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "node"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -85,14 +88,17 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/namespaces").To(monitoring.MonitorAllNamespaces).
-		Doc("Get namespace-level metrics.").
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. namespace_cpu|namespace_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("resources_filter", "Namespace filter in regexp pattern, eg. namespace-1|namespace-2.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_metric", "Sort namespaces by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
-		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank namespaces.").DataType("string").Required(false)).
+		Doc("Get namespace-level metric data of all namespaces.").
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both namespace CPU usage and memory usage: `namespace_cpu_usage|namespace_memory_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("resources_filter", "The namespace filter consists of a regexp pattern. It specifies which namespace data to return. For example, the following filter matches both namespace test and kube-system: `test|kube-system`.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_metric", "Sort namespaces by the specified metric. Not applicable if **start** and **end** are provided.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_type", "Direction of the sort. One of asc, desc.").DefaultValue("desc.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("page", "The page number. This field paginates result data of each metric, then returns a specific page. For example, setting **page** to 2 returns the second page. It only applies to sorted metric data.").DataType("integer").Required(false)).
+		Param(ws.QueryParameter("limit", "Page size, the maximum number of results in a single page. Defaults to 5.").DataType("integer").Required(false).DefaultValue("5")).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "namespace"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -100,13 +106,13 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/namespaces/{namespace}").To(monitoring.MonitorSpecificNamespace).
-		Doc("Get specific namespace metrics.").
-		Param(ws.PathParameter("namespace", "Specify the target namespace.").DataType("string").Required(true)).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. namespace_cpu|namespace_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
+		Doc("Get namespace-level metric data of a specific namespace.").
+		Param(ws.PathParameter("namespace", "Specify the monitored namespace.").DataType("string").Required(true)).
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both namespace CPU usage and memory usage: `namespace_cpu_usage|namespace_memory_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "namespace"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -114,15 +120,18 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/namespaces/{namespace}/pods").To(monitoring.MonitorAllPodsOfSpecificNamespace).
-		Doc("Get all pod-level metrics of a given namespace.").
-		Param(ws.PathParameter("namespace", "Specify the target namespace.").DataType("string").Required(true)).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. pod_cpu|pod_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("resources_filter", "Pods filter in regexp pattern, eg. coredns-77b8449dc9-hd6gd|coredns-77b8449dc9-b4n74.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_metric", "Sort pods by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
-		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank pods.").DataType("string").Required(false)).
+		Doc("Get pod-level metric data of a specific namespace's pods.").
+		Param(ws.PathParameter("namespace", "Specify the monitored namespace.").DataType("string").Required(true)).
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both pod CPU usage and memory usage: `pod_cpu_usage|pod_memory_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("resources_filter", "The pod filter consists of a regexp pattern. It specifies which pod data to return. For example, the following filter matches any pod whose name begins with redis: `redis.*`.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_metric", "Sort pods by the specified metric. Not applicable if **start** and **end** are provided.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_type", "Direction of the sort. One of asc, desc.").DefaultValue("desc.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("page", "The page number. This field paginates result data of each metric, then returns a specific page. For example, setting **page** to 2 returns the second page. It only applies to sorted metric data.").DataType("integer").Required(false)).
+		Param(ws.QueryParameter("limit", "Page size, the maximum number of results in a single page. Defaults to 5.").DataType("integer").Required(false).DefaultValue("5")).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "pod"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -130,14 +139,14 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/namespaces/{namespace}/pods/{pod}").To(monitoring.MonitorSpecificPodOfSpecificNamespace).
-		Doc("Get specific pod metrics of a given namespace.").
-		Param(ws.PathParameter("namespace", "Specify the target namespace.").DataType("string").Required(true)).
-		Param(ws.PathParameter("pod", "Specify the target pod.").DataType("string").Required(true)).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. pod_cpu|pod_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
+		Doc("Get pod-level metric data of a specific pod. Navigate to the pod by the pod's namespace.").
+		Param(ws.PathParameter("namespace", "The namespace of the pod.").DataType("string").Required(true)).
+		Param(ws.PathParameter("pod", "Specify the monitored pod.").DataType("string").Required(true)).
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both pod CPU usage and memory usage: `pod_cpu_usage|pod_memory_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "pod"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -145,15 +154,18 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/nodes/{node}/pods").To(monitoring.MonitorAllPodsOnSpecificNode).
-		Doc("Get metrics of all pods on a specific node.").
-		Param(ws.PathParameter("node", "Specify the target node.").DataType("string").Required(true)).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. node_cpu|node_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("resources_filter", "Pod filter in regexp pattern, eg. coredns-77b8449dc9-hd6gd|coredns-77b8449dc9-b4n74.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_metric", "Sort pods by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
-		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank pods.").DataType("string").Required(false)).
+		Doc("Get pod-level metric data of all pods on a specific node.").
+		Param(ws.PathParameter("node", "Specify the monitored node.").DataType("string").Required(true)).
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both pod CPU usage and memory usage: `pod_cpu_usage|pod_memory_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("resources_filter", "The pod filter consists of a regexp pattern. It specifies which pod data to return. For example, the following filter matches any pod whose name begins with redis: `redis.*`.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_metric", "Sort pods by the specified metric. Not applicable if **start** and **end** are provided.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_type", "Direction of the sort. One of asc, desc.").DefaultValue("desc.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("page", "The page number. This field paginates result data of each metric, then returns a specific page. For example, setting **page** to 2 returns the second page. It only applies to sorted metric data.").DataType("integer").Required(false)).
+		Param(ws.QueryParameter("limit", "Page size, the maximum number of results in a single page. Defaults to 5.").DataType("integer").Required(false).DefaultValue("5")).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "pod"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -161,14 +173,14 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/nodes/{node}/pods/{pod}").To(monitoring.MonitorSpecificPodOnSpecificNode).
-		Doc("Get specific pod metrics on a specified node.").
-		Param(ws.PathParameter("node", "Specify the target node.").DataType("string").Required(true)).
-		Param(ws.PathParameter("pod", "Specify the target pod.").DataType("string").Required(true)).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. pod_cpu|pod_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
+		Doc("Get pod-level metric data of a specific pod. Navigate to the pod by the node where it is scheduled.").
+		Param(ws.PathParameter("node", "Node name.").DataType("string").Required(true)).
+		Param(ws.PathParameter("pod", "Specify the monitored pod.").DataType("string").Required(true)).
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both pod CPU usage and memory usage: `pod_cpu_usage|pod_memory_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "pod"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -176,16 +188,19 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/nodes/{node}/pods/{pod}/containers").To(monitoring.MonitorAllContainersOnSpecificNode).
-		Doc("Get container-level metrics of a specific pod on a node.").
-		Param(ws.PathParameter("node", "Specify the target node.").DataType("string").Required(true)).
-		Param(ws.PathParameter("pod", "Specify the target pod.").DataType("string").Required(true)).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. container_cpu|container_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("resources_filter", "Container filter in regexp pattern.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_metric", "Sort containers by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
-		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank containers.").DataType("string").Required(false)).
+		Doc("Get container-level metric data of a specific pod's containers. Navigate to the pod by the node where it is scheduled.").
+		Param(ws.PathParameter("node", "Node name.").DataType("string").Required(true)).
+		Param(ws.PathParameter("pod", "Specified the monitored pod.").DataType("string").Required(true)).
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both container CPU usage and memory usage: `container_cpu_usage|container_memory_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("resources_filter", "The container filter consists of a regexp pattern. It specifies which container data to return. For example, the following filter matches container prometheus and prometheus-config-reloader: `prometheus|prometheus-config-reloader`.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_metric", "Sort containers by the specified metric. Not applicable if **start** and **end** are provided.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_type", "Direction of the sort. One of asc, desc.").DefaultValue("desc.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("page", "The page number. This field paginates result data of each metric, then returns a specific page. For example, setting **page** to 2 returns the second page. It only applies to sorted metric data.").DataType("integer").Required(false)).
+		Param(ws.QueryParameter("limit", "Page size, the maximum number of results in a single page. Defaults to 5.").DataType("integer").Required(false).DefaultValue("5")).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "container"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -193,16 +208,19 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/namespaces/{namespace}/pods/{pod}/containers").To(monitoring.MonitorAllContainersOfSpecificNamespace).
-		Doc("Get all container-level metrics of a given pod.").
-		Param(ws.PathParameter("namespace", "Specify the target namespace.").DataType("string").Required(true)).
-		Param(ws.PathParameter("pod", "Specify the target pod.").DataType("string").Required(true)).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. container_cpu|container_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("resources_filter", "Container filter in regexp pattern.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_metric", "Sort containers by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
-		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank containers.").DataType("string").Required(false)).
+		Doc("Get container-level metric data of a specific pod's containers. Navigate to the pod by the pod's namespace.").
+		Param(ws.PathParameter("namespace", "The namespace of the pod.").DataType("string").Required(true)).
+		Param(ws.PathParameter("pod", "Specify the monitored pod.").DataType("string").Required(true)).
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both container CPU usage and memory usage: `container_cpu_usage|container_memory_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("resources_filter", "The container filter consists of a regexp pattern. It specifies which container data to return. For example, the following filter matches container prometheus and prometheus-config-reloader: `prometheus|prometheus-config-reloader`.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_metric", "Sort containers by the specified metric. Not applicable if **start** and **end** are provided.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_type", "Direction of the sort. One of asc, desc.").DefaultValue("desc.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("page", "The page number. This field paginates result data of each metric, then returns a specific page. For example, setting **page** to 2 returns the second page. It only applies to sorted metric data.").DataType("integer").Required(false)).
+		Param(ws.QueryParameter("limit", "Page size, the maximum number of results in a single page. Defaults to 5.").DataType("integer").Required(false).DefaultValue("5")).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "container"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -210,35 +228,36 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/namespaces/{namespace}/pods/{pod}/containers/{container}").To(monitoring.MonitorSpecificContainerOfSpecificNamespace).
-		Doc("Get specific container metrics of a given pod.").
-		Param(ws.PathParameter("namespace", "Specify the target namespace.").DataType("string").Required(true)).
-		Param(ws.PathParameter("pod", "Specify the target pod.").DataType("string").Required(true)).
-		Param(ws.PathParameter("container", "Specify the target container.").DataType("string").Required(true)).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. container_cpu|container_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
+		Doc("Get container-level metric data of a specific container. Navigate to the container by the pod name and the namespace.").
+		Param(ws.PathParameter("namespace", "Namespace of the pod.").DataType("string").Required(true)).
+		Param(ws.PathParameter("pod", "Pod name of the container.").DataType("string").Required(true)).
+		Param(ws.PathParameter("container", "Specify the monitored container.").DataType("string").Required(true)).
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both container CPU usage and memory usage: `container_cpu_usage|container_memory_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "container"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
 		Consumes(restful.MIME_JSON, restful.MIME_XML).
 		Produces(restful.MIME_JSON)
 
-	// Only use this api to monitor pod status of a {workload}
-	// To monitor a specific workload, try the next two apis with "resources_filter"
 	ws.Route(ws.GET("/namespaces/{namespace}/workloads/{kind}/{workload}/pods").To(monitoring.MonitorSpecificWorkload).
-		Doc("Get all pod-level metrics of a workload.").
-		Param(ws.PathParameter("namespace", "Specify the target namespace.").DataType("string").Required(true)).
-		Param(ws.PathParameter("kind", "Specify the target workload kind. One of deployment, daemonset, statefulset.").DataType("string").Required(true).DefaultValue("(.*)")).
-		Param(ws.PathParameter("workload", "Specify the target workload.").DataType("string").Required(true)).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. pod_cpu|pod_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("resources_filter", "Pod filter in regexp pattern.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank pods.").DataType("string").Required(false)).
+		Doc("Get pod-level metric data of a specific workload's pods. Navigate to the workload by the namespace.").
+		Param(ws.PathParameter("namespace", "Namespace of the workload.").DataType("string").Required(true)).
+		Param(ws.PathParameter("kind", "Workload kind. One of deployment, daemonset, statefulset.").DataType("string").Required(true)).
+		Param(ws.PathParameter("workload", "Specify the monitored workload.").DataType("string").Required(true)).
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both pod CPU usage and memory usage: `pod_cpu_usage|pod_memory_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("resources_filter", "The pod filter consists of a regexp pattern. It specifies which pod data to return. For example, the following filter matches any pod whose name begins with redis: `redis.*`.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_metric", "Sort pods by the specified metric. Not applicable if **start** and **end** are provided.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_type", "Direction of the sort. One of asc, desc.").DefaultValue("desc.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("page", "The page number. This field paginates result data of each metric, then returns a specific page. For example, setting **page** to 2 returns the second page. It only applies to sorted metric data.").DataType("integer").Required(false)).
+		Param(ws.QueryParameter("limit", "Page size, the maximum number of results in a single page. Defaults to 5.").DataType("integer").Required(false).DefaultValue("5")).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "pod"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -246,16 +265,19 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/namespaces/{namespace}/workloads/{kind}").To(monitoring.MonitorAllWorkloadsOfSpecificKind).
-		Doc("Get all workload-level metrics of a specific workload kind under a given namespace.").
-		Param(ws.PathParameter("namespace", "Specify the target namespace.").DataType("string").Required(true)).
-		Param(ws.PathParameter("kind", "Specify the target workload kind. One of deployment, daemonset, statefulset. Other values will be interpreted as any of three.").DataType("string").Required(true).DefaultValue("(.*)")).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. node_cpu|node_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("resources_filter", "Workload filter, separated by vertical bar. eg. fluent-bit|elasticsearch-logging-data. The workload filter does not support regexp so far.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_metric", "Sort workloads by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
-		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank workloads.").DataType("string").Required(false)).
+		Doc("Get workload-level metric data of all workloads which belongs to a specific kind.").
+		Param(ws.PathParameter("namespace", "Namespace of workloads.").DataType("string").Required(true)).
+		Param(ws.PathParameter("kind", "Specify the monitored workload kind. One of deployment, daemonset, statefulset.").DataType("string").Required(true)).
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both workload CPU usage and memory usage: `workload_pod_cpu_usage|workload_pod_memory_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("resources_filter", "The workload filter consists of a regexp pattern. It specifies which workload data to return. For example, the following filter matches any workload whose name begins with prometheus: `prometheus.*`.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_metric", "Sort workloads by the specified metric. Not applicable if **start** and **end** are provided.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_type", "Direction of the sort. One of asc, desc.").DefaultValue("desc.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("page", "The page number. This field paginates result data of each metric, then returns a specific page. For example, setting **page** to 2 returns the second page. It only applies to sorted metric data.").DataType("integer").Required(false)).
+		Param(ws.QueryParameter("limit", "Page size, the maximum number of results in a single page. Defaults to 5.").DataType("integer").Required(false).DefaultValue("5")).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "workload"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -263,15 +285,18 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/namespaces/{namespace}/workloads").To(monitoring.MonitorAllWorkloadsOfSpecificNamespace).
-		Doc("Get all workload-level metrics of a given namespace.").
-		Param(ws.PathParameter("namespace", "Specify the target namespace.").DataType("string").Required(true)).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. workload_cpu|workload_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("resources_filter", "Workload filter, separated by vertical bar. eg. fluent-bit|elasticsearch-logging-data. The workload filter does not support regexp so far.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_metric", "Sort workloads by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
-		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is rank. Use rank with sort_metric and sort_type to rank workloads.").DataType("string").Required(false)).
+		Doc("Get workload-level metric data of a specific namespace's workloads.").
+		Param(ws.PathParameter("namespace", "Specify the monitored namespace.").DataType("string").Required(true)).
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both workload CPU usage and memory usage: `workload_pod_cpu_usage|workload_pod_memory_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("resources_filter", "The workload filter consists of a regexp pattern. It specifies which workload data to return. For example, the following filter matches any workload whose name begins with prometheus: `prometheus.*`.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_metric", "Sort workloads by the specified metric. Not applicable if **start** and **end** are provided.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_type", "Direction of the sort. One of asc, desc.").DefaultValue("desc.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("page", "The page number. This field paginates result data of each metric, then returns a specific page. For example, setting **page** to 2 returns the second page. It only applies to sorted metric data.").DataType("integer").Required(false)).
+		Param(ws.QueryParameter("limit", "Page size, the maximum number of results in a single page. Defaults to 5.").DataType("integer").Required(false).DefaultValue("5")).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "workload"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -280,14 +305,14 @@ func addWebService(c *restful.Container) error {
 
 	// list all namespace in this workspace by selected metrics
 	ws.Route(ws.GET("/workspaces/{workspace}").To(monitoring.MonitorSpecificWorkspace).
-		Doc("Get specific workspace metrics.").
-		Param(ws.PathParameter("workspace", "Specify the target workspace.").DataType("string").Required(true)).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. workspace_cpu|workspace_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("type", "Additional operation. Currently supported type is statistics. Use statistics to get total number of namespaces, devops projects, users and roles in this workspace.").DataType("string").Required(false)).
+		Doc("Get workspace-level metric data of a specific workspace.").
+		Param(ws.PathParameter("workspace", "Specify the monitored workspace.").DataType("string").Required(true)).
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both workspace CPU usage and memory usage: `workspace_cpu_usage|workspace_memory_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("type", "Additional operations. Currently available types is statistics. It retrieves the total number of namespaces, devops projects, members and roles in this workspace at the moment.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "workspace"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -295,14 +320,18 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/workspaces").To(monitoring.MonitorAllWorkspaces).
-		Doc("Get workspace-level metrics.").
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. workspace_cpu|workspace_memory.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("resources_filter", "Workspace filter in regexp pattern, eg. workspace_1|workspace_2.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_metric", "Sort workspaces by the specified metric. Valid only if type is rank.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("sort_type", "Sorting order, one of asc, desc. Valid only if type is rank.").DefaultValue("desc.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("page", "Total number of pages. Used to page results per metric. Default to return the whole metrics.").DataType("integer").Required(false).DefaultValue("1")).
-		Param(ws.QueryParameter("limit", "Max count of items per page.").DataType("integer").Required(false).DefaultValue("5")).
-		Param(ws.QueryParameter("type", "Additional operation. Currently supported types are rank and statistics. Use rank with sort_metric and sort_type to rank workspaces. Use statistics to get total number of workspaces, devops projects, namespaces, users in the cluster.").DataType("string").Required(false)).
+		Doc("Get workspace-level metric data of all workspaces.").
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both workspace CPU usage and memory usage: `workspace_cpu_usage|workspace_memory_usage`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("resources_filter", "The workspace filter consists of a regexp pattern. It specifies which workspace data to return.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_metric", "Sort workspaces by the specified metric. Not applicable if **start** and **end** are provided.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("sort_type", "Direction of the sort. One of asc, desc.").DefaultValue("desc.").DataType("string").Required(false)).
+		Param(ws.QueryParameter("page", "The page number. This field paginates result data of each metric, then returns a specific page. For example, setting **page** to 2 returns the second page. It only applies to sorted metric data.").DataType("integer").Required(false)).
+		Param(ws.QueryParameter("limit", "Page size, the maximum number of results in a single page. Defaults to 5.").DataType("integer").Required(false).DefaultValue("5")).
+		Param(ws.QueryParameter("type", "Additional operations. Currently available types is statistics. It retrieves the total number of workspaces, devops projects, namespaces, accounts in the cluster at the moment.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "workspace"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).
@@ -310,13 +339,13 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	ws.Route(ws.GET("/components/{component}").To(monitoring.MonitorComponent).
-		Doc("Get component-level metrics.").
-		Param(ws.PathParameter("component", "Specify the target component. One of etcd, apiserver, scheduler, controller_manager, coredns, prometheus.").DataType("string").Required(true)).
-		Param(ws.QueryParameter("metrics_filter", "Metrics filter in regexp pattern, eg. etcd_server_list|etcd_mvcc_db_size.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("step", "Used to get metrics over a range of time. Query resolution step, eg. 10m, refer to Prometheus duration strings of the form [0-9]+[smhdwy].").DataType("string").DefaultValue("10m").Required(false)).
-		Param(ws.QueryParameter("start", "Used to get metrics over a range of time. Start of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use start in pair with end.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("end", "Used to get metrics over a range of time. End of query range. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729. No default value. Must use end in pair with start.").DataType("string").Required(false)).
-		Param(ws.QueryParameter("time", "Used to get metrics at a given time point. This option accepts epoch_second format, the number of seconds since the epoch, eg. 1559762729.").DataType("string").Required(false)).
+		Doc("Get component-level metric data of a specific kubesphere core component.").
+		Param(ws.PathParameter("component", "Specify the monitored kubesphere component. One of etcd, apiserver, scheduler, controller_manager, coredns, prometheus.").DataType("string").Required(true)).
+		Param(ws.QueryParameter("metrics_filter", "The metric name filter consists of a regexp pattern. It specifies which metric data to return. For example, the following filter matches both etcd server list and total size of the underlying database: `etcd_server_list|etcd_mvcc_db_size`. View available metrics at [kubesphere.io](https://kubesphere.io).").DataType("string").Required(false)).
+		Param(ws.QueryParameter("start", "Start time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1559347200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("end", "End time of query. Use **start** and **end** to retrieve metric data over a time span. It is a string with Unix time format, eg. 1561939200. ").DataType("string").Required(false)).
+		Param(ws.QueryParameter("step", "Time interval. Retrieve metric data at a fixed interval. It requires both **start** and **end** are provided. The format is [0-9]+[smhdwy]. Defaults to 10m (i.e. 10 min).").DataType("string").DefaultValue("10m").Required(false)).
+		Param(ws.QueryParameter("time", "A timestamp in Unix time format. Retrieve metric data at a single time point. Defaults to now.").DataType("string").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{"Monitoring", "component"}).
 		Writes(metrics.FormatedLevelMetric{}).
 		Returns(http.StatusOK, RespOK, metrics.FormatedLevelMetric{})).

--- a/pkg/models/metrics/metrics.go
+++ b/pkg/models/metrics/metrics.go
@@ -49,6 +49,9 @@ const (
 type FormatedLevelMetric struct {
 	MetricsLevel string           `json:"metrics_level" description:"metric level, eg. cluster"`
 	Results      []FormatedMetric `json:"results" description:"actual array of results"`
+	CurrentPage  int              `json:"page,omitempty" description:"current page returned"`
+	TotalPage    int              `json:"total_page,omitempty" description:"total number of pages"`
+	TotalItem    int              `json:"total_item,omitempty" description:"page size"`
 }
 
 type FormatedMetric struct {
@@ -58,7 +61,7 @@ type FormatedMetric struct {
 }
 
 type FormatedMetricData struct {
-	Result     []map[string]interface{} `json:"result" description:"result including metric labels, time points and values"`
+	Result     []map[string]interface{} `json:"result" description:"metric data including metric metadata, time points and values"`
 	ResultType string                   `json:"resultType" description:"result type, one of matrix, vector"`
 }
 

--- a/pkg/models/metrics/metricsrule.go
+++ b/pkg/models/metrics/metricsrule.go
@@ -27,12 +27,16 @@ func MakeWorkloadPromQL(metricName, nsName, resources_filter, wkKind string) str
 		wkKind = DaemonSet
 	case "statefulset":
 		wkKind = StatefulSet
-	default:
-		wkKind = "(.*)"
 	}
 
-	if resources_filter == "" {
-		resources_filter = ".*"
+	if wkKind == "" {
+		resources_filter = Any
+	} else if resources_filter == "" {
+		if strings.Contains(metricName, "pod") {
+			resources_filter = wkKind + ":" + Any
+		} else if strings.Contains(metricName, strings.ToLower(wkKind)) {
+			resources_filter = Any
+		}
 	} else {
 		var prefix string
 

--- a/pkg/models/metrics/metricsruleconst.go
+++ b/pkg/models/metrics/metricsruleconst.go
@@ -76,6 +76,7 @@ const (
 	StatefulSet = "StatefulSet"
 	DaemonSet   = "DaemonSet"
 	Deployment  = "Deployment"
+	Any         = ".*"
 )
 
 const (
@@ -598,6 +599,10 @@ var RulePromQLTmplMap = MetricMap{
 
 	// workload
 	// Join the "container_cpu_usage_seconds_total" metric with "kube_pod_owner" to calculate workload-level resource usage
+	//
+	// Note the name convention:
+	// For hardware resource metrics, combine pod metric name with `workload_`
+	// For k8s resource metrics, must specify the workload type in metric names
 	"workload_pod_cpu_usage":             `round(namespace:workload_cpu_usage:sum{namespace="$2", workload=~"$3"}, 0.001)`,
 	"workload_pod_memory_usage":          `namespace:workload_memory_usage:sum{namespace="$2", workload=~"$3"}`,
 	"workload_pod_memory_usage_wo_cache": `namespace:workload_memory_usage_wo_cache:sum{namespace="$2", workload=~"$3"}`,

--- a/pkg/models/metrics/util.go
+++ b/pkg/models/metrics/util.go
@@ -239,19 +239,11 @@ func Page(pageNum string, limitNum string, fmtLevelMetric *FormatedLevelMetric, 
 	allPage := int(math.Ceil(float64(maxLength) / float64(limit)))
 
 	// add page fields
-	return &struct {
-		*FormatedLevelMetric
-		CurrentPage int    `json:"page"`
-		TotalPage   int    `json:"total_page"`
-		TotalItem   int    `json:"total_item"`
-		Message     string `json:"msg"`
-	}{
-		FormatedLevelMetric: fmtLevelMetric,
-		CurrentPage:         page,
-		TotalItem:           maxLength,
-		TotalPage:           allPage,
-		Message:             "paged",
-	}
+	fmtLevelMetric.CurrentPage = page
+	fmtLevelMetric.TotalItem = maxLength
+	fmtLevelMetric.TotalPage = allPage
+
+	return fmtLevelMetric
 }
 
 // maybe this function is time consuming


### PR DESCRIPTION
Changes include:
1. refine api docs
2. declare type explicitly: move declaration of type `FormatedLevelMetric`  to `metrics.go`, instead of declaring it inside a function, [see the link](https://github.com/kubesphere/kubesphere/compare/master...huanggze:monitor-fix?expand=1#diff-2f26a676439155b261450208ffb42925)
3. remove buggy `if` statements
4. fix PromQL construction, [see the link](https://github.com/kubesphere/kubesphere/compare/master...huanggze:monitor-fix?expand=1#diff-1056b5065093935e50a138eaa8e1a721)

The fix has been verfied with a test environment.

Signed-off-by: huanggze <loganhuang@yunify.com>