### PR TITLE
skip informer creating when corresponding crd not exists

### DIFF
--- a/pkg/simple/client/k8s/kubernetes.go
+++ b/pkg/simple/client/k8s/kubernetes.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	s2i "github.com/kubesphere/s2ioperator/pkg/client/clientset/versioned"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -11,6 +12,9 @@ import (
 type KubernetesClient struct {
 	// kubernetes client interface
 	k8s *kubernetes.Clientset
+
+	// discovery client
+	discoveryClient *discovery.DiscoveryClient
 
 	// generated clientset
 	ks *kubesphere.Clientset
@@ -33,11 +37,12 @@ func NewKubernetesClientOrDie(options *KubernetesOptions) *KubernetesClient {
 	config.Burst = options.Burst
 
 	k := &KubernetesClient{
-		k8s:    kubernetes.NewForConfigOrDie(config),
-		ks:     kubesphere.NewForConfigOrDie(config),
-		s2i:    s2i.NewForConfigOrDie(config),
-		master: config.Host,
-		config: config,
+		k8s:             kubernetes.NewForConfigOrDie(config),
+		discoveryClient: discovery.NewDiscoveryClientForConfigOrDie(config),
+		ks:              kubesphere.NewForConfigOrDie(config),
+		s2i:             s2i.NewForConfigOrDie(config),
+		master:          config.Host,
+		config:          config,
 	}
 
 	if options.Master != "" {
@@ -81,6 +86,10 @@ func NewKubernetesClient(options *KubernetesOptions) (*KubernetesClient, error) 
 
 func (k *KubernetesClient) Kubernetes() kubernetes.Interface {
 	return k.k8s
+}
+
+func (k *KubernetesClient) Discovery() discovery.DiscoveryInterface {
+	return k.discoveryClient
 }
 
 func (k *KubernetesClient) KubeSphere() kubesphere.Interface {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
ks-apiserver will create informers for those resources needed to list, but if  crds are missing(forget to create first), ks-apiserver will failed to start. This pr skip creating those informers if no corresponding crd.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
