### PR TITLE
Fix one go.mod Errors caused by the loss of older versions in

### DIFF
--- a/hack/pin-dependency.sh
+++ b/hack/pin-dependency.sh
@@ -48,7 +48,16 @@ mkdir -p "${_tmp}"
 
 # Add the require directive
 echo "Running: go get ${dep}@${sha}"
+
+cp "$KUBE_ROOT/go.mod" "${_tmp}/go.mod.bak"
+sed -i "/`echo ${dep} | sed 's#/#\\\\\/#g'`/d" $KUBE_ROOT/go.mod
+returnbak() {
+  rm -f "$KUBE_ROOT/go.mod"
+  cp "${_tmp}/go.mod.bak" "$KUBE_ROOT/go.mod"
+}
+trap 'returnbak;kube::log::errexit' ERR
 go get -d "${dep}@${sha}"
+trap 'kube::log::errexit' ERR
 
 # Find the resolved version
 rev=$(go mod edit -json | jq -r ".Require[] | select(.Path == \"${dep}\") | .Version")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When I build the source code of V2.1.1 ，an error occurred：

```
$ make test
which: no controller-gen in (***)
go generate ./pkg/... ./cmd/...
go: github.com/openshift/api@v3.9.0+incompatible: reading github.com/openshift/api/go.mod at revision v3.9.0: unknown revision v3.9.0
make: *** [Makefile:83：generate] 错误 1
```

It's because github.com/openshift/api V3.9.0 has been deleted.

For the same reason, I cant run this command :

```
bash hack/pin-dependency.sh github.com/openshift/api fb2a6ca106ae74e2c3ec795d887bc36675654614
Running: go get github.com/openshift/api@fb2a6ca106ae74e2c3ec795d887bc36675654614
go: github.com/openshift/api@v3.9.0+incompatible: reading github.com/openshift/api/go.mod at revision v3.9.0: unknown revision v3.9.0
!!! Error in hack/pin-dependency.sh:51
  Error in hack/pin-dependency.sh:51. 'go get -d "${dep}@${sha}"' exited with status 1
Call stack:
  1: hack/pin-dependency.sh:51 main(...)
Exiting with status 1
```

**Which issue(s) this PR fixes**:

So, I run the command `sed` first to delete the wrong part of go.mod (with backup, of course), and then run the cmd `go get -d`.

Because go.mod is been modified, so I need to make sure that when `go get -d` goes wrong go.mod Can be recovered.

```
trap 'returnbak;kube::log::errexit' ERR
go get -d "${dep}@${sha}"
trap 'kube::log::errexit' ERR
```

**Special notes for reviewers**:

```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
