### PR TITLE
fix doc-gen conflict

### DIFF
--- a/pkg/models/metrics/metrics_rules.go
+++ b/pkg/models/metrics/metrics_rules.go
@@ -520,9 +520,13 @@ var metricsPromqlMap = map[string]string{
 // As of Kubernetes v1.16, any Prometheus queries that match `pod_name` and
 // `container_name` labels must be updated to use `pod` and `container` instead.
 func CompatibleMetrics() {
+	if client.ClientSets() == nil {
+		return
+	}
+
 	version, err := client.ClientSets().K8s().Discovery().ServerVersion()
 	if err != nil {
-		klog.Errorf("fail to fetch k8s version: %v", err)
+		klog.Errorf("fail to fetch k8s version: %v.", err)
 		return
 	}
 


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
