### PR TITLE
fix: filter pod by service name

### DIFF
--- a/pkg/models/resources/pods.go
+++ b/pkg/models/resources/pods.go
@@ -140,7 +140,7 @@ func podBelongToService(item *v1.Pod, serviceName string) bool {
 	}
 
 	selector := labels.Set(service.Spec.Selector).AsSelectorPreValidated()
-	if !selector.Matches(labels.Set(item.Labels)) {
+	if selector.Empty() || !selector.Matches(labels.Set(item.Labels)) {
 		return false
 	}
 	return true


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

**What type of PR is this?**

 /kind bug


**What this PR does / why we need it**:

if service selector is empty must return false, means no pod match the condition