### PR TITLE
change router underlying resource apiversion

### DIFF
--- a/pkg/models/routers/routers_suite_test.go
+++ b/pkg/models/routers/routers_suite_test.go
@@ -1,1 +1,0 @@
-package routers

--- a/pkg/models/routers/routers_test.go
+++ b/pkg/models/routers/routers_test.go
@@ -1,1 +1,0 @@
-package routers


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:
Change router underlying resource version to apps/v1 since we are moving to Kubernetes v1.16

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
