### PR TITLE
api do not return 401

### DIFF
--- a/pkg/apiserver/devops/devops.go
+++ b/pkg/apiserver/devops/devops.go
@@ -177,6 +177,9 @@ func Validate(req *restful.Request, resp *restful.Response) {
 	}
 
 	resp.Header().Set(restful.HEADER_ContentType, restful.MIME_JSON)
+	if resp.StatusCode() == http.StatusUnauthorized {
+		resp.WriteHeader(http.StatusPreconditionRequired)
+	}
 	resp.Write(res)
 }
 


### PR DESCRIPTION
The front end will now treat 401 as not logged in. Modify the return code here.

/cc @soulseen 