### PR TITLE
fix: workspaces-manager cannot be overwrite

### DIFF
--- a/pkg/models/iam/am.go
+++ b/pkg/models/iam/am.go
@@ -489,23 +489,21 @@ func GetUserWorkspaceSimpleRules(workspace, username string) ([]models.SimpleRul
 		return GetWorkspaceRoleSimpleRules(workspace, constants.WorkspaceAdmin), nil
 	}
 
+	// workspaces-manager
+	if RulesMatchesRequired(clusterRules, rbacv1.PolicyRule{
+		Verbs:     []string{"*"},
+		APIGroups: []string{"*"},
+		Resources: []string{"workspaces", "workspaces/*"},
+	}) {
+		return GetWorkspaceRoleSimpleRules(workspace, constants.WorkspacesManager), nil
+	}
+
 	workspaceRole, err := GetUserWorkspaceRole(workspace, username)
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-
-			// workspaces-manager
-			if RulesMatchesRequired(clusterRules, rbacv1.PolicyRule{
-				Verbs:     []string{"*"},
-				APIGroups: []string{"*"},
-				Resources: []string{"workspaces", "workspaces/*"},
-			}) {
-				return GetWorkspaceRoleSimpleRules(workspace, constants.WorkspacesManager), nil
-			}
-
 			return []models.SimpleRule{}, nil
 		}
-
 		klog.Error(err)
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

workspaces-manager is a special cluster role that cannot be overwrite in workspace.
 
**Which issue(s) this PR fixes**:

Fixes #1844