### PR TITLE
fix: do not delete devops project when devops is not enabled

### DIFF
--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -324,6 +324,15 @@ func (r *ReconcileWorkspace) deleteGroup(instance *tenantv1alpha1.Workspace) err
 }
 
 func (r *ReconcileWorkspace) deleteDevOpsProjects(instance *tenantv1alpha1.Workspace) error {
+	if _, err := cs.ClientSets().Devops(); err != nil {
+		// skip if devops is not enabled
+		if _, notEnabled := err.(cs.ClientSetNotEnabledError); notEnabled {
+			return nil
+		} else {
+			log.Error(err, "")
+			return err
+		}
+	}
 	var wg sync.WaitGroup
 
 	log.Info("Delete DevOps Projects")


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:

do not delete devops project when devops is not enabled

**Which issue(s) this PR fixes**:

Fixes #1168

