### PR TITLE
use user auth when using credential and pipeline

### DIFF
--- a/pkg/apiserver/devops/project_credential.go
+++ b/pkg/apiserver/devops/project_credential.go
@@ -14,6 +14,7 @@ limitations under the License.
 package devops
 
 import (
+	"fmt"
 	"github.com/emicklei/go-restful"
 	"k8s.io/klog"
 	"kubesphere.io/kubesphere/pkg/constants"
@@ -33,13 +34,21 @@ func CreateDevOpsProjectCredentialHandler(request *restful.Request, resp *restfu
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	err = devops.CheckProjectUserInRole(username, projectId, []string{devops.ProjectOwner, devops.ProjectMaintainer})
-	if err != nil {
-		klog.Errorf("%+v", err)
-		errors.ParseSvcErr(restful.NewError(http.StatusForbidden, err.Error()), resp)
+	xuseranme, xpassword, ok := request.Request.BasicAuth()
+	if !ok {
+		err := fmt.Errorf("basic auth not found")
+		klog.Error("%+v", err)
+		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	credentialId, err := devops.CreateProjectCredential(projectId, username, credential)
+
+	server, err := devops.NewServer(xuseranme, xpassword)
+	if err != nil {
+		klog.Errorf("%+v", err)
+		errors.ParseSvcErr(err, resp)
+		return
+	}
+	credentialId, err := server.CreateProjectCredential(projectId, username, credential)
 
 	if err != nil {
 		klog.Errorf("%+v", err)
@@ -56,7 +65,6 @@ func CreateDevOpsProjectCredentialHandler(request *restful.Request, resp *restfu
 func UpdateDevOpsProjectCredentialHandler(request *restful.Request, resp *restful.Response) {
 
 	projectId := request.PathParameter("devops")
-	username := request.HeaderParameter(constants.UserNameHeader)
 	credentialId := request.PathParameter("credential")
 	var credential *devops.JenkinsCredential
 	err := request.ReadEntity(&credential)
@@ -65,13 +73,21 @@ func UpdateDevOpsProjectCredentialHandler(request *restful.Request, resp *restfu
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	err = devops.CheckProjectUserInRole(username, projectId, []string{devops.ProjectOwner, devops.ProjectMaintainer})
-	if err != nil {
-		klog.Errorf("%+v", err)
-		errors.ParseSvcErr(restful.NewError(http.StatusForbidden, err.Error()), resp)
+	xuseranme, xpassword, ok := request.Request.BasicAuth()
+	if !ok {
+		err := fmt.Errorf("basic auth not found")
+		klog.Error("%+v", err)
+		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	credentialId, err = devops.UpdateProjectCredential(projectId, credentialId, credential)
+
+	server, err := devops.NewServer(xuseranme, xpassword)
+	if err != nil {
+		klog.Errorf("%+v", err)
+		errors.ParseSvcErr(err, resp)
+		return
+	}
+	credentialId, err = server.UpdateProjectCredential(projectId, credentialId, credential)
 
 	if err != nil {
 		klog.Errorf("%+v", err)
@@ -88,7 +104,6 @@ func UpdateDevOpsProjectCredentialHandler(request *restful.Request, resp *restfu
 func DeleteDevOpsProjectCredentialHandler(request *restful.Request, resp *restful.Response) {
 
 	projectId := request.PathParameter("devops")
-	username := request.HeaderParameter(constants.UserNameHeader)
 	credentialId := request.PathParameter("credential")
 	var credential *devops.JenkinsCredential
 	err := request.ReadEntity(&credential)
@@ -97,13 +112,21 @@ func DeleteDevOpsProjectCredentialHandler(request *restful.Request, resp *restfu
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	err = devops.CheckProjectUserInRole(username, projectId, []string{devops.ProjectOwner, devops.ProjectMaintainer})
-	if err != nil {
-		klog.Errorf("%+v", err)
-		errors.ParseSvcErr(restful.NewError(http.StatusForbidden, err.Error()), resp)
+	xuseranme, xpassword, ok := request.Request.BasicAuth()
+	if !ok {
+		err := fmt.Errorf("basic auth not found")
+		klog.Error("%+v", err)
+		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	credentialId, err = devops.DeleteProjectCredential(projectId, credentialId, credential)
+
+	server, err := devops.NewServer(xuseranme, xpassword)
+	if err != nil {
+		klog.Errorf("%+v", err)
+		errors.ParseSvcErr(err, resp)
+		return
+	}
+	credentialId, err = server.DeleteProjectCredential(projectId, credentialId, credential)
 
 	if err != nil {
 		klog.Errorf("%+v", err)
@@ -120,18 +143,25 @@ func DeleteDevOpsProjectCredentialHandler(request *restful.Request, resp *restfu
 func GetDevOpsProjectCredentialHandler(request *restful.Request, resp *restful.Response) {
 
 	projectId := request.PathParameter("devops")
-	username := request.HeaderParameter(constants.UserNameHeader)
 	credentialId := request.PathParameter("credential")
 	getContent := request.QueryParameter("content")
 	domain := request.QueryParameter("domain")
 
-	err := devops.CheckProjectUserInRole(username, projectId, []string{devops.ProjectOwner, devops.ProjectMaintainer})
-	if err != nil {
-		klog.Errorf("%+v", err)
-		errors.ParseSvcErr(restful.NewError(http.StatusForbidden, err.Error()), resp)
+	xuseranme, xpassword, ok := request.Request.BasicAuth()
+	if !ok {
+		err := fmt.Errorf("basic auth not found")
+		klog.Error("%+v", err)
+		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	response, err := devops.GetProjectCredential(projectId, credentialId, domain, getContent)
+
+	server, err := devops.NewServer(xuseranme, xpassword)
+	if err != nil {
+		klog.Errorf("%+v", err)
+		errors.ParseSvcErr(err, resp)
+		return
+	}
+	response, err := server.GetProjectCredential(projectId, credentialId, domain, getContent)
 
 	if err != nil {
 		klog.Errorf("%+v", err)
@@ -145,16 +175,24 @@ func GetDevOpsProjectCredentialHandler(request *restful.Request, resp *restful.R
 
 func GetDevOpsProjectCredentialsHandler(request *restful.Request, resp *restful.Response) {
 	projectId := request.PathParameter("devops")
-	username := request.HeaderParameter(constants.UserNameHeader)
 	domain := request.QueryParameter("domain")
 
-	err := devops.CheckProjectUserInRole(username, projectId, []string{devops.ProjectOwner, devops.ProjectMaintainer})
-	if err != nil {
-		klog.Errorf("%+v", err)
-		errors.ParseSvcErr(restful.NewError(http.StatusForbidden, err.Error()), resp)
+	xuseranme, xpassword, ok := request.Request.BasicAuth()
+	if !ok {
+		err := fmt.Errorf("basic auth not found")
+		klog.Error("%+v", err)
+		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	jenkinsCredentials, err := devops.GetProjectCredentials(projectId, domain)
+
+	server, err := devops.NewServer(xuseranme, xpassword)
+	if err != nil {
+		klog.Errorf("%+v", err)
+		errors.ParseSvcErr(err, resp)
+		return
+	}
+
+	jenkinsCredentials, err := server.GetProjectCredentials(projectId, domain)
 	if err != nil {
 		klog.Errorf("%+v", err)
 		errors.ParseSvcErr(err, resp)

--- a/pkg/apiserver/devops/project_credential.go
+++ b/pkg/apiserver/devops/project_credential.go
@@ -37,7 +37,7 @@ func CreateDevOpsProjectCredentialHandler(request *restful.Request, resp *restfu
 	xuseranme, xpassword, ok := request.Request.BasicAuth()
 	if !ok {
 		err := fmt.Errorf("basic auth not found")
-		klog.Error("%+v", err)
+		klog.Errorf("%+v", err)
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
@@ -76,7 +76,7 @@ func UpdateDevOpsProjectCredentialHandler(request *restful.Request, resp *restfu
 	xuseranme, xpassword, ok := request.Request.BasicAuth()
 	if !ok {
 		err := fmt.Errorf("basic auth not found")
-		klog.Error("%+v", err)
+		klog.Errorf("%+v", err)
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
@@ -115,7 +115,7 @@ func DeleteDevOpsProjectCredentialHandler(request *restful.Request, resp *restfu
 	xuseranme, xpassword, ok := request.Request.BasicAuth()
 	if !ok {
 		err := fmt.Errorf("basic auth not found")
-		klog.Error("%+v", err)
+		klog.Errorf("%+v", err)
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
@@ -150,7 +150,7 @@ func GetDevOpsProjectCredentialHandler(request *restful.Request, resp *restful.R
 	xuseranme, xpassword, ok := request.Request.BasicAuth()
 	if !ok {
 		err := fmt.Errorf("basic auth not found")
-		klog.Error("%+v", err)
+		klog.Errorf("%+v", err)
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
@@ -180,7 +180,7 @@ func GetDevOpsProjectCredentialsHandler(request *restful.Request, resp *restful.
 	xuseranme, xpassword, ok := request.Request.BasicAuth()
 	if !ok {
 		err := fmt.Errorf("basic auth not found")
-		klog.Error("%+v", err)
+		klog.Errorf("%+v", err)
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}

--- a/pkg/apiserver/devops/project_pipeline.go
+++ b/pkg/apiserver/devops/project_pipeline.go
@@ -14,9 +14,9 @@ limitations under the License.
 package devops
 
 import (
+	"fmt"
 	"github.com/emicklei/go-restful"
 	"k8s.io/klog"
-	"kubesphere.io/kubesphere/pkg/constants"
 	"kubesphere.io/kubesphere/pkg/models/devops"
 	"kubesphere.io/kubesphere/pkg/server/errors"
 	"net/http"
@@ -25,7 +25,6 @@ import (
 func CreateDevOpsProjectPipelineHandler(request *restful.Request, resp *restful.Response) {
 
 	projectId := request.PathParameter("devops")
-	username := request.HeaderParameter(constants.UserNameHeader)
 	var pipeline *devops.ProjectPipeline
 	err := request.ReadEntity(&pipeline)
 	if err != nil {
@@ -33,13 +32,21 @@ func CreateDevOpsProjectPipelineHandler(request *restful.Request, resp *restful.
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	err = devops.CheckProjectUserInRole(username, projectId, []string{devops.ProjectOwner, devops.ProjectMaintainer})
-	if err != nil {
-		klog.Errorf("%+v", err)
-		errors.ParseSvcErr(restful.NewError(http.StatusForbidden, err.Error()), resp)
+	xuseranme, xpassword, ok := request.Request.BasicAuth()
+	if !ok {
+		err := fmt.Errorf("basic auth not found")
+		klog.Error("%+v", err)
+		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	pipelineName, err := devops.CreateProjectPipeline(projectId, pipeline)
+
+	server, err := devops.NewServer(xuseranme, xpassword)
+	if err != nil {
+		klog.Errorf("%+v", err)
+		errors.ParseSvcErr(err, resp)
+		return
+	}
+	pipelineName, err := server.CreateProjectPipeline(projectId, pipeline)
 
 	if err != nil {
 		klog.Errorf("%+v", err)
@@ -55,16 +62,23 @@ func CreateDevOpsProjectPipelineHandler(request *restful.Request, resp *restful.
 
 func DeleteDevOpsProjectPipelineHandler(request *restful.Request, resp *restful.Response) {
 	projectId := request.PathParameter("devops")
-	username := request.HeaderParameter(constants.UserNameHeader)
 	pipelineId := request.PathParameter("pipeline")
 
-	err := devops.CheckProjectUserInRole(username, projectId, []string{devops.ProjectOwner, devops.ProjectMaintainer})
-	if err != nil {
-		klog.Errorf("%+v", err)
-		errors.ParseSvcErr(restful.NewError(http.StatusForbidden, err.Error()), resp)
+	xuseranme, xpassword, ok := request.Request.BasicAuth()
+	if !ok {
+		err := fmt.Errorf("basic auth not found")
+		klog.Error("%+v", err)
+		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	pipelineName, err := devops.DeleteProjectPipeline(projectId, pipelineId)
+
+	server, err := devops.NewServer(xuseranme, xpassword)
+	if err != nil {
+		klog.Errorf("%+v", err)
+		errors.ParseSvcErr(err, resp)
+		return
+	}
+	pipelineName, err := server.DeleteProjectPipeline(projectId, pipelineId)
 
 	if err != nil {
 		klog.Errorf("%+v", err)
@@ -81,7 +95,6 @@ func DeleteDevOpsProjectPipelineHandler(request *restful.Request, resp *restful.
 func UpdateDevOpsProjectPipelineHandler(request *restful.Request, resp *restful.Response) {
 
 	projectId := request.PathParameter("devops")
-	username := request.HeaderParameter(constants.UserNameHeader)
 	pipelineId := request.PathParameter("pipeline")
 	var pipeline *devops.ProjectPipeline
 	err := request.ReadEntity(&pipeline)
@@ -90,13 +103,21 @@ func UpdateDevOpsProjectPipelineHandler(request *restful.Request, resp *restful.
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	err = devops.CheckProjectUserInRole(username, projectId, []string{devops.ProjectOwner, devops.ProjectMaintainer})
-	if err != nil {
-		klog.Errorf("%+v", err)
-		errors.ParseSvcErr(restful.NewError(http.StatusForbidden, err.Error()), resp)
+	xuseranme, xpassword, ok := request.Request.BasicAuth()
+	if !ok {
+		err := fmt.Errorf("basic auth not found")
+		klog.Error("%+v", err)
+		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	pipelineName, err := devops.UpdateProjectPipeline(projectId, pipelineId, pipeline)
+
+	server, err := devops.NewServer(xuseranme, xpassword)
+	if err != nil {
+		klog.Errorf("%+v", err)
+		errors.ParseSvcErr(err, resp)
+		return
+	}
+	pipelineName, err := server.UpdateProjectPipeline(projectId, pipelineId, pipeline)
 
 	if err != nil {
 		klog.Errorf("%+v", err)
@@ -113,16 +134,23 @@ func UpdateDevOpsProjectPipelineHandler(request *restful.Request, resp *restful.
 func GetDevOpsProjectPipelineHandler(request *restful.Request, resp *restful.Response) {
 
 	projectId := request.PathParameter("devops")
-	username := request.HeaderParameter(constants.UserNameHeader)
 	pipelineId := request.PathParameter("pipeline")
 
-	err := devops.CheckProjectUserInRole(username, projectId, []string{devops.ProjectOwner, devops.ProjectMaintainer})
-	if err != nil {
-		klog.Errorf("%+v", err)
-		errors.ParseSvcErr(restful.NewError(http.StatusForbidden, err.Error()), resp)
+	xuseranme, xpassword, ok := request.Request.BasicAuth()
+	if !ok {
+		err := fmt.Errorf("basic auth not found")
+		klog.Error("%+v", err)
+		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	pipeline, err := devops.GetProjectPipeline(projectId, pipelineId)
+
+	server, err := devops.NewServer(xuseranme, xpassword)
+	if err != nil {
+		klog.Errorf("%+v", err)
+		errors.ParseSvcErr(err, resp)
+		return
+	}
+	pipeline, err := server.GetProjectPipeline(projectId, pipelineId)
 
 	if err != nil {
 		klog.Errorf("%+v", err)
@@ -136,15 +164,22 @@ func GetDevOpsProjectPipelineHandler(request *restful.Request, resp *restful.Res
 
 func GetPipelineSonarStatusHandler(request *restful.Request, resp *restful.Response) {
 	projectId := request.PathParameter("devops")
-	username := request.HeaderParameter(constants.UserNameHeader)
 	pipelineId := request.PathParameter("pipeline")
-	err := devops.CheckProjectUserInRole(username, projectId, devops.AllRoleSlice)
-	if err != nil {
-		klog.Errorf("%+v", err)
-		errors.ParseSvcErr(restful.NewError(http.StatusForbidden, err.Error()), resp)
+	xuseranme, xpassword, ok := request.Request.BasicAuth()
+	if !ok {
+		err := fmt.Errorf("basic auth not found")
+		klog.Error("%+v", err)
+		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	sonarStatus, err := devops.GetPipelineSonar(projectId, pipelineId)
+
+	server, err := devops.NewServer(xuseranme, xpassword)
+	if err != nil {
+		klog.Errorf("%+v", err)
+		errors.ParseSvcErr(err, resp)
+		return
+	}
+	sonarStatus, err := server.GetPipelineSonar(projectId, pipelineId)
 	if err != nil {
 		klog.Errorf("%+v", err)
 		errors.ParseSvcErr(err, resp)
@@ -155,16 +190,23 @@ func GetPipelineSonarStatusHandler(request *restful.Request, resp *restful.Respo
 
 func GetMultiBranchesPipelineSonarStatusHandler(request *restful.Request, resp *restful.Response) {
 	projectId := request.PathParameter("devops")
-	username := request.HeaderParameter(constants.UserNameHeader)
 	pipelineId := request.PathParameter("pipeline")
 	branchId := request.PathParameter("branch")
-	err := devops.CheckProjectUserInRole(username, projectId, devops.AllRoleSlice)
-	if err != nil {
-		klog.Errorf("%+v", err)
-		errors.ParseSvcErr(restful.NewError(http.StatusForbidden, err.Error()), resp)
+	xuseranme, xpassword, ok := request.Request.BasicAuth()
+	if !ok {
+		err := fmt.Errorf("basic auth not found")
+		klog.Error("%+v", err)
+		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
-	sonarStatus, err := devops.GetMultiBranchPipelineSonar(projectId, pipelineId, branchId)
+
+	server, err := devops.NewServer(xuseranme, xpassword)
+	if err != nil {
+		klog.Errorf("%+v", err)
+		errors.ParseSvcErr(err, resp)
+		return
+	}
+	sonarStatus, err := server.GetMultiBranchPipelineSonar(projectId, pipelineId, branchId)
 	if err != nil {
 		klog.Errorf("%+v", err)
 		errors.ParseSvcErr(err, resp)

--- a/pkg/apiserver/devops/project_pipeline.go
+++ b/pkg/apiserver/devops/project_pipeline.go
@@ -35,7 +35,7 @@ func CreateDevOpsProjectPipelineHandler(request *restful.Request, resp *restful.
 	xuseranme, xpassword, ok := request.Request.BasicAuth()
 	if !ok {
 		err := fmt.Errorf("basic auth not found")
-		klog.Error("%+v", err)
+		klog.Errorf("%+v", err)
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
@@ -67,7 +67,7 @@ func DeleteDevOpsProjectPipelineHandler(request *restful.Request, resp *restful.
 	xuseranme, xpassword, ok := request.Request.BasicAuth()
 	if !ok {
 		err := fmt.Errorf("basic auth not found")
-		klog.Error("%+v", err)
+		klog.Errorf("%+v", err)
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
@@ -106,7 +106,7 @@ func UpdateDevOpsProjectPipelineHandler(request *restful.Request, resp *restful.
 	xuseranme, xpassword, ok := request.Request.BasicAuth()
 	if !ok {
 		err := fmt.Errorf("basic auth not found")
-		klog.Error("%+v", err)
+		klog.Errorf("%+v", err)
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
@@ -139,7 +139,7 @@ func GetDevOpsProjectPipelineHandler(request *restful.Request, resp *restful.Res
 	xuseranme, xpassword, ok := request.Request.BasicAuth()
 	if !ok {
 		err := fmt.Errorf("basic auth not found")
-		klog.Error("%+v", err)
+		klog.Errorf("%+v", err)
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
@@ -168,7 +168,7 @@ func GetPipelineSonarStatusHandler(request *restful.Request, resp *restful.Respo
 	xuseranme, xpassword, ok := request.Request.BasicAuth()
 	if !ok {
 		err := fmt.Errorf("basic auth not found")
-		klog.Error("%+v", err)
+		klog.Errorf("%+v", err)
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}
@@ -195,7 +195,7 @@ func GetMultiBranchesPipelineSonarStatusHandler(request *restful.Request, resp *
 	xuseranme, xpassword, ok := request.Request.BasicAuth()
 	if !ok {
 		err := fmt.Errorf("basic auth not found")
-		klog.Error("%+v", err)
+		klog.Errorf("%+v", err)
 		errors.ParseSvcErr(restful.NewError(http.StatusBadRequest, err.Error()), resp)
 		return
 	}

--- a/pkg/simple/client/devops/devops.go
+++ b/pkg/simple/client/devops/devops.go
@@ -34,10 +34,9 @@ func NewDevopsClient(options *DevopsOptions) (*DevopsClient, error) {
 	jenkins := gojenkins.CreateJenkins(nil, options.Host, options.MaxConnections, options.Username, options.Password)
 	jenkins, err := jenkins.Init()
 	if err != nil {
-		klog.Errorf("failed to connecto to jenkins role, %+v", err)
+		klog.Errorf("failed to connect to jenkins role, %+v", err)
 		return nil, err
 	}
-
 	d.jenkinsClient = jenkins
 
 	err = d.initializeJenkins()


### PR DESCRIPTION
Signed-off-by: runzexia <runzexia@yunify.com>


/kind cleanup
/area devops
/milestone 2.1.1
/cc @soulseen 
In previous versions, the auth info used when operating the pipeline and credentials was the admin's auth info.
The user's own auth info should be used, and authentication will be done in jenkins.