### PR TITLE
fix: controller error handle function

### DIFF
--- a/pkg/controller/application/application_controller.go
+++ b/pkg/controller/application/application_controller.go
@@ -242,7 +242,7 @@ func (v *ApplicationController) enqueueObject(obj interface{}) {
 }
 
 func (v *ApplicationController) handleErr(err error, key interface{}) {
-	if err != nil {
+	if err == nil {
 		v.queue.Forget(key)
 		return
 	}

--- a/pkg/controller/destinationrule/destinationrule_controller.go
+++ b/pkg/controller/destinationrule/destinationrule_controller.go
@@ -471,7 +471,7 @@ func (v *DestinationRuleController) addServicePolicy(obj interface{}) {
 }
 
 func (v *DestinationRuleController) handleErr(err error, key interface{}) {
-	if err != nil {
+	if err == nil {
 		v.queue.Forget(key)
 		return
 	}

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -170,6 +170,7 @@ func (v *JobController) syncJob(key string) error {
 
 	if err != nil {
 		log.Error(err, "make job revision failed", "namespace", namespace, "name", name)
+		return err
 	}
 
 	return nil
@@ -186,7 +187,7 @@ func (v *JobController) addJob(obj interface{}) {
 }
 
 func (v *JobController) handleErr(err error, key interface{}) {
-	if err != nil {
+	if err == nil {
 		v.queue.Forget(key)
 		return
 	}

--- a/pkg/controller/virtualservice/virtualservice_controller.go
+++ b/pkg/controller/virtualservice/virtualservice_controller.go
@@ -484,7 +484,7 @@ func (v *VirtualServiceController) addStrategy(obj interface{}) {
 }
 
 func (v *VirtualServiceController) handleErr(err error, key interface{}) {
-	if err != nil {
+	if err == nil {
 		v.queue.Forget(key)
 		return
 	}


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

remove key from queue if error is nil

```
I0921 15:01:28.672756   83578 destinationrule_controller.go:480] Error syncing virtualservice for service, retrying.keykubesphere-devops-system/s2ioperatorerror<nil>
```
