### PR TITLE
fix websocket bug

### DIFF
--- a/pkg/models/tenant/tenent_test.go
+++ b/pkg/models/tenant/tenent_test.go
@@ -290,7 +290,7 @@ func prepare() Interface {
 	k8sClient := fakek8s.NewSimpleClientset()
 	istioClient := fakeistio.NewSimpleClientset()
 	appClient := fakeapp.NewSimpleClientset()
-	fakeInformerFactory := informers.NewInformerFactories(k8sClient, ksClient, istioClient, appClient)
+	fakeInformerFactory := informers.NewInformerFactories(k8sClient, ksClient, istioClient, appClient, nil, nil)
 
 	for _, workspace := range workspaces {
 		fakeInformerFactory.KubeSphereSharedInformerFactory().Tenant().V1alpha1().


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
websocket is only supported when using http1, so we need to disable http2 when using WebSocket. This PR disable http2 when proxy requests to kube-apiserver, we can revert these changes when upgraded to k8s v1.18 which already include a similar commit in module https://github.com/kubernetes/kubernetes/pull/88781

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
