### PR TITLE
monitor: filter out non-labeled workspace

### DIFF
--- a/pkg/models/metrics/metrics.go
+++ b/pkg/models/metrics/metrics.go
@@ -518,7 +518,7 @@ func makePromqlForWorkspace(metricName string, params RequestParams) string {
 	if params.WorkspaceName != "" {
 		workspaceSelector = fmt.Sprintf(`label_kubesphere_io_workspace="%s"`, params.WorkspaceName)
 	} else {
-		workspaceSelector = fmt.Sprintf(`label_kubesphere_io_workspace=~"%s"`, params.ResourcesFilter)
+		workspaceSelector = fmt.Sprintf(`label_kubesphere_io_workspace=~"%s", label_kubesphere_io_workspace!=""`, params.ResourcesFilter)
 	}
 
 	return strings.Replace(exp, "$1", workspaceSelector, -1)


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#1249](https://git.internal.yunify.com/KubeSphere/kubesphere-console/issues/1249)

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
