### PR TITLE
refactor logging options

### DIFF
--- a/cmd/ks-apiserver/app/options/options.go
+++ b/cmd/ks-apiserver/app/options/options.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/klog"
 	genericoptions "kubesphere.io/kubesphere/pkg/server/options"
 	"kubesphere.io/kubesphere/pkg/simple/client/devops"
+	esclient "kubesphere.io/kubesphere/pkg/simple/client/elasticsearch"
 	"kubesphere.io/kubesphere/pkg/simple/client/k8s"
 	"kubesphere.io/kubesphere/pkg/simple/client/ldap"
 	"kubesphere.io/kubesphere/pkg/simple/client/mysql"
@@ -31,6 +32,7 @@ type ServerRunOptions struct {
 	S3Options          *s2is3.S3Options
 	RedisOptions       *redis.RedisOptions
 	OpenPitrixOptions  *openpitrix.OpenPitrixOptions
+	LoggingOptions     *esclient.ElasticSearchOptions
 }
 
 func NewServerRunOptions() *ServerRunOptions {
@@ -47,6 +49,7 @@ func NewServerRunOptions() *ServerRunOptions {
 		S3Options:               s2is3.NewS3Options(),
 		RedisOptions:            redis.NewRedisOptions(),
 		OpenPitrixOptions:       openpitrix.NewOpenPitrixOptions(),
+		LoggingOptions:          esclient.NewElasticSearchOptions(),
 	}
 
 	return &s
@@ -65,6 +68,7 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 	s.OpenPitrixOptions.AddFlags(fss.FlagSet("openpitrix"))
 	s.ServiceMeshOptions.AddFlags(fss.FlagSet("servicemesh"))
 	s.MonitoringOptions.AddFlags(fss.FlagSet("monitoring"))
+	s.LoggingOptions.AddFlags(fss.FlagSet("logging"))
 
 	fs := fss.FlagSet("klog")
 	local := flag.NewFlagSet("klog", flag.ExitOnError)

--- a/cmd/ks-apiserver/app/options/validation.go
+++ b/cmd/ks-apiserver/app/options/validation.go
@@ -15,6 +15,7 @@ func (s *ServerRunOptions) Validate() []error {
 	errors = append(errors, s.S3Options.Validate()...)
 	errors = append(errors, s.RedisOptions.Validate()...)
 	errors = append(errors, s.OpenPitrixOptions.Validate()...)
+	errors = append(errors, s.LoggingOptions.Validate()...)
 
 	return errors
 }

--- a/pkg/api/logging/v1alpha2/types.go
+++ b/pkg/api/logging/v1alpha2/types.go
@@ -1,4 +1,4 @@
-package esclient
+package v1alpha2
 
 import (
 	"encoding/json"

--- a/pkg/apis/logging/v1alpha2/register.go
+++ b/pkg/apis/logging/v1alpha2/register.go
@@ -21,11 +21,11 @@ import (
 	"github.com/emicklei/go-restful"
 	"github.com/emicklei/go-restful-openapi"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"kubesphere.io/kubesphere/pkg/api/logging/v1alpha2"
 	"kubesphere.io/kubesphere/pkg/apiserver/logging"
 	"kubesphere.io/kubesphere/pkg/apiserver/runtime"
 	"kubesphere.io/kubesphere/pkg/constants"
 	"kubesphere.io/kubesphere/pkg/models/log"
-	esclient "kubesphere.io/kubesphere/pkg/simple/client/elasticsearch"
 	fluentbitclient "kubesphere.io/kubesphere/pkg/simple/client/fluentbit"
 	"net/http"
 )
@@ -66,8 +66,8 @@ func addWebService(c *restful.Container) error {
 		Param(ws.QueryParameter("from", "The offset from the result set. This field returns query results from the specified offset. It requires **operation** is set to query. Defaults to 0 (i.e. from the beginning of the result set).").DataType("integer").DefaultValue("0").Required(false)).
 		Param(ws.QueryParameter("size", "Size of result to return. It requires **operation** is set to query. Defaults to 10 (i.e. 10 log records).").DataType("integer").DefaultValue("10").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.LogQueryTag}).
-		Writes(esclient.QueryResult{}).
-		Returns(http.StatusOK, RespOK, esclient.QueryResult{})).
+		Writes(v1alpha2.QueryResult{}).
+		Returns(http.StatusOK, RespOK, v1alpha2.QueryResult{})).
 		Consumes(restful.MIME_JSON, restful.MIME_XML).
 		Produces(restful.MIME_JSON)
 
