### PR TITLE
fix hypersphere apis installation

### DIFF
--- a/cmd/ks-apigateway/apiserver.go
+++ b/cmd/ks-apigateway/apiserver.go
@@ -20,11 +20,6 @@ package main
 import (
 	"kubesphere.io/kubesphere/cmd/ks-apigateway/app"
 	"os"
-
-	// Install apis
-	_ "kubesphere.io/kubesphere/pkg/apigateway/caddy-plugin/authenticate"
-	_ "kubesphere.io/kubesphere/pkg/apigateway/caddy-plugin/authentication"
-	_ "kubesphere.io/kubesphere/pkg/apigateway/caddy-plugin/swagger"
 )
 
 func main() {

--- a/cmd/ks-apigateway/app/server.go
+++ b/cmd/ks-apigateway/app/server.go
@@ -8,6 +8,8 @@ import (
 	apiserverconfig "kubesphere.io/kubesphere/pkg/server/config"
 	"kubesphere.io/kubesphere/pkg/simple/client"
 	"kubesphere.io/kubesphere/pkg/utils/signals"
+
+	"kubesphere.io/kubesphere/pkg/apigateway"
 )
 
 func NewAPIGatewayCommand() *cobra.Command {
@@ -24,6 +26,8 @@ Kubernetes API Server for KubeSphere authorization purpose.
 			if err != nil {
 				return err
 			}
+
+			apigateway.RegisterPlugins()
 
 			return Run(signals.SetupSignalHandler())
 		},

--- a/cmd/ks-apiserver/app/server.go
+++ b/cmd/ks-apiserver/app/server.go
@@ -37,16 +37,7 @@ import (
 	"kubesphere.io/kubesphere/pkg/utils/term"
 	"net/http"
 
-	// Install apis
-	_ "kubesphere.io/kubesphere/pkg/apis/devops/install"
-	_ "kubesphere.io/kubesphere/pkg/apis/logging/install"
-	_ "kubesphere.io/kubesphere/pkg/apis/monitoring/install"
-	_ "kubesphere.io/kubesphere/pkg/apis/openpitrix/install"
-	_ "kubesphere.io/kubesphere/pkg/apis/operations/install"
-	_ "kubesphere.io/kubesphere/pkg/apis/resources/install"
-	_ "kubesphere.io/kubesphere/pkg/apis/servicemesh/metrics/install"
-	_ "kubesphere.io/kubesphere/pkg/apis/tenant/install"
-	_ "kubesphere.io/kubesphere/pkg/apis/terminal/install"
+	"kubesphere.io/kubesphere/pkg/apis"
 )
 
 func NewAPIServerCommand() *cobra.Command {
@@ -142,6 +133,8 @@ func CreateAPIServer(s *options.ServerRunOptions) error {
 	container.DoNotRecover(false)
 	container.Filter(filter.Logging)
 	container.RecoverHandler(server.LogStackOnRecover)
+
+	apis.InstallAPIs(container)
 
 	// install config api
 	apiserverconfig.InstallAPI(container)

--- a/cmd/ks-iam/apiserver.go
+++ b/cmd/ks-iam/apiserver.go
@@ -20,8 +20,6 @@ package main
 import (
 	"kubesphere.io/kubesphere/cmd/ks-iam/app"
 	"log"
-	// Install apis
-	_ "kubesphere.io/kubesphere/pkg/apis/iam/install"
 )
 
 func main() {

--- a/cmd/ks-iam/app/server.go
+++ b/cmd/ks-iam/app/server.go
@@ -36,6 +36,8 @@ import (
 	"kubesphere.io/kubesphere/pkg/utils/term"
 	"net/http"
 	"time"
+
+	"kubesphere.io/kubesphere/pkg/apis"
 )
 
 func NewAPIServerCommand() *cobra.Command {
@@ -111,6 +113,8 @@ func Run(s *options.ServerRunOptions, stopChan <-chan struct{}) error {
 	container.Filter(filter.Logging)
 	container.DoNotRecover(false)
 	container.RecoverHandler(server.LogStackOnRecover)
+
+	apis.InstallAuthorizationAPIs(container)
 
 	if s.GenericServerRunOptions.InsecurePort != 0 {
 		klog.Infof("Server listening on %s:%d ", s.GenericServerRunOptions.BindAddress, s.GenericServerRunOptions.InsecurePort)

--- a/pkg/apigateway/caddy-plugin/authenticate/auto_load.go
+++ b/pkg/apigateway/caddy-plugin/authenticate/auto_load.go
@@ -25,13 +25,6 @@ import (
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
 
-func init() {
-	caddy.RegisterPlugin("authenticate", caddy.Plugin{
-		ServerType: "http",
-		Action:     Setup,
-	})
-}
-
 func Setup(c *caddy.Controller) error {
 
 	rule, err := parse(c)

--- a/pkg/apigateway/caddy-plugin/authentication/auto_load.go
+++ b/pkg/apigateway/caddy-plugin/authentication/auto_load.go
@@ -27,13 +27,6 @@ import (
 	"kubesphere.io/kubesphere/pkg/informers"
 )
 
-func init() {
-	caddy.RegisterPlugin("authentication", caddy.Plugin{
-		ServerType: "http",
-		Action:     Setup,
-	})
-}
-
 // Setup is called by Caddy to parse the config block
 func Setup(c *caddy.Controller) error {
 

--- a/pkg/apigateway/caddy-plugin/swagger/auto_load.go
+++ b/pkg/apigateway/caddy-plugin/swagger/auto_load.go
@@ -25,13 +25,6 @@ import (
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
 
-func init() {
-	caddy.RegisterPlugin("swagger", caddy.Plugin{
-		ServerType: "http",
-		Action:     Setup,
-	})
-}
-
 func Setup(c *caddy.Controller) error {
 
 	handler, err := parse(c)

--- a/pkg/apigateway/plugins.go
+++ b/pkg/apigateway/plugins.go
@@ -1,0 +1,26 @@
+package apigateway
+
+import (
+	"github.com/mholt/caddy"
+
+	"kubesphere.io/kubesphere/pkg/apigateway/caddy-plugin/authenticate"
+	"kubesphere.io/kubesphere/pkg/apigateway/caddy-plugin/authentication"
+	swagger "kubesphere.io/kubesphere/pkg/apigateway/caddy-plugin/swagger"
+)
+
+func RegisterPlugins() {
+	caddy.RegisterPlugin("swagger", caddy.Plugin{
+		ServerType: "http",
+		Action:     swagger.Setup,
+	})
+
+	caddy.RegisterPlugin("authenticate", caddy.Plugin{
+		ServerType: "http",
+		Action:     authenticate.Setup,
+	})
+
+	caddy.RegisterPlugin("authentication", caddy.Plugin{
+		ServerType: "http",
+		Action:     authentication.Setup,
+	})
+}

--- a/pkg/apis/kapis.go
+++ b/pkg/apis/kapis.go
@@ -1,0 +1,32 @@
+package apis
+
+import (
+	"github.com/emicklei/go-restful"
+	urlruntime "k8s.io/apimachinery/pkg/util/runtime"
+	devopsv1alpha2 "kubesphere.io/kubesphere/pkg/apis/devops/v1alpha2"
+	iamv1alpha2 "kubesphere.io/kubesphere/pkg/apis/iam/v1alpha2"
+	loggingv1alpha2 "kubesphere.io/kubesphere/pkg/apis/logging/v1alpha2"
+	monitoringv1alpha2 "kubesphere.io/kubesphere/pkg/apis/monitoring/v1alpha2"
+	openpitrixv1 "kubesphere.io/kubesphere/pkg/apis/openpitrix/v1"
+	operationsv1alpha2 "kubesphere.io/kubesphere/pkg/apis/operations/v1alpha2"
+	resourcesv1alpha2 "kubesphere.io/kubesphere/pkg/apis/resources/v1alpha2"
+	servicemeshv1alpha2 "kubesphere.io/kubesphere/pkg/apis/servicemesh/metrics/v1alpha2"
+	tenantv1alpha2 "kubesphere.io/kubesphere/pkg/apis/tenant/v1alpha2"
+	terminalv1alpha2 "kubesphere.io/kubesphere/pkg/apis/terminal/v1alpha2"
+)
+
+func InstallAPIs(container *restful.Container) {
+	urlruntime.Must(servicemeshv1alpha2.AddToContainer(container))
+	urlruntime.Must(devopsv1alpha2.AddToContainer(container))
+	urlruntime.Must(loggingv1alpha2.AddToContainer(container))
+	urlruntime.Must(monitoringv1alpha2.AddToContainer(container))
+	urlruntime.Must(openpitrixv1.AddToContainer(container))
+	urlruntime.Must(operationsv1alpha2.AddToContainer(container))
+	urlruntime.Must(resourcesv1alpha2.AddToContainer(container))
+	urlruntime.Must(tenantv1alpha2.AddToContainer(container))
+	urlruntime.Must(terminalv1alpha2.AddToContainer(container))
+}
+
+func InstallAuthorizationAPIs(container *restful.Container) {
+	urlruntime.Must(iamv1alpha2.AddToContainer(container))
+}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:

Since we will switch to hypersphere to start kubesphere, so we imported all commands in one place. The bad thing is the way we install apis through init function. The result is we will installed all components apis even though we only want to invoke one component. This pr aims to reduce the usage of init function. 

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
