### PR TITLE
fix the bug "Cannot read property 'get' of undefined"

### DIFF
--- a/pkg/apiserver/auditing/types_test.go
+++ b/pkg/apiserver/auditing/types_test.go
@@ -16,6 +16,7 @@ import (
 	ksinformers "kubesphere.io/kubesphere/pkg/client/informers/externalversions"
 	"kubesphere.io/kubesphere/pkg/utils/iputil"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
@@ -248,7 +249,7 @@ func TestAuditing_LogResponseObject(t *testing.T) {
 
 	e := a.LogRequestObject(req, info)
 
-	resp := &ResponseCapture{}
+	resp := NewResponseCapture(httptest.NewRecorder())
 	resp.WriteHeader(200)
 
 	a.LogResponseObject(e, resp, info)

--- a/pkg/apiserver/auditing/types_test.go
+++ b/pkg/apiserver/auditing/types_test.go
@@ -296,3 +296,29 @@ func TestAuditing_LogResponseObject(t *testing.T) {
 
 	assert.EqualValues(t, string(expectedBs), string(bs))
 }
+
+func TestResponseCapture_WriteHeader(t *testing.T) {
+	record := httptest.NewRecorder()
+	resp := NewResponseCapture(record)
+
+	resp.WriteHeader(404)
+
+	assert.EqualValues(t, 404, resp.StatusCode())
+	assert.EqualValues(t, 404, record.Code)
+}
+
+func TestResponseCapture_Write(t *testing.T) {
+
+	record := httptest.NewRecorder()
+	resp := NewResponseCapture(record)
+
+	body := []byte("123")
+
+	_, err := resp.Write(body)
+	if err != nil {
+		panic(err)
+	}
+
+	assert.EqualValues(t, body, resp.Bytes())
+	assert.EqualValues(t, body, record.Body.Bytes())
+}


### PR DESCRIPTION
Signed-off-by: wanjunlei wanjunlei@yunify.com

What type of PR is this?
> /kind bug


What this PR does / why we need it:
This bug causesed by the auditing components dose not passed the response code to the next handler, all response code was set to 200. To fix this bug, pass the response code to the next handler by call function WriteHeader.