### PR TITLE
log: fix crash if api caller has no access to provided namespaces

### DIFF
--- a/pkg/apiserver/tenant/tenant.go
+++ b/pkg/apiserver/tenant/tenant.go
@@ -339,6 +339,7 @@ func ListDevopsRules(req *restful.Request, resp *restful.Response) {
 }
 
 func LogQuery(req *restful.Request, resp *restful.Response) {
+	operation := req.QueryParameter("operation")
 	req, err := regenerateLoggingRequest(req)
 	switch {
 	case err != nil:
@@ -346,10 +347,11 @@ func LogQuery(req *restful.Request, resp *restful.Response) {
 	case req != nil:
 		logging.LoggingQueryCluster(req, resp)
 	default:
-		if req.QueryParameter("operation") == "export" {
+		if operation == "export" {
+			resp.Header().Set("Content-Type", restful.MIME_OCTET)
 			resp.Write(nil)
 		} else {
-			resp.WriteAsJson(loggingv1alpha2.QueryResult{})
+			resp.WriteAsJson(loggingv1alpha2.QueryResult{Read: new(loggingv1alpha2.ReadResult)})
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Special notes for reviewers**:
```
req.QueryParameter would crash, because req is nil
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
