### PR TITLE
remove specific version of generic proxy server

### DIFF
--- a/pkg/kapis/alerting/v1/register.go
+++ b/pkg/kapis/alerting/v1/register.go
@@ -6,7 +6,8 @@ import (
 	"kubesphere.io/kubesphere/pkg/kapis/generic"
 )
 
-var GroupVersion = schema.GroupVersion{Group: "alerting.kubesphere.io", Version: "v1"}
+// there are no versions specified cause we want to proxy all versions of requests to backend service
+var GroupVersion = schema.GroupVersion{Group: "alerting.kubesphere.io", Version: ""}
 
 func AddToContainer(container *restful.Container, endpoint string) error {
 	proxy, err := generic.NewGenericProxy(endpoint, GroupVersion.Group, GroupVersion.Version)

--- a/pkg/kapis/notification/v1/register.go
+++ b/pkg/kapis/notification/v1/register.go
@@ -6,7 +6,8 @@ import (
 	"kubesphere.io/kubesphere/pkg/kapis/generic"
 )
 
-var GroupVersion = schema.GroupVersion{Group: "notification.kubesphere.io", Version: "v1"}
+// there are no versions specified cause we want to proxy all versions of requests to backend service
+var GroupVersion = schema.GroupVersion{Group: "notification.kubesphere.io", Version: ""}
 
 func AddToContainer(container *restful.Container, endpoint string) error {
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Remove notification and alerting API versions when using generic proxy to proxy all versions of APIs to backend service.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
