### PR TITLE
monitor: no need to produce error when devops is disabled

### DIFF
--- a/pkg/models/metrics/metrics.go
+++ b/pkg/models/metrics/metrics.go
@@ -679,7 +679,9 @@ func GetClusterStatistics() *Response {
 	go func() {
 		num, err := workspaces.GetAllDevOpsProjectsNums()
 		if err != nil {
-			klog.Errorln(err)
+			if _, notEnabled := err.(cs.ClientSetNotEnabledError); !notEnabled {
+				klog.Errorln(err)
+			}
 			devopsStats.Status = "error"
 		} else {
 			devopsStats.withMetricResult(now, num)
@@ -746,7 +748,9 @@ func GetWorkspaceStatistics(workspaceName string) *Response {
 	go func() {
 		num, err := workspaces.GetDevOpsProjectsCount(workspaceName)
 		if err != nil {
-			klog.Errorln(err)
+			if _, notEnabled := err.(cs.ClientSetNotEnabledError); !notEnabled {
+				klog.Errorln(err)
+			}
 			devopsStats.Status = "error"
 		} else {
 			devopsStats.withMetricResult(now, num)

--- a/pkg/models/workspaces/workspaces.go
+++ b/pkg/models/workspaces/workspaces.go
@@ -169,6 +169,10 @@ func DeleteWorkspaceRoleBinding(workspace, username string, role string) error {
 }
 
 func GetDevOpsProjectsCount(workspaceName string) (int, error) {
+	_, err := clientset.ClientSets().Devops()
+	if _, notEnabled := err.(clientset.ClientSetNotEnabledError); notEnabled {
+		return 0, err
+	}
 
 	dbconn, err := clientset.ClientSets().MySQL()
 	if err != nil {
@@ -237,6 +241,11 @@ func GetAllProjectNums() (int, error) {
 }
 
 func GetAllDevOpsProjectsNums() (int, error) {
+	_, err := clientset.ClientSets().Devops()
+	if _, notEnabled := err.(clientset.ClientSetNotEnabledError); notEnabled {
+		return 0, err
+	}
+
 	dbconn, err := clientset.ClientSets().MySQL()
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
refer to #1048 

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
