### PR TITLE
log: fix elastic version detection

### DIFF
--- a/pkg/simple/client/elasticsearch/esclient.go
+++ b/pkg/simple/client/elasticsearch/esclient.go
@@ -60,7 +60,7 @@ type ElasticSearchClient struct {
 }
 
 func NewLoggingClient(options *ElasticSearchOptions) (*ElasticSearchClient, error) {
-	version := "6"
+	var version, index string
 	esClient := &ElasticSearchClient{}
 
 	if options.Version == "" {
@@ -69,23 +69,25 @@ func NewLoggingClient(options *ElasticSearchOptions) (*ElasticSearchClient, erro
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		version = options.Version
 	}
 
 	if options.LogstashFormat {
 		if options.LogstashPrefix != "" {
-			options.Index = options.LogstashPrefix
+			index = options.LogstashPrefix
 		} else {
-			options.Index = "logstash"
+			index = "logstash"
 		}
 	}
 
 	switch version {
 	case ElasticV5:
-		esClient.client = v5.New(options.Host, options.Index)
+		esClient.client = v5.New(options.Host, index)
 	case ElasticV6:
-		esClient.client = v6.New(options.Host, options.Index)
+		esClient.client = v6.New(options.Host, index)
 	case ElasticV7:
-		esClient.client = v7.New(options.Host, options.Index)
+		esClient.client = v7.New(options.Host, index)
 	default:
 		return nil, fmt.Errorf("unsupported elasticsearch version %s", version)
 	}

--- a/pkg/simple/client/elasticsearch/options.go
+++ b/pkg/simple/client/elasticsearch/options.go
@@ -21,7 +21,7 @@ func NewElasticSearchOptions() *ElasticSearchOptions {
 		Index:          "fluentbit",
 		LogstashPrefix: "",
 		Match:          "kube.*",
-		Version:        "6",
+		Version:        "",
 	}
 }
 

--- a/pkg/simple/client/elasticsearch/versions/v5/elasticsearch.go
+++ b/pkg/simple/client/elasticsearch/versions/v5/elasticsearch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/elastic/go-elasticsearch/v5"
 	"github.com/elastic/go-elasticsearch/v5/esapi"
 	"io/ioutil"
+	"k8s.io/klog"
 	"time"
 )
 
@@ -17,9 +18,13 @@ type Elastic struct {
 }
 
 func New(address string, index string) *Elastic {
-	client, _ := elasticsearch.NewClient(elasticsearch.Config{
+	client, err := elasticsearch.NewClient(elasticsearch.Config{
 		Addresses: []string{address},
 	})
+	if err != nil {
+		klog.Error(err)
+		return nil
+	}
 
 	return &Elastic{client: client, index: index}
 }

--- a/pkg/simple/client/elasticsearch/versions/v6/elasticsearch.go
+++ b/pkg/simple/client/elasticsearch/versions/v6/elasticsearch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/elastic/go-elasticsearch/v6"
 	"github.com/elastic/go-elasticsearch/v6/esapi"
 	"io/ioutil"
+	"k8s.io/klog"
 	"time"
 )
 
@@ -17,9 +18,13 @@ type Elastic struct {
 }
 
 func New(address string, index string) *Elastic {
-	client, _ := elasticsearch.NewClient(elasticsearch.Config{
+	client, err := elasticsearch.NewClient(elasticsearch.Config{
 		Addresses: []string{address},
 	})
+	if err != nil {
+		klog.Error(err)
+		return nil
+	}
 
 	return &Elastic{Client: client, index: index}
 }

--- a/pkg/simple/client/elasticsearch/versions/v7/elasticsearch.go
+++ b/pkg/simple/client/elasticsearch/versions/v7/elasticsearch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"io/ioutil"
+	"k8s.io/klog"
 	"time"
 )
 
@@ -17,9 +18,13 @@ type Elastic struct {
 }
 
 func New(address string, index string) *Elastic {
-	client, _ := elasticsearch.NewClient(elasticsearch.Config{
+	client, err := elasticsearch.NewClient(elasticsearch.Config{
 		Addresses: []string{address},
 	})
+	if err != nil {
+		klog.Error(err)
+		return nil
+	}
 
 	return &Elastic{client: client, index: index}
 }


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
```
If elastic version number is not provided, it always create esclient for v6. 
```

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
