### PR TITLE
Run tests with different configuration name

### DIFF
--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -104,10 +104,17 @@ func convertToMap(conf *Config) map[string]bool {
 }
 
 // Load loads configuration after setup
-func Load() error {
+// configName is the name of the configuration file, you do not need to pass this parameter by default.
+// To avoid conflicts with the default configuration, we pass this parameter when execute test.
+func Load(configName ...string) error {
 	sharedConfig = newConfig()
 
-	viper.SetConfigName(DefaultConfigurationName)
+	if len(configName) == 0 {
+		viper.SetConfigName(DefaultConfigurationName)
+	} else {
+		viper.SetConfigName(configName[0])
+	}
+
 	viper.AddConfigPath(DefaultConfigurationPath)
 	viper.AddConfigPath(".")
 

--- a/pkg/server/config/config_test.go
+++ b/pkg/server/config/config_test.go
@@ -24,6 +24,8 @@ import (
 	"time"
 )
 
+const DefaultTestConfigurationName = "kubesphere_test"
+
 func newTestConfig() *Config {
 	conf := &Config{
 		MySQLOptions: &mysql.MySQLOptions{
@@ -112,14 +114,14 @@ func saveTestConfig(t *testing.T, conf *Config) {
 		t.Fatalf("error marshal config. %v", err)
 	}
 
-	err = ioutil.WriteFile(fmt.Sprintf("%s.yaml", DefaultConfigurationName), content, 0640)
+	err = ioutil.WriteFile(fmt.Sprintf("%s.yaml", DefaultTestConfigurationName), content, 0640)
 	if err != nil {
 		t.Fatalf("error write configuration file, %v", err)
 	}
 }
 
 func cleanTestConfig(t *testing.T) {
-	file := fmt.Sprintf("%s.yaml", DefaultConfigurationName)
+	file := fmt.Sprintf("%s.yaml", DefaultTestConfigurationName)
 	if _, err := os.Stat(file); os.IsNotExist(err) {
 		t.Log("file not exists, skipping")
 		return
@@ -137,7 +139,7 @@ func TestGet(t *testing.T) {
 	saveTestConfig(t, conf)
 	defer cleanTestConfig(t)
 
-	err := Load()
+	err := Load(DefaultTestConfigurationName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +159,7 @@ func TestKubeSphereOptions(t *testing.T) {
 		saveTestConfig(t, &savedConf)
 		defer cleanTestConfig(t)
 
-		err := Load()
+		err := Load(DefaultTestConfigurationName)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -176,7 +178,7 @@ func TestKubeSphereOptions(t *testing.T) {
 		saveTestConfig(t, &savedConf)
 		defer cleanTestConfig(t)
 
-		err := Load()
+		err := Load(DefaultTestConfigurationName)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Signed-off-by: runzexia <runzexia@yunify.com>
/kind test
/cc @zryfish @wansir 

**What this PR does / why we need it**:

In previous versions we used the same configuration with the default name for configuration testing. If the user has configured the configuration file locally for development, this may result in a test failure/configuration being overwritten.