### PR TITLE
fix: support redirect proxy authorization

### DIFF
--- a/pkg/apiserver/dispatch/dispatch.go
+++ b/pkg/apiserver/dispatch/dispatch.go
@@ -88,7 +88,7 @@ func (c *clusterDispatch) Dispatch(w http.ResponseWriter, req *http.Request, han
 	u.Host = endpoint.Host
 	u.Path = strings.Replace(u.Path, fmt.Sprintf("/clusters/%s", info.Cluster), "", 1)
 
-	httpProxy := proxy.NewUpgradeAwareHandler(&u, http.DefaultTransport, true, false, c)
+	httpProxy := proxy.NewUpgradeAwareHandler(&u, http.DefaultTransport, false, false, c)
 	httpProxy.ServeHTTP(w, req)
 }
 


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Support redirect proxy authorization.

for example:

The cluster scope resource request(`/kapis/clusters/{cluster}/ openpitrix.io/v1/namespaces/{namespace}/applications`) need to authenticate through ks-apiserver in member cluster and then handle the request(`/kapis/ openpitrix.io/v1/namespaces/{namespace}/applications`) in host cluster, need to authenticate before redirection.

This PR fixes the wrong redirect path.