### PR TITLE
fix namespace networkpolicy

### DIFF
--- a/pkg/controller/network/nsnetworkpolicy/nsnetworkpolicy_test.go
+++ b/pkg/controller/network/nsnetworkpolicy/nsnetworkpolicy_test.go
@@ -48,14 +48,8 @@ spec:
         - namespaceSelector:
             matchLabels:
               %s: %s
-  Egress:
-    - To:
-        - namespaceSelector:
-            matchLabels:
-              %s: %s
   policyTypes:
-    - Ingress
-    - Egress`
+    - Ingress`
 
 	serviceTmp = `
 apiVersion: v1
@@ -141,7 +135,7 @@ var _ = Describe("Nsnetworkpolicy", func() {
 	})
 
 	It("Should create ns networkisolate np correctly in workspace", func() {
-		objSrt := fmt.Sprintf(workspaceNP, "testns", constants.WorkspaceLabelKey, "testworkspace", constants.WorkspaceLabelKey, "testworkspace")
+		objSrt := fmt.Sprintf(workspaceNP, "testns", constants.WorkspaceLabelKey, "testworkspace")
 		obj := &netv1.NetworkPolicy{}
 		Expect(StringToObject(objSrt, obj)).ShouldNot(HaveOccurred())
 
@@ -150,7 +144,7 @@ var _ = Describe("Nsnetworkpolicy", func() {
 	})
 
 	It("Should create ns networkisolate np correctly in ns", func() {
-		objSrt := fmt.Sprintf(workspaceNP, "testns", constants.NamespaceLabelKey, "testns", constants.NamespaceLabelKey, "testns")
+		objSrt := fmt.Sprintf(workspaceNP, "testns", constants.NamespaceLabelKey, "testns")
 		obj := &netv1.NetworkPolicy{}
 		Expect(StringToObject(objSrt, obj)).ShouldNot(HaveOccurred())
 

--- a/pkg/controller/network/provider/ns_k8s.go
+++ b/pkg/controller/network/provider/ns_k8s.go
@@ -19,10 +19,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
+	"kubesphere.io/kubesphere/pkg/controller/network"
 )
 
 const (
-	defaultSyncTime = 5 * time.Minute
+	defaultSyncTime = 1 * time.Minute
 )
 
 func (c *k8sPolicyController) GetKey(name, nsname string) string {
@@ -231,9 +232,11 @@ func NewNsNetworkPolicyProvider(client kubernetes.Interface, npInformer informer
 		// Filter in only objects that are written by policy controller.
 		m := make(map[string]interface{})
 		for _, policy := range policies {
-			policy.ObjectMeta = metav1.ObjectMeta{Name: policy.Name, Namespace: policy.Namespace}
-			k := c.GetKey(policy.Name, policy.Namespace)
-			m[k] = *policy
+			if strings.HasPrefix(policy.Name, network.NSNPPrefix) {
+				policy.ObjectMeta = metav1.ObjectMeta{Name: policy.Name, Namespace: policy.Namespace}
+				k := c.GetKey(policy.Name, policy.Namespace)
+				m[k] = *policy
+			}
 		}
 
 		klog.Infof("Found %d policies in k8s datastore:", len(m))

--- a/pkg/controller/network/types.go
+++ b/pkg/controller/network/types.go
@@ -1,0 +1,5 @@
+package network
+
+const (
+	NSNPPrefix = "nsnp-"
+)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
When network isolate is enabled, the engress should be allowed default.
To distinguish it from the native network policy, the prefix "nsnp-" was added.
Remove some useless log,  reduce useless log output,  easy to view.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
