### PR TITLE
do not set content md5 manually

### DIFF
--- a/pkg/models/devops/s2ibinary_handler.go
+++ b/pkg/models/devops/s2ibinary_handler.go
@@ -90,7 +90,6 @@ func UploadS2iBinary(namespace, name, md5 string, fileHeader *multipart.FileHead
 		Bucket:             s3Client.Bucket(),
 		Key:                aws.String(fmt.Sprintf("%s-%s", namespace, name)),
 		Body:               binFile,
-		ContentMD5:         aws.String(md5),
 		ContentDisposition: aws.String(fmt.Sprintf("attachment; filename=\"%s\"", copy.Spec.FileName)),
 	})
 


### PR DESCRIPTION
Signed-off-by: runzexia <runzexia@yunify.com>

fix when filesize less than 5mib
/cc @zryfish 
```
API: PutObject(bucket=s2i-binaries, object=test-a-txt5dmo)
Time: 08:42:31 UTC 10/12/2019
RequestID: 15CCD9B73DA0AA3B
RemoteHost: 10.233.99.214
UserAgent: aws-sdk-go/1.22.2 (go1.12.4; linux; amd64) S3Manager
Error: Bad digest: Expected 7f969cf35dbb6f76fa6fce5c75cd777f6dfb73ad34e5df34 is not valid with what we calculated f5ac8127b3b6b85cdc13f237c6005d80
       1: cmd/logger/logger.go:294:logger.LogIf()
       2: cmd/fs-v1-helpers.go:349:cmd.fsCreateFile()
       3: cmd/fs-v1.go:924:cmd.(*FSObjects).putObject()
       4: cmd/fs-v1.go:834:cmd.(*FSObjects).PutObject()
       5: cmd/object-handlers.go:1023:cmd.(ObjectLayer).PutObject-fm()
       6: cmd/object-handlers.go:1104:cmd.objectAPIHandlers.PutObjectHandler()
       7: cmd/api-router.go:72:cmd.(objectAPIHandlers).PutObjectHandler-fm()
       8: net/http/server.go:1947:http.HandlerFunc.ServeHTTP()
```