### PR TITLE
fix: devops project sorted in ascending order by default

### DIFF
--- a/pkg/models/tenant/devops.go
+++ b/pkg/models/tenant/devops.go
@@ -86,9 +86,9 @@ func ListDevopsProjects(workspace, username string, conditions *params.Condition
 		}
 	default:
 		if reverse {
-			query.OrderAsc(devops.DevOpsProjectCreateTimeColumn)
-		} else {
 			query.OrderDesc(devops.DevOpsProjectCreateTimeColumn)
+		} else {
+			query.OrderAsc(devops.DevOpsProjectCreateTimeColumn)
 		}
 
 	}


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

devops project sorted in ascending order by default
