### PR TITLE
fix: redefine prometheus client timeout

### DIFF
--- a/pkg/simple/client/prometheus/prometheus.go
+++ b/pkg/simple/client/prometheus/prometheus.go
@@ -36,7 +36,7 @@ type PrometheusClient struct {
 func NewPrometheusClient(options *PrometheusOptions) (*PrometheusClient, error) {
 	return &PrometheusClient{
 		client: &http.Client{
-			Timeout: time.Duration(3) * time.Second,
+			Timeout: 10 * time.Second,
 		},
 		endpoint:          options.Endpoint,
 		secondaryEndpoint: options.SecondaryEndpoint,


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
The client timeout was set too small. It may cause `net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)` sometimes. A sensible timeout shoud be 10s.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
