### PR TITLE
fix: default reverse param always false

### DIFF
--- a/pkg/apiserver/iam/am.go
+++ b/pkg/apiserver/iam/am.go
@@ -76,7 +76,7 @@ func ListRoles(req *restful.Request, resp *restful.Response) {
 	namespace := req.PathParameter("namespace")
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, resources.CreateTime)
 	limit, offset := params.ParsePaging(req)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 	conditions, err := params.ParseConditions(req)
 
 	if err != nil {

--- a/pkg/apiserver/iam/im.go
+++ b/pkg/apiserver/iam/im.go
@@ -291,7 +291,7 @@ func ListUsers(req *restful.Request, resp *restful.Response) {
 	limit, offset := params.ParsePaging(req)
 	conditions, err := params.ParseConditions(req)
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, resources.CreateTime)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 
 	if err != nil {
 		klog.Info(err)

--- a/pkg/apiserver/openpitrix/applications.go
+++ b/pkg/apiserver/openpitrix/applications.go
@@ -40,7 +40,7 @@ func ListApplications(req *restful.Request, resp *restful.Response) {
 	namespaceName := req.PathParameter("namespace")
 	conditions, err := params.ParseConditions(req)
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, openpitrix.CreateTime)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 
 	if err != nil {
 		resp.WriteHeaderAndEntity(http.StatusBadRequest, errors.Wrap(err))

--- a/pkg/apiserver/openpitrix/apps.go
+++ b/pkg/apiserver/openpitrix/apps.go
@@ -145,7 +145,7 @@ func GetAppVersionFiles(req *restful.Request, resp *restful.Response) {
 func ListAppVersionAudits(req *restful.Request, resp *restful.Response) {
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, openpitrix.StatusTime)
 	limit, offset := params.ParsePaging(req)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 	appId := req.PathParameter("app")
 	versionId := req.PathParameter("version")
 	conditions, err := params.ParseConditions(req)
@@ -177,7 +177,7 @@ func ListAppVersionAudits(req *restful.Request, resp *restful.Response) {
 func ListReviews(req *restful.Request, resp *restful.Response) {
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, openpitrix.StatusTime)
 	limit, offset := params.ParsePaging(req)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 	conditions, err := params.ParseConditions(req)
 
 	if err != nil {
@@ -204,7 +204,7 @@ func ListReviews(req *restful.Request, resp *restful.Response) {
 func ListAppVersions(req *restful.Request, resp *restful.Response) {
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, openpitrix.CreateTime)
 	limit, offset := params.ParsePaging(req)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 	appId := req.PathParameter("app")
 	statistics := params.GetBoolValueWithDefault(req, "statistics", false)
 	conditions, err := params.ParseConditions(req)
@@ -247,7 +247,7 @@ func ListAppVersions(req *restful.Request, resp *restful.Response) {
 func ListApps(req *restful.Request, resp *restful.Response) {
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, openpitrix.CreateTime)
 	limit, offset := params.ParsePaging(req)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 	statistics, _ := strconv.ParseBool(req.QueryParameter("statistics"))
 	conditions, err := params.ParseConditions(req)
 

--- a/pkg/apiserver/openpitrix/categories.go
+++ b/pkg/apiserver/openpitrix/categories.go
@@ -126,7 +126,7 @@ func DescribeCategory(req *restful.Request, resp *restful.Response) {
 func ListCategories(req *restful.Request, resp *restful.Response) {
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, openpitrix.CreateTime)
 	limit, offset := params.ParsePaging(req)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 	statistics := params.GetBoolValueWithDefault(req, "statistics", false)
 	conditions, err := params.ParseConditions(req)
 

--- a/pkg/apiserver/openpitrix/repos.go
+++ b/pkg/apiserver/openpitrix/repos.go
@@ -167,7 +167,7 @@ func DescribeRepo(req *restful.Request, resp *restful.Response) {
 func ListRepos(req *restful.Request, resp *restful.Response) {
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, openpitrix.CreateTime)
 	limit, offset := params.ParsePaging(req)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 	conditions, err := params.ParseConditions(req)
 
 	if err != nil {

--- a/pkg/apiserver/resources/resources.go
+++ b/pkg/apiserver/resources/resources.go
@@ -35,7 +35,7 @@ func ListResources(req *restful.Request, resp *restful.Response) {
 	resourceName := req.PathParameter("resources")
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, resources.CreateTime)
 	limit, offset := params.ParsePaging(req)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 	conditions, err := params.ParseConditions(req)
 
 	if err != nil {

--- a/pkg/apiserver/tenant/tenant.go
+++ b/pkg/apiserver/tenant/tenant.go
@@ -60,7 +60,7 @@ func ListWorkspaces(req *restful.Request, resp *restful.Response) {
 	username := req.HeaderParameter(constants.UserNameHeader)
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, resources.CreateTime)
 	limit, offset := params.ParsePaging(req)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 	conditions, err := params.ParseConditions(req)
 
 	if err != nil {
@@ -112,7 +112,7 @@ func ListNamespaces(req *restful.Request, resp *restful.Response) {
 	conditions, err := params.ParseConditions(req)
 	orderBy := params.GetStringValueWithDefault(req, params.OrderByParam, resources.CreateTime)
 	limit, offset := params.ParsePaging(req)
-	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, true)
+	reverse := params.GetBoolValueWithDefault(req, params.ReverseParam, false)
 
 	if err != nil {
 		resp.WriteHeaderAndEntity(http.StatusBadRequest, errors.Wrap(err))


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Change the misleading default value. When descending order is required, you must explicitly specify the parameter reverse = true.