### PR TITLE
Change web kubectl to use serviceaccount

### DIFF
--- a/cmd/ks-iam/app/options/options.go
+++ b/cmd/ks-iam/app/options/options.go
@@ -42,6 +42,7 @@ type ServerRunOptions struct {
 	JWTSecret               string
 	AuthRateLimit           string
 	EnableMultiLogin        bool
+	GenerateKubeConfig      bool
 }
 
 func NewServerRunOptions() *ServerRunOptions {
@@ -66,6 +67,7 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 	fs.StringVar(&s.JWTSecret, "jwt-secret", "", "jwt secret")
 	fs.StringVar(&s.AuthRateLimit, "auth-rate-limit", "5/30m", "specifies the maximum number of authentication attempts permitted and time interval,valid time units are \"s\",\"m\",\"h\"")
 	fs.BoolVar(&s.EnableMultiLogin, "enable-multi-login", false, "allow one account to have multiple sessions")
+	fs.BoolVar(&s.GenerateKubeConfig, "generate-kubeconfig", true, "generate kubeconfig for new users, kubeconfig is required in devops pipeline, set to false if you don't need devops.")
 
 	s.KubernetesOptions.AddFlags(fss.FlagSet("kubernetes"))
 	s.LdapOptions.AddFlags(fss.FlagSet("ldap"))

--- a/cmd/ks-iam/app/server.go
+++ b/cmd/ks-iam/app/server.go
@@ -94,7 +94,7 @@ func Run(s *options.ServerRunOptions, stopChan <-chan struct{}) error {
 
 	waitForResourceSync(stopChan)
 
-	err := iam.Init(s.AdminEmail, s.AdminPassword, s.AuthRateLimit, s.TokenIdleTimeout, s.EnableMultiLogin)
+	err := iam.Init(s.AdminEmail, s.AdminPassword, s.AuthRateLimit, s.TokenIdleTimeout, s.EnableMultiLogin, s.GenerateKubeConfig)
 
 	jwtutil.Setup(s.JWTSecret)
 

--- a/pkg/models/routers/routers.go
+++ b/pkg/models/routers/routers.go
@@ -287,13 +287,7 @@ func updateRouterService(namespace string, routerType corev1.ServiceType, annota
 
 	service.Spec.Type = routerType
 
-	originalAnnotations := service.GetAnnotations()
-
-	for key, val := range annotations {
-		originalAnnotations[key] = val
-	}
-
-	service.SetAnnotations(originalAnnotations)
+	service.SetAnnotations(annotations)
 
 	service, err = k8sClient.CoreV1().Services(constants.IngressControllerNamespace).Update(service)
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Currently web kubectl po is using generated kubeconfig, have to give kubesphere ca certificate to generate such kubeconfig. change to use serviceaccount, we don't need ca certificate any more

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the 
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
