### PR TITLE
filter out metrics with empty resource_name when sorting

### DIFF
--- a/pkg/models/metrics/util.go
+++ b/pkg/models/metrics/util.go
@@ -126,7 +126,7 @@ func (rawMetrics *Response) SortBy(sortMetricName string, sortType string) (*Res
 					// record the ordering of resource_name to indexMap
 					// example: {"metric":{ResultItemMetricResourceName: "Deployment:xxx"},"value":[1541142931.731,"3"]}
 					resourceName, exist := r.Metric[ResultItemMetricResourceName]
-					if exist {
+					if exist && resourceName != "" {
 						if _, exist := indexMap[resourceName]; !exist {
 							indexMap[resourceName] = i
 							i = i + 1
@@ -138,7 +138,7 @@ func (rawMetrics *Response) SortBy(sortMetricName string, sortType string) (*Res
 			// iterator all metric to find max metricItems length
 			for _, r := range metricItem.Data.Result {
 				k, ok := r.Metric[ResultItemMetricResourceName]
-				if ok {
+				if ok && k != "" {
 					currentResourceMap[k] = 1
 				}
 			}
@@ -167,7 +167,7 @@ func (rawMetrics *Response) SortBy(sortMetricName string, sortType string) (*Res
 			for j := 0; j < len(re.Data.Result); j++ {
 				r := re.Data.Result[j]
 				k, exist := r.Metric[ResultItemMetricResourceName]
-				if exist {
+				if exist && k != "" {
 					index, exist := indexMap[k]
 					if exist {
 						sortedMetric[index] = r

--- a/pkg/models/metrics/util_test.go
+++ b/pkg/models/metrics/util_test.go
@@ -1,0 +1,315 @@
+package metrics
+
+import (
+	"kubesphere.io/kubesphere/pkg/api/monitoring/v1alpha2"
+	"reflect"
+	"testing"
+)
+
+func TestSortBy(t *testing.T) {
+	tests := []struct {
+		description string
+		rawMetrics  *Response
+		sortMetrics string
+		sortType    string
+		expected    *Response
+	}{
+		{
+			description: "sort a set of node metrics for node1, node2 and a node with blank name (this should be considered as abnormal).",
+			rawMetrics: &Response{
+				Results: []APIResponse{
+					{
+						MetricName: "node_cpu_usage",
+						APIResponse: v1alpha2.APIResponse{
+							Status: "success",
+							Data: v1alpha2.QueryResult{
+								ResultType: "vector",
+								Result: []v1alpha2.QueryValue{
+									{
+										Metric: map[string]string{"resource_name": "node1"},
+										Value:  []interface{}{1578987135.334, "0.221"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node2"},
+										Value:  []interface{}{1578987135.334, "0.177"},
+									},
+									{
+										Metric: map[string]string{"resource_name": ""},
+										Value:  []interface{}{1578987135.334, ""},
+									},
+								},
+							},
+						},
+					},
+					{
+						MetricName: "node_memory_total",
+						APIResponse: v1alpha2.APIResponse{
+							Status: "success",
+							Data: v1alpha2.QueryResult{
+								ResultType: "vector",
+								Result: []v1alpha2.QueryValue{
+									{
+										Metric: map[string]string{"resource_name": "node1"},
+										Value:  []interface{}{1578987135.334, "8201043968"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node2"},
+										Value:  []interface{}{1578987135.334, "8201039872"},
+									},
+									{
+										Metric: map[string]string{"resource_name": ""},
+										Value:  []interface{}{1578987135.334, ""},
+									},
+								},
+							},
+						},
+					},
+					{
+						MetricName: "node_pod_running_count",
+						APIResponse: v1alpha2.APIResponse{
+							Status: "success",
+							Data: v1alpha2.QueryResult{
+								ResultType: "vector",
+								Result: []v1alpha2.QueryValue{
+									{
+										Metric: map[string]string{"resource_name": "node1"},
+										Value:  []interface{}{1578987135.334, "19"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node2"},
+										Value:  []interface{}{1578987135.334, "6"},
+									},
+									{
+										Metric: map[string]string{"resource_name": ""},
+										Value:  []interface{}{1578987135.334, ""},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			sortMetrics: "node_cpu_usage",
+			sortType:    "desc",
+			expected: &Response{
+				Results: []APIResponse{
+					{
+						MetricName: "node_cpu_usage",
+						APIResponse: v1alpha2.APIResponse{
+							Status: "success",
+							Data: v1alpha2.QueryResult{
+								ResultType: "vector",
+								Result: []v1alpha2.QueryValue{
+									{
+										Metric: map[string]string{"resource_name": "node1"},
+										Value:  []interface{}{1578987135.334, "0.221"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node2"},
+										Value:  []interface{}{1578987135.334, "0.177"},
+									},
+								},
+							},
+						},
+					},
+					{
+						MetricName: "node_memory_total",
+						APIResponse: v1alpha2.APIResponse{
+							Status: "success",
+							Data: v1alpha2.QueryResult{
+								ResultType: "vector",
+								Result: []v1alpha2.QueryValue{
+									{
+										Metric: map[string]string{"resource_name": "node1"},
+										Value:  []interface{}{1578987135.334, "8201043968"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node2"},
+										Value:  []interface{}{1578987135.334, "8201039872"},
+									},
+								},
+							},
+						},
+					},
+					{
+						MetricName: "node_pod_running_count",
+						APIResponse: v1alpha2.APIResponse{
+							Status: "success",
+							Data: v1alpha2.QueryResult{
+								ResultType: "vector",
+								Result: []v1alpha2.QueryValue{
+									{
+										Metric: map[string]string{"resource_name": "node1"},
+										Value:  []interface{}{1578987135.334, "19"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node2"},
+										Value:  []interface{}{1578987135.334, "6"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "sort a set of node metrics for node1, node2 and node3.",
+			rawMetrics: &Response{
+				Results: []APIResponse{
+					{
+						MetricName: "node_cpu_usage",
+						APIResponse: v1alpha2.APIResponse{
+							Status: "success",
+							Data: v1alpha2.QueryResult{
+								ResultType: "vector",
+								Result: []v1alpha2.QueryValue{
+									{
+										Metric: map[string]string{"resource_name": "node1"},
+										Value:  []interface{}{1578987135.334, "0.221"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node2"},
+										Value:  []interface{}{1578987135.334, "0.177"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node3"},
+										Value:  []interface{}{1578987135.334, "0.194"},
+									},
+								},
+							},
+						},
+					},
+					{
+						MetricName: "node_memory_total",
+						APIResponse: v1alpha2.APIResponse{
+							Status: "success",
+							Data: v1alpha2.QueryResult{
+								ResultType: "vector",
+								Result: []v1alpha2.QueryValue{
+									{
+										Metric: map[string]string{"resource_name": "node1"},
+										Value:  []interface{}{1578987135.334, "8201043968"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node2"},
+										Value:  []interface{}{1578987135.334, "8201039872"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node3"},
+										Value:  []interface{}{1578987135.334, "8201056256"},
+									},
+								},
+							},
+						},
+					},
+					{
+						MetricName: "node_pod_running_count",
+						APIResponse: v1alpha2.APIResponse{
+							Status: "success",
+							Data: v1alpha2.QueryResult{
+								ResultType: "vector",
+								Result: []v1alpha2.QueryValue{
+									{
+										Metric: map[string]string{"resource_name": "node1"},
+										Value:  []interface{}{1578987135.334, "19"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node2"},
+										Value:  []interface{}{1578987135.334, "6"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node3"},
+										Value:  []interface{}{1578987135.334, "14"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			sortMetrics: "node_cpu_usage",
+			sortType:    "desc",
+			expected: &Response{
+				Results: []APIResponse{
+					{
+						MetricName: "node_cpu_usage",
+						APIResponse: v1alpha2.APIResponse{
+							Status: "success",
+							Data: v1alpha2.QueryResult{
+								ResultType: "vector",
+								Result: []v1alpha2.QueryValue{
+									{
+										Metric: map[string]string{"resource_name": "node1"},
+										Value:  []interface{}{1578987135.334, "0.221"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node3"},
+										Value:  []interface{}{1578987135.334, "0.194"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node2"},
+										Value:  []interface{}{1578987135.334, "0.177"},
+									},
+								},
+							},
+						},
+					},
+					{
+						MetricName: "node_memory_total",
+						APIResponse: v1alpha2.APIResponse{
+							Status: "success",
+							Data: v1alpha2.QueryResult{
+								ResultType: "vector",
+								Result: []v1alpha2.QueryValue{
+									{
+										Metric: map[string]string{"resource_name": "node1"},
+										Value:  []interface{}{1578987135.334, "8201043968"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node3"},
+										Value:  []interface{}{1578987135.334, "8201056256"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node2"},
+										Value:  []interface{}{1578987135.334, "8201039872"},
+									},
+								},
+							},
+						},
+					},
+					{
+						MetricName: "node_pod_running_count",
+						APIResponse: v1alpha2.APIResponse{
+							Status: "success",
+							Data: v1alpha2.QueryResult{
+								ResultType: "vector",
+								Result: []v1alpha2.QueryValue{
+									{
+										Metric: map[string]string{"resource_name": "node1"},
+										Value:  []interface{}{1578987135.334, "19"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node3"},
+										Value:  []interface{}{1578987135.334, "14"},
+									},
+									{
+										Metric: map[string]string{"resource_name": "node2"},
+										Value:  []interface{}{1578987135.334, "6"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		res, _ := test.rawMetrics.SortBy(test.sortMetrics, test.sortType)
+		if !reflect.DeepEqual(res, test.expected) {
+			t.Errorf("got unexpected results: %v", res)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1464

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
