### PR TITLE
Change router apiversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
 script:
   - diff -u <(echo -n) <(gofmt -d ./pkg ./cmd ./tools)
   - make openapi
-  - make all && $HOME/gopath/bin/goveralls -coverprofile=cover.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+  - make all && $HOME/gopath/bin/goveralls -coverprofile=cover.out -service=travis-ci -repotoken=$COVERALLS_TOKEN
 
 install:
   - go get golang.org/x/tools/cmd/cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,11 @@ before_script:
 script:
   - diff -u <(echo -n) <(gofmt -d ./pkg ./cmd ./tools)
   - make openapi
-  - make all
+  - make all && $HOME/gopath/bin/goveralls -coverprofile=cover.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+
+install:
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
 
 deploy:
   skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ docker-build: all
 
 # Run tests
 test: fmt vet
-	export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=1m; go test ./pkg/... ./cmd/... -coverprofile cover.out
+	export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=1m; go test -v ./pkg/... ./cmd/... -covermode=count -coverprofile cover.out
 
 .PHONY: clean
 clean:

--- a/pkg/models/routers/routers_suite_test.go
+++ b/pkg/models/routers/routers_suite_test.go
@@ -1,0 +1,1 @@
+package routers

--- a/pkg/models/routers/routers_test.go
+++ b/pkg/models/routers/routers_test.go
@@ -1,0 +1,1 @@
+package routers


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug


**What this PR does / why we need it**:
Bump router underlying resource version to apps/v1 since we are moving to Kubernetes 1.16

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
