### PR TITLE
fix SecretRef nil

### DIFF
--- a/pkg/kapis/resources/v1alpha2/handler.go
+++ b/pkg/kapis/resources/v1alpha2/handler.go
@@ -274,8 +274,12 @@ func (r *resourceHandler) handleVerifyGitCredential(request *restful.Request, re
 		api.HandleBadRequest(response, nil, err)
 		return
 	}
-
-	err = r.gitVerifier.VerifyGitCredential(credential.RemoteUrl, credential.SecretRef.Namespace, credential.SecretRef.Name)
+	var namespace, secretName string
+	if credential.SecretRef != nil {
+		namespace = credential.SecretRef.Namespace
+		secretName = credential.SecretRef.Name
+	}
+	err = r.gitVerifier.VerifyGitCredential(credential.RemoteUrl, namespace, secretName)
 	if err != nil {
 		api.HandleBadRequest(response, nil, err)
 		return


### PR DESCRIPTION
Signed-off-by: shaowenchen <mail@chenshaowen.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

when the parameter is {“remoteUrl”:“https://github.com/xxx.git”}，credential.SecretRef is nil .
This pr fixs this situation.