@@ -91,8 +91,8 @@ func addWebService(c *restful.Container) error {
 		Param(ws.QueryParameter("from", "The offset from the result set. This field returns query results from the specified offset. It requires **operation** is set to query. Defaults to 0 (i.e. from the beginning of the result set).").DataType("integer").DefaultValue("0").Required(false)).
 		Param(ws.QueryParameter("size", "Size of result to return. It requires **operation** is set to query. Defaults to 10 (i.e. 10 log records).").DataType("integer").DefaultValue("10").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.LogQueryTag}).
-		Writes(esclient.QueryResult{}).
-		Returns(http.StatusOK, RespOK, esclient.QueryResult{})).
+		Writes(v1alpha2.QueryResult{}).
+		Returns(http.StatusOK, RespOK, v1alpha2.QueryResult{})).
 		Consumes(restful.MIME_JSON, restful.MIME_XML).
 		Produces(restful.MIME_JSON)
 
@@ -114,8 +114,8 @@ func addWebService(c *restful.Container) error {
 		Param(ws.QueryParameter("from", "The offset from the result set. This field returns query results from the specified offset. It requires **operation** is set to query. Defaults to 0 (i.e. from the beginning of the result set).").DataType("integer").DefaultValue("0").Required(false)).
 		Param(ws.QueryParameter("size", "Size of result to return. It requires **operation** is set to query. Defaults to 10 (i.e. 10 log records).").DataType("integer").DefaultValue("10").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.LogQueryTag}).
-		Writes(esclient.QueryResult{}).
-		Returns(http.StatusOK, RespOK, esclient.QueryResult{})).
+		Writes(v1alpha2.QueryResult{}).
+		Returns(http.StatusOK, RespOK, v1alpha2.QueryResult{})).
 		Consumes(restful.MIME_JSON, restful.MIME_XML).
 		Produces(restful.MIME_JSON)
 
@@ -136,8 +136,8 @@ func addWebService(c *restful.Container) error {
 		Param(ws.QueryParameter("from", "The offset from the result set. This field returns query results from the specified offset. It requires **operation** is set to query. Defaults to 0 (i.e. from the beginning of the result set).").DataType("integer").DefaultValue("0").Required(false)).
 		Param(ws.QueryParameter("size", "Size of result to return. It requires **operation** is set to query. Defaults to 10 (i.e. 10 log records).").DataType("integer").DefaultValue("10").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.LogQueryTag}).
-		Writes(esclient.QueryResult{}).
-		Returns(http.StatusOK, RespOK, esclient.QueryResult{})).
+		Writes(v1alpha2.QueryResult{}).
+		Returns(http.StatusOK, RespOK, v1alpha2.QueryResult{})).
 		Consumes(restful.MIME_JSON, restful.MIME_XML).
 		Produces(restful.MIME_JSON)
 
@@ -156,8 +156,8 @@ func addWebService(c *restful.Container) error {
 		Param(ws.QueryParameter("from", "The offset from the result set. This field returns query results from the specified offset. It requires **operation** is set to query. Defaults to 0 (i.e. from the beginning of the result set).").DataType("integer").DefaultValue("0").Required(false)).
 		Param(ws.QueryParameter("size", "Size of result to return. It requires **operation** is set to query. Defaults to 10 (i.e. 10 log records).").DataType("integer").DefaultValue("10").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.LogQueryTag}).
