### PR TITLE
Add API for setting default storage class (#1757)

### DIFF
--- a/pkg/apis/resources/v1alpha2/register.go
+++ b/pkg/apis/resources/v1alpha2/register.go
@@ -22,6 +22,7 @@ import (
 	"github.com/emicklei/go-restful-openapi"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"kubesphere.io/kubesphere/pkg/apiserver/components"
 	"kubesphere.io/kubesphere/pkg/apiserver/git"
@@ -257,7 +258,14 @@ func addWebService(c *restful.Container) error {
 		Returns(http.StatusOK, ok, status.WorkLoadStatus{}).
 		To(workloadstatuses.GetNamespacedAbnormalWorkloads))
 
-	c.Add(webservice)
+	webservice.Route(webservice.PATCH("/storageclasses/{storageclass}").
+		To(resources.PatchStorageClass).
+		Doc("patch storage class").
+		Metadata(restfulspec.KeyOpenAPITags, []string{constants.ClusterResourcesTag}).
+		Returns(http.StatusOK, ok, storagev1.StorageClass{}).
+		Writes(storagev1.StorageClass{}).
+		Param(webservice.PathParameter("storageclass", "the name of storage class")))
 
+	c.Add(webservice)
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Xin Wang <wileywang@yunify.com>
(cherry picked from commit 66850ee3ee6ca3ae5fcb3db9e2fecffdcbfab657)

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1656 

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Usage:
PATCH /kapis/resources.kubesphere.io/v1alpha2/storageclasses/{storageclassname}
Body {"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}
If succeed, return code 200 and return default storage class definition.
```
