### PR TITLE
fix namespace controller crash when openpitrix is not enabled

### DIFF
--- a/pkg/simple/client/openpitrix/openpitrix.go
+++ b/pkg/simple/client/openpitrix/openpitrix.go
@@ -186,6 +186,10 @@ func newAppManagerClient(endpoint string) (pb.AppManagerClient, error) {
 
 // will return a nil client and nil error if endpoint is empty
 func NewClient(options *Options) (Client, error) {
+	if options.IsEmpty() {
+		return nil, nil
+	}
+
 	runtimeMangerClient, err := newRuntimeManagerClient(options.RuntimeManagerEndpoint)
 	if err != nil {
 		klog.Error(err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix namespace controller crashes when openpitrix is not enabled

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
