### PR TITLE
default reverse false & b before a

### DIFF
--- a/pkg/apiserver/iam/am.go
+++ b/pkg/apiserver/iam/am.go
@@ -76,7 +76,7 @@ func ListRoles(req *restful.Request, resp *restful.Response) {
 	namespace := req.PathParameter("namespace")
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, resources.CreateTime)
 	limit, offset := params.ParsePaging(req)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 	conditions, err := params.ParseConditions(req)
 
 	if err != nil {

--- a/pkg/apiserver/iam/im.go
+++ b/pkg/apiserver/iam/im.go
@@ -298,7 +298,7 @@ func ListUsers(req *restful.Request, resp *restful.Response) {
 	limit, offset := params.ParsePaging(req)
 	conditions, err := params.ParseConditions(req)
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, resources.CreateTime)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 
 	if err != nil {
 		klog.Info(err)

--- a/pkg/apiserver/resources/resources.go
+++ b/pkg/apiserver/resources/resources.go
@@ -35,7 +35,7 @@ func ListResources(req *restful.Request, resp *restful.Response) {
 	resourceName := req.PathParameter("resources")
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, resources.CreateTime)
 	limit, offset := params.ParsePaging(req)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 	conditions, err := params.ParseConditions(req)
 
 	if err != nil {

--- a/pkg/apiserver/tenant/tenant.go
+++ b/pkg/apiserver/tenant/tenant.go
@@ -60,7 +60,7 @@ func ListWorkspaces(req *restful.Request, resp *restful.Response) {
 	username := req.HeaderParameter(constants.UserNameHeader)
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, resources.CreateTime)
 	limit, offset := params.ParsePaging(req)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 	conditions, err := params.ParseConditions(req)
 
 	if err != nil {
@@ -112,7 +112,7 @@ func ListNamespaces(req *restful.Request, resp *restful.Response) {
 	conditions, err := params.ParseConditions(req)
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, resources.CreateTime)
 	limit, offset := params.ParsePaging(req)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 
 	if err != nil {
 		resp.WriteHeaderAndEntity(http.StatusBadRequest, errors.Wrap(err))

--- a/pkg/models/iam/im.go
+++ b/pkg/models/iam/im.go
@@ -623,7 +623,7 @@ func ListUsers(conditions *params.Conditions, orderBy string, reverse bool, limi
 		case "createTime":
 			fallthrough
 		default:
-			return users[i].CreateTime.Before(users[j].CreateTime)
+			return users[j].CreateTime.Before(users[i].CreateTime)
 		}
 	})
 

--- a/pkg/models/resources/resources.go
+++ b/pkg/models/resources/resources.go
@@ -250,7 +250,7 @@ func compare(a, b metav1.ObjectMeta, by string) bool {
 		if a.CreationTimestamp.Equal(&b.CreationTimestamp) {
 			return strings.Compare(a.Name, b.Name) <= 0
 		}
-		return a.CreationTimestamp.Time.Before(b.CreationTimestamp.Time)
+		return b.CreationTimestamp.Time.Before(a.CreationTimestamp.Time)
 	case Name:
 		fallthrough
 	default:

--- a/pkg/models/tenant/namespaces.go
+++ b/pkg/models/tenant/namespaces.go
@@ -77,7 +77,7 @@ func (*namespaceSearcher) fuzzy(fuzzy map[string]string, item *v1.Namespace) boo
 func (*namespaceSearcher) compare(a, b *v1.Namespace, orderBy string) bool {
 	switch orderBy {
 	case "createTime":
-		return a.CreationTimestamp.Time.Before(b.CreationTimestamp.Time)
+		return b.CreationTimestamp.Time.Before(a.CreationTimestamp.Time)
 	case "name":
 		fallthrough
 	default:

--- a/pkg/models/tenant/workspaces.go
+++ b/pkg/models/tenant/workspaces.go
@@ -76,7 +76,7 @@ func (*workspaceSearcher) fuzzy(fuzzy map[string]string, item *v1alpha1.Workspac
 func (*workspaceSearcher) compare(a, b *v1alpha1.Workspace, orderBy string) bool {
 	switch orderBy {
 	case resources.CreateTime:
-		return a.CreationTimestamp.Time.Before(b.CreationTimestamp.Time)
+		return b.CreationTimestamp.Time.Before(a.CreationTimestamp.Time)
 	case resources.Name:
 		fallthrough
 	default:


### PR DESCRIPTION
Signed-off-by: runzexia <runzexia@yunify.com>

/kind bug
/area api
/milestone 2.1.1
/cc @zryfish @wansir 

The reverse parameter is not passed in by default. When reverse is needed, the front end passes reverse = true.
So the backend should not let reverse default to true.  Change the default sorting method to make newer elements come first.