-		Writes(esclient.QueryResult{}).
-		Returns(http.StatusOK, RespOK, esclient.QueryResult{})).
+		Writes(v1alpha2.QueryResult{}).
+		Returns(http.StatusOK, RespOK, v1alpha2.QueryResult{})).
 		Consumes(restful.MIME_JSON, restful.MIME_XML).
 		Produces(restful.MIME_JSON)
 
@@ -175,8 +175,8 @@ func addWebService(c *restful.Container) error {
 		Param(ws.QueryParameter("from", "The offset from the result set. This field returns query results from the specified offset. It requires **operation** is set to query. Defaults to 0 (i.e. from the beginning of the result set).").DataType("integer").DefaultValue("0").Required(false)).
 		Param(ws.QueryParameter("size", "Size of result to return. It requires **operation** is set to query. Defaults to 10 (i.e. 10 log records).").DataType("integer").DefaultValue("10").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.LogQueryTag}).
-		Writes(esclient.QueryResult{}).
-		Returns(http.StatusOK, RespOK, esclient.QueryResult{})).
+		Writes(v1alpha2.QueryResult{}).
+		Returns(http.StatusOK, RespOK, v1alpha2.QueryResult{})).
 		Consumes(restful.MIME_JSON, restful.MIME_XML).
 		Produces(restful.MIME_JSON)
 

--- a/pkg/apis/tenant/v1alpha2/register.go
+++ b/pkg/apis/tenant/v1alpha2/register.go
@@ -23,15 +23,14 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	devopsv1alpha2 "kubesphere.io/kubesphere/pkg/api/devops/v1alpha2"
+	"kubesphere.io/kubesphere/pkg/api/logging/v1alpha2"
 	"kubesphere.io/kubesphere/pkg/apis/tenant/v1alpha1"
 	"kubesphere.io/kubesphere/pkg/apiserver/runtime"
 	"kubesphere.io/kubesphere/pkg/apiserver/tenant"
 	"kubesphere.io/kubesphere/pkg/constants"
-	"kubesphere.io/kubesphere/pkg/server/params"
-	"kubesphere.io/kubesphere/pkg/simple/client/elasticsearch"
-
 	"kubesphere.io/kubesphere/pkg/models"
 	"kubesphere.io/kubesphere/pkg/server/errors"
+	"kubesphere.io/kubesphere/pkg/server/params"
 
 	"net/http"
 )
@@ -177,8 +176,8 @@ func addWebService(c *restful.Container) error {
 		Param(ws.QueryParameter("from", "The offset from the result set. This field returns query results from the specified offset. It requires **operation** is set to query. Defaults to 0 (i.e. from the beginning of the result set).").DataType("integer").DefaultValue("0").Required(false)).
 		Param(ws.QueryParameter("size", "Size of result to return. It requires **operation** is set to query. Defaults to 10 (i.e. 10 log records).").DataType("integer").DefaultValue("10").Required(false)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.TenantResourcesTag}).
-		Writes(esclient.Response{}).
-		Returns(http.StatusOK, RespOK, esclient.Response{})).
+		Writes(v1alpha2.Response{}).
+		Returns(http.StatusOK, RespOK, v1alpha2.Response{})).
 		Consumes(restful.MIME_JSON, restful.MIME_XML).
 		Produces(restful.MIME_JSON)
 

