### PR TITLE
fix: return early when err is nil

### DIFF
--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -216,8 +216,8 @@ func (r *ReconcileNamespace) checkAndCreateRoles(namespace *corev1.Namespace) er
 				err = r.Create(context.TODO(), role)
 				if err != nil {
 					klog.Error(err)
+					return err
 				}
-				return err
 			} else {
 				klog.Error(err)
 				return err


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

create default roles but return early when err is nil

