### PR TITLE
update namespace metrics

### DIFF
--- a/pkg/models/metrics/metrics_rules.go
+++ b/pkg/models/metrics/metrics_rules.go
@@ -303,7 +303,7 @@ var metricsPromqlMap = map[string]string{
 	"cluster_disk_inode_total":           `sum(node:node_inodes_total:)`,
 	"cluster_disk_inode_usage":           `sum(node:node_inodes_total:) - sum(node:node_inodes_free:)`,
 	"cluster_disk_inode_utilisation":     `cluster:disk_inode_utilization:ratio`,
-	"cluster_namespace_count":            `count(kube_namespace_annotations)`,
+	"cluster_namespace_count":            `count(kube_namespace_created)`,
 	"cluster_pod_count":                  `cluster:pod:sum`,
 	"cluster_pod_quota":                  `sum(max(kube_node_status_capacity_pods) by (node) unless on (node) (kube_node_status_condition{condition="Ready",status=~"unknown|false"} > 0))`,
 	"cluster_pod_utilisation":            `cluster:pod_utilization:ratio`,


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
As of kube-state-metrics 1.7.2, kube_namespace_annotations has been removed
https://github.com/kubernetes/kube-state-metrics/blob/957e2b82e42ec367efe5a25f253f5e967c133704/CHANGELOG.md#v172--2019-08-05

kube_namespace_created (Gauge) is a good alternative.

![image](https://user-images.githubusercontent.com/22350668/74331133-032b6a00-4dce-11ea-8c2c-a552517a90f7.png)

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