--- a/pkg/apiserver/tenant/tenant.go
+++ b/pkg/apiserver/tenant/tenant.go
@@ -24,7 +24,8 @@ import (
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/klog"
-	"kubesphere.io/kubesphere/pkg/api/devops/v1alpha2"
+	devopsv1alpha2 "kubesphere.io/kubesphere/pkg/api/devops/v1alpha2"
+	loggingv1alpha2 "kubesphere.io/kubesphere/pkg/api/logging/v1alpha2"
 	"kubesphere.io/kubesphere/pkg/apis/tenant/v1alpha1"
 	"kubesphere.io/kubesphere/pkg/apiserver/logging"
 	"kubesphere.io/kubesphere/pkg/constants"
@@ -36,7 +37,6 @@ import (
 	"kubesphere.io/kubesphere/pkg/server/errors"
 	"kubesphere.io/kubesphere/pkg/server/params"
 
-	"kubesphere.io/kubesphere/pkg/simple/client/elasticsearch"
 	"kubesphere.io/kubesphere/pkg/utils/sliceutil"
 	"net/http"
 	"strings"
@@ -286,7 +286,7 @@ func CreateDevopsProject(req *restful.Request, resp *restful.Response) {
 	workspaceName := req.PathParameter("workspace")
 	username := req.HeaderParameter(constants.UserNameHeader)
 
-	var devops v1alpha2.DevOpsProject
+	var devops devopsv1alpha2.DevOpsProject
 
 	err := req.ReadEntity(&devops)
 
@@ -374,7 +374,7 @@ func LogQuery(req *restful.Request, resp *restful.Response) {
 		// if the user belongs to no namespace
 		// then no log visible
 		if len(namespaces) == 0 {
-			res := esclient.QueryResult{Status: http.StatusOK}
+			res := loggingv1alpha2.QueryResult{Status: http.StatusOK}
 			resp.WriteAsJson(res)
 			return
 		} else if len(queryNamespaces) == 1 && queryNamespaces[0] == "" {
@@ -382,7 +382,7 @@ func LogQuery(req *restful.Request, resp *restful.Response) {
 		} else {
 			inter := intersection(queryNamespaces, namespaces)
 			if len(inter) == 0 {
-				res := esclient.QueryResult{Status: http.StatusOK}
+				res := loggingv1alpha2.QueryResult{Status: http.StatusOK}
 				resp.WriteAsJson(res)
 				return
 			}

--- a/pkg/models/log/logcrd.go
+++ b/pkg/models/log/logcrd.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
+	"kubesphere.io/kubesphere/pkg/api/logging/v1alpha2"
 	"kubesphere.io/kubesphere/pkg/informers"
-	es "kubesphere.io/kubesphere/pkg/simple/client/elasticsearch"
 	fb "kubesphere.io/kubesphere/pkg/simple/client/fluentbit"
 	"net/http"
 	"strings"
@@ -102,12 +102,6 @@ func FluentbitOutputInsert(output fb.OutputPlugin) *FluentbitOutputsResult {
 		return &result
 	}
 
-	// 3. If it's an configs output added, reset configs client configs
-	configs := ParseEsOutputParams(output.Parameters)
-	if configs != nil {
-		configs.WriteESConfigs()
-	}
-
 	result.Status = http.StatusOK
 	return &result
 }
@@ -153,12 +147,6 @@ func FluentbitOutputUpdate(output fb.OutputPlugin, id string) *FluentbitOutputsR
 		result.Status = http.StatusInternalServerError
 		result.Error = err.Error()
 		return &result
-	}
-
-	// 3. If it's an configs output updated, reset configs client configs
-	configs := ParseEsOutputParams(output.Parameters)
-	if configs != nil {
-		configs.WriteESConfigs()
 	}
 
 	result.Status = http.StatusOK
@@ -333,7 +321,7 @@ func syncFluentbitCRDOutputWithConfigMap(outputs []fb.OutputPlugin) error {
 }
 
 // Parse es host, port and index
-func ParseEsOutputParams(params []fb.Parameter) *es.Config {
+func ParseEsOutputParams(params []fb.Parameter) *v1alpha2.Config {
 
 	var (
 		isEsFound bool
@@ -377,5 +365,5 @@ func ParseEsOutputParams(params []fb.Parameter) *es.Config {
 		}
 	}
 
-	return &es.Config{Host: host, Port: port, Index: index}
+	return &v1alpha2.Config{Host: host, Port: port, Index: index}
 }

--- a/pkg/server/config/config_test.go
+++ b/pkg/server/config/config_test.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
+	"kubesphere.io/kubesphere/pkg/simple/client/alerting"
 	"kubesphere.io/kubesphere/pkg/simple/client/devops"
+	esclient "kubesphere.io/kubesphere/pkg/simple/client/elasticsearch"
 	"kubesphere.io/kubesphere/pkg/simple/client/k8s"
 	"kubesphere.io/kubesphere/pkg/simple/client/kubesphere"
 	"kubesphere.io/kubesphere/pkg/simple/client/ldap"
 	"kubesphere.io/kubesphere/pkg/simple/client/mysql"
+	"kubesphere.io/kubesphere/pkg/simple/client/notification"
 	"kubesphere.io/kubesphere/pkg/simple/client/openpitrix"
 	"kubesphere.io/kubesphere/pkg/simple/client/prometheus"
 	"kubesphere.io/kubesphere/pkg/simple/client/redis"
@@ -83,9 +86,23 @@ func newTestConfig() *Config {
 			Endpoint:          "http://prometheus.kubesphere-monitoring-system.svc",
 			SecondaryEndpoint: "http://prometheus.kubesphere-monitoring-system.svc",
 		},
+		LoggingOptions: &esclient.ElasticSearchOptions{
+			Host:           "http://elasticsearch-logging.kubesphere-logging-system.svc:9200",
+			LogstashFormat: false,
+			Index:          "",
+			LogstashPrefix: "elk",
+			Match:          "kube.*",
+			Version:        "6",
+		},
 		KubeSphereOptions: &kubesphere.KubeSphereOptions{
 			APIServer:     "http://ks-apiserver.kubesphere-system.svc",
 			AccountServer: "http://ks-account.kubesphere-system.svc",
+		},
+		AlertingOptions: &alerting.AlertingOptions{
+			Endpoint: "http://alerting.kubesphere-alerting-system.svc:9200",
+		},
+		NotificationOptions: &notification.NotificationOptions{
+			Endpoint: "http://notification.kubesphere-alerting-system.svc:9200",
 		},
 	}
 	return conf

--- a/pkg/simple/client/alerting/options.go
+++ b/pkg/simple/client/alerting/options.go
@@ -1,0 +1,17 @@
+package alerting
+
+type AlertingOptions struct {
+	Endpoint string
+}
+
+func NewAlertingOptions() *AlertingOptions {
+	return &AlertingOptions{
+		Endpoint: "",
+	}
+}
+
+func (s *AlertingOptions) ApplyTo(options *AlertingOptions) {
+	if s.Endpoint != "" {
+		options.Endpoint = s.Endpoint
+	}
+}

--- a/pkg/simple/client/elasticsearch/interface.go
+++ b/pkg/simple/client/elasticsearch/interface.go
@@ -1,72 +1,7 @@
 package esclient
 
-import (
-	"context"
-	"encoding/json"
-	"fmt"
-	v5 "kubesphere.io/kubesphere/pkg/simple/client/elasticsearch/versions/v5"
-	v6 "kubesphere.io/kubesphere/pkg/simple/client/elasticsearch/versions/v6"
-	v7 "kubesphere.io/kubesphere/pkg/simple/client/elasticsearch/versions/v7"
-	"strings"
-)
-
-const (
-	ElasticV5 = "5"
-	ElasticV6 = "6"
-	ElasticV7 = "7"
-)
-
 type Client interface {
 	// Perform Search API
 	Search(body []byte) ([]byte, error)
 	GetTotalHitCount(v interface{}) int64
-}
-
-func NewForConfig(cfg *Config) Client {
-	address := fmt.Sprintf("http://%s:%s", cfg.Host, cfg.Port)
-	index := cfg.Index
-	switch cfg.VersionMajor {
-	case ElasticV5:
-		return v5.New(address, index)
-	case ElasticV6:
-		return v6.New(address, index)
-	case ElasticV7:
-		return v7.New(address, index)
-	default:
-		return nil
-	}
-}
-
-func detectVersionMajor(cfg *Config) error {
-
-	// Info APIs are backward compatible with versions of v5.x, v6.x and v7.x
-	address := fmt.Sprintf("http://%s:%s", cfg.Host, cfg.Port)
-	es := v6.New(address, "")
-	res, err := es.Client.Info(
-		es.Client.Info.WithContext(context.Background()),
-	)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-
-	var b map[string]interface{}
-	if err := json.NewDecoder(res.Body).Decode(&b); err != nil {
-		return err
-	}
-	if res.IsError() {
-		// Print the response status and error information.
-		e, _ := b["error"].(map[string]interface{})
-		return fmt.Errorf("[%s] %s: %s", res.Status(), e["type"], e["reason"])
-	}
-
-	// get the major version
-	version, _ := b["version"].(map[string]interface{})
-	number, _ := version["number"].(string)
-	if number == "" {
-		return fmt.Errorf("failed to detect elastic version number")
-	}
-
-	cfg.VersionMajor = strings.Split(number, ".")[0]
-	return nil
 }

--- a/pkg/simple/client/elasticsearch/options.go
+++ b/pkg/simple/client/elasticsearch/options.go
@@ -1,0 +1,63 @@
+package esclient
+
+import (
+	"github.com/spf13/pflag"
+	"kubesphere.io/kubesphere/pkg/utils/reflectutils"
+)
+
+type ElasticSearchOptions struct {
+	Host           string `json:"host,omitempty" yaml:"host,omitempty"`
+	LogstashFormat bool   `json:"logstashFormat,omitempty" yaml:"logstashFormat,omitempty"`
+	Index          string `json:",omitempty" yaml:",omitempty"`
+	LogstashPrefix string `json:"logstashPrefix,omitempty" yaml:"logstashPrefix,omitempty"`
+	Match          string `json:",omitempty" yaml:",omitempty"`
+	Version        string `json:",omitempty" yaml:",omitempty"`
+}
+
+func NewElasticSearchOptions() *ElasticSearchOptions {
+	return &ElasticSearchOptions{
+		Host:           "",
+		LogstashFormat: false,
+		Index:          "fluentbit",
+		LogstashPrefix: "",
+		Match:          "kube.*",
+		Version:        "6",
+	}
+}
+
+func (s *ElasticSearchOptions) ApplyTo(options *ElasticSearchOptions) {
+	if s.Host != "" {
+		reflectutils.Override(options, s)
+	}
+}
+
+func (s *ElasticSearchOptions) Validate() []error {
+	errs := []error{}
+
+	return errs
+}
+
+func (s *ElasticSearchOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&s.Host, "elasticsearch-host", s.Host, ""+
+		"ElasticSearch logging service host. KubeSphere is using elastic as log store, "+
+		"if this filed left blank, KubeSphere will use kubernetes builtin log API instead, and"+
+		" the following elastic search options will be ignored.")
+
+	fs.BoolVar(&s.LogstashFormat, "logstash-format", s.LogstashFormat, ""+
+		"Whether to toggle logstash format compatibility.")
+
+	fs.StringVar(&s.LogstashPrefix, "logstash-prefix", s.LogstashPrefix, ""+
+		"If logstash-format is enabled, the Index name is composed using a prefix and the date,"+
+		"e.g: If logstash-prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'."+
+		"The last string appended belongs to the date when the data is being generated.")
+
+	fs.StringVar(&s.Match, "elasticsearch-match", s.Match, ""+
+		"The regex match for index, eg. kube.*")
+
+	fs.StringVar(&s.Index, "elasticsearch-index", s.Index, ""+
+		"Index name.")
+
+	fs.StringVar(&s.Version, "elasticsearch-version", s.Version, ""+
+		"ElasticSearch major version, e.g. 5/6/7, if left blank, will detect automatically."+
+		"Currently, minimum supported version is 5.x")
+}

--- a/pkg/simple/client/elasticsearch/versions/v5/elasticsearch.go
+++ b/pkg/simple/client/elasticsearch/versions/v5/elasticsearch.go
@@ -14,16 +14,16 @@ type Elastic struct {
 	index  string
 }
 
-func New(address string, index string) Elastic {
+func New(address string, index string) *Elastic {
 
 	client, _ := elasticsearch.NewClient(elasticsearch.Config{
 		Addresses: []string{address},
 	})
 
-	return Elastic{client: client, index: index}
+	return &Elastic{client: client, index: index}
 }
 
-func (e Elastic) Search(body []byte) ([]byte, error) {
+func (e *Elastic) Search(body []byte) ([]byte, error) {
 
 	response, err := e.client.Search(
 		e.client.Search.WithContext(context.Background()),
@@ -49,7 +49,7 @@ func (e Elastic) Search(body []byte) ([]byte, error) {
 	return ioutil.ReadAll(response.Body)
 }
 
-func (e Elastic) GetTotalHitCount(v interface{}) int64 {
+func (e *Elastic) GetTotalHitCount(v interface{}) int64 {
 	f, _ := v.(float64)
 	return int64(f)
 }

--- a/pkg/simple/client/elasticsearch/versions/v6/elasticsearch.go
+++ b/pkg/simple/client/elasticsearch/versions/v6/elasticsearch.go
@@ -14,16 +14,16 @@ type Elastic struct {
 	index  string
 }
 
-func New(address string, index string) Elastic {
+func New(address string, index string) *Elastic {
 
 	client, _ := elasticsearch.NewClient(elasticsearch.Config{
 		Addresses: []string{address},
 	})
 
-	return Elastic{Client: client, index: index}
+	return &Elastic{Client: client, index: index}
 }
 
-func (e Elastic) Search(body []byte) ([]byte, error) {
+func (e *Elastic) Search(body []byte) ([]byte, error) {
 
 	response, err := e.Client.Search(
 		e.Client.Search.WithContext(context.Background()),
@@ -49,7 +49,7 @@ func (e Elastic) Search(body []byte) ([]byte, error) {
 	return ioutil.ReadAll(response.Body)
 }
 
-func (e Elastic) GetTotalHitCount(v interface{}) int64 {
+func (e *Elastic) GetTotalHitCount(v interface{}) int64 {
 	f, _ := v.(float64)
 	return int64(f)
 }

--- a/pkg/simple/client/elasticsearch/versions/v7/elasticsearch.go
+++ b/pkg/simple/client/elasticsearch/versions/v7/elasticsearch.go
@@ -14,16 +14,16 @@ type Elastic struct {
 	index  string
 }
 
-func New(address string, index string) Elastic {
+func New(address string, index string) *Elastic {
 
 	client, _ := elasticsearch.NewClient(elasticsearch.Config{
 		Addresses: []string{address},
 	})
 
-	return Elastic{client: client, index: index}
+	return &Elastic{client: client, index: index}
 }
 
-func (e Elastic) Search(body []byte) ([]byte, error) {
+func (e *Elastic) Search(body []byte) ([]byte, error) {
 
 	response, err := e.client.Search(
 		e.client.Search.WithContext(context.Background()),
@@ -50,7 +50,7 @@ func (e Elastic) Search(body []byte) ([]byte, error) {
 	return ioutil.ReadAll(response.Body)
 }
 
-func (e Elastic) GetTotalHitCount(v interface{}) int64 {
+func (e *Elastic) GetTotalHitCount(v interface{}) int64 {
 	m, _ := v.(map[string]interface{})
 	f, _ := m["value"].(float64)
 	return int64(f)

--- a/pkg/simple/client/notification/options.go
+++ b/pkg/simple/client/notification/options.go
@@ -1,0 +1,17 @@
+package notification
+
+type NotificationOptions struct {
+	Endpoint string
+}
+
+func NewNotificationOptions() *NotificationOptions {
+	return &NotificationOptions{
+		Endpoint: "",
+	}
+}
+
+func (s *NotificationOptions) ApplyTo(options *NotificationOptions) {
+	if s.Endpoint != "" {
+		options.Endpoint = s.Endpoint
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind feature

**What this PR does / why we need it**:
Currently, logging options was read from configmap of kubesphere-logging-system, if use choose to disable logging, the configmap will be deleted as well, configuration will be lost. This PR makes kubesphere reads configuration from command line arguments and configuration file.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
