### PR TITLE
fix cluster status unchanged when cluster agent is already unavailable

### DIFF
--- a/pkg/controller/application/application_controller.go
+++ b/pkg/controller/application/application_controller.go
@@ -205,6 +205,9 @@ func (v *ApplicationController) syncApplication(key string) error {
 	}
 
 	annotations := application.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
 	annotations["kubesphere.io/last-updated"] = time.Now().String()
 	application.SetAnnotations(annotations)
 

--- a/pkg/controller/cluster/cluster_controller.go
+++ b/pkg/controller/cluster/cluster_controller.go
@@ -518,7 +518,8 @@ func (c *clusterController) syncCluster(key string) error {
 		c.updateClusterCondition(cluster, clusterReadyCondition)
 	}
 
-	if !isConditionTrue(cluster, clusterv1alpha1.ClusterAgentAvailable) {
+	if cluster.Spec.Connection.Type == clusterv1alpha1.ConnectionTypeProxy &&
+		!isConditionTrue(cluster, clusterv1alpha1.ClusterAgentAvailable) {
 		clusterNotReadyCondition := clusterv1alpha1.ClusterCondition{
 			Type:               clusterv1alpha1.ClusterReady,
 			Status:             v1.ConditionFalse,


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
1. Fix cluster status bug, cluster status changed to not ready when cluster agent is not available, 
this should only applied to cluster using proxy connection
2. Fix nil pointer exception when set application annotations

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
