### PR TITLE
fix: sort deployment by last update time

### DIFF
--- a/pkg/models/resources/pods.go
+++ b/pkg/models/resources/pods.go
@@ -221,6 +221,14 @@ func (*podSearcher) fuzzy(fuzzy map[string]string, item *v1.Pod) bool {
 
 func (*podSearcher) compare(a, b *v1.Pod, orderBy string) bool {
 	switch orderBy {
+	case StartTime:
+		if a.Status.StartTime == nil {
+			return false
+		}
+		if b.Status.StartTime == nil {
+			return true
+		}
+		return a.Status.StartTime.Before(b.Status.StartTime)
 	case CreateTime:
 		return a.CreationTimestamp.Time.Before(b.CreationTimestamp.Time)
 	case Name:

--- a/pkg/models/resources/resources.go
+++ b/pkg/models/resources/resources.go
@@ -67,6 +67,7 @@ const (
 	Role                     = "role"
 	CreateTime               = "createTime"
 	UpdateTime               = "updateTime"
+	StartTime                = "startTime"
 	LastScheduleTime         = "lastScheduleTime"
 	chart                    = "chart"
 	release                  = "release"


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

1. sort deployment by last update time.
2. sort pod by start time.
