### PR TITLE
fix pod quota metrics

### DIFF
--- a/pkg/models/metrics/metricsruleconst.go
+++ b/pkg/models/metrics/metricsruleconst.go
@@ -414,7 +414,7 @@ var RulePromQLTmplMap = MetricMap{
 
 	// cluster_pod_count = cluster_pod_running_count + cluster_pod_succeeded_count + cluster_pod_abnormal_count
 	"cluster_pod_count":           `cluster:pod:sum`,
-	"cluster_pod_quota":           `sum(kube_node_status_capacity_pods unless on (node) (kube_node_status_condition{condition="Ready",status=~"unknown|false"} > 0))`,
+	"cluster_pod_quota":           `sum(max(kube_node_status_capacity_pods) by (node) unless on (node) (kube_node_status_condition{condition="Ready",status=~"unknown|false"} > 0))`,
 	"cluster_pod_utilisation":     `cluster:pod_utilization:ratio`,
 	"cluster_pod_running_count":   `cluster:pod_running:count`,
 	"cluster_pod_succeeded_count": `count(kube_pod_info unless on (pod) (kube_pod_status_phase{phase=~"Failed|Pending|Unknown|Running"} > 0) unless on (node) (kube_node_status_condition{condition="Ready",status=~"unknown|false"} > 0))`,
@@ -492,7 +492,7 @@ var RulePromQLTmplMap = MetricMap{
 	"node_disk_inode_utilisation": `node:disk_inode_utilization:ratio$1`,
 
 	"node_pod_count":           `node:pod_count:sum$1`,
-	"node_pod_quota":           `sum(kube_node_status_capacity_pods$1) by (node) unless on (node) (kube_node_status_condition{condition="Ready",status=~"unknown|false"} > 0)`,
+	"node_pod_quota":           `max(kube_node_status_capacity_pods$1) by (node) unless on (node) (kube_node_status_condition{condition="Ready",status=~"unknown|false"} > 0)`,
 	"node_pod_utilisation":     `node:pod_utilization:ratio$1`,
 	"node_pod_running_count":   `node:pod_running:count$1`,
 	"node_pod_succeeded_count": `node:pod_succeeded:count$1`,


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When exporter pod is recreating (eg. kube-state-metrics get scaled), stale data from old pods may be mixed with the new ones. Therefore, we should use `max` (or min) instead of `sum` to avoid such a mix.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#1171](https://git.internal.yunify.com/KubeSphere/kubesphere-console/issues/1171)

