### PR TITLE
Bugfix: UpsertRuntime create wrong runtime_id

### DIFF
--- a/pkg/simple/client/openpitrix/openpitrix.go
+++ b/pkg/simple/client/openpitrix/openpitrix.go
@@ -71,7 +71,7 @@ func (c *client) UpsertRuntime(cluster string, kubeConfig string) error {
 	ctx := SystemContext()
 	req := &pb.CreateRuntimeCredentialRequest{
 		Name:                     &wrappers.StringValue{Value: fmt.Sprintf("kubeconfig-%s", cluster)},
-		Provider:                 &wrappers.StringValue{Value: "kubernetes"},
+		Provider:                 &wrappers.StringValue{Value: KubernetesProvider},
 		Description:              &wrappers.StringValue{Value: "kubeconfig"},
 		RuntimeUrl:               &wrappers.StringValue{Value: "kubesphere"},
 		RuntimeCredentialContent: &wrappers.StringValue{Value: kubeConfig},
@@ -86,6 +86,7 @@ func (c *client) UpsertRuntime(cluster string, kubeConfig string) error {
 		RuntimeCredentialId: &wrappers.StringValue{Value: cluster},
 		Provider:            &wrappers.StringValue{Value: KubernetesProvider},
 		Zone:                &wrappers.StringValue{Value: cluster},
+		RuntimeId:           &wrappers.StringValue{Value: cluster},
 	})
 
 	return err


### PR DESCRIPTION
Signed-off-by: Zhengyi Lai <zheng1@yunify.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
UpsertRuntime create wrong runtime_id

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
