### PR TITLE
fix authorization header stripped by kube-apiserver

### DIFF
--- a/pkg/apiserver/dispatch/dispatch_test.go
+++ b/pkg/apiserver/dispatch/dispatch_test.go
@@ -1,0 +1,1 @@
+package dispatch

--- a/pkg/apiserver/filters/requestinfo.go
+++ b/pkg/apiserver/filters/requestinfo.go
@@ -32,6 +32,19 @@ func WithRequestInfo(handler http.Handler, resolver request.RequestInfoResolver)
 			return
 		}
 
+		// KubeSphere supports kube-apiserver proxy requests in multicluster mode. But kube-apiserver
+		// stripped all authorization headers. Use custom header to carry token to avoid losing authentication token.
+		// We may need a better way. See issue below.
+		// https://github.com/kubernetes/kubernetes/issues/38775#issuecomment-277915961
+		authorization := req.Header.Get("Authorization")
+		if len(authorization) == 0 {
+			xAuthorization := req.Header.Get("X-KubeSphere-Authorization")
+			if len(xAuthorization) != 0 {
+				req.Header.Set("Authorization", xAuthorization)
+				req.Header.Del("X-KubeSphere-Authorization")
+			}
+		}
+
 		req = req.WithContext(request.WithRequestInfo(ctx, info))
 		handler.ServeHTTP(w, req)
 	})


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Kube-apiserver will strip authorization header when proxy requests to service, this pr keeps original authorization token using a custom header.

https://github.com/kubernetes/kubernetes/issues/38775

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
