### PR TITLE
fix nil pointer reference when creating image

### DIFF
--- a/cmd/ks-apiserver/app/server.go
+++ b/cmd/ks-apiserver/app/server.go
@@ -29,6 +29,7 @@ import (
 	"kubesphere.io/kubesphere/pkg/apiserver/runtime"
 	"kubesphere.io/kubesphere/pkg/apiserver/servicemesh/tracing"
 	"kubesphere.io/kubesphere/pkg/informers"
+	"kubesphere.io/kubesphere/pkg/models/metrics"
 	"kubesphere.io/kubesphere/pkg/server"
 	apiserverconfig "kubesphere.io/kubesphere/pkg/server/config"
 	"kubesphere.io/kubesphere/pkg/server/filter"
@@ -135,6 +136,7 @@ func CreateAPIServer(s *options.ServerRunOptions) error {
 	container.RecoverHandler(server.LogStackOnRecover)
 
 	apis.InstallAPIs(container)
+	metrics.CompatibleMetrics()
 
 	// install config api
 	apiserverconfig.InstallAPI(container)

--- a/pkg/apis/monitoring/v1alpha2/register.go
+++ b/pkg/apis/monitoring/v1alpha2/register.go
@@ -405,8 +405,5 @@ func addWebService(c *restful.Container) error {
 		Produces(restful.MIME_JSON)
 
 	c.Add(ws)
-
-	metrics.CompatibleMetrics()
-
 	return nil
 }


### PR DESCRIPTION
`metrics.CompatibleMetrics()` 调用的位置不对，导致创建镜像生成二进制文件时，调用栈里使用了未经初始化的sharedclientset变量