### PR TITLE
fix: label filter logic

### DIFF
--- a/pkg/models/resources/v1alpha3/interface.go
+++ b/pkg/models/resources/v1alpha3/interface.go
@@ -144,21 +144,19 @@ func labelMatch(labels map[string]string, filter string) bool {
 		}
 		value = fields[1]
 	} else {
-		value = fields[0]
+		key = fields[0]
+		value = "*"
 	}
 	for k, v := range labels {
 		if opposite {
-			if (key == "" || k == key) && v != value {
+			if (k == key) && v != value {
 				return true
 			}
 		} else {
-			if (key == "" || k == key) && v == value {
+			if (k == key) && (value == "*" || v == value) {
 				return true
 			}
 		}
-	}
-	if opposite && labels[key] == "" {
-		return true
 	}
 	return false
 }

--- a/pkg/models/resources/v1alpha3/interface_test.go
+++ b/pkg/models/resources/v1alpha3/interface_test.go
@@ -1,0 +1,85 @@
+/*
+
+ Copyright 2020 The KubeSphere Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
+
+package v1alpha3
+
+import "testing"
+
+func TestLabelMatch(t *testing.T) {
+	tests := []struct {
+		labels       map[string]string
+		filter       string
+		expectResult bool
+	}{
+		{
+			labels: map[string]string{
+				"kubesphere.io/workspace": "kubesphere-system",
+			},
+			filter:       "kubesphere.io/workspace",
+			expectResult: true,
+		},
+		{
+			labels: map[string]string{
+				"kubesphere.io/creator": "system",
+			},
+			filter:       "kubesphere.io/workspace",
+			expectResult: false,
+		},
+		{
+			labels: map[string]string{
+				"kubesphere.io/workspace": "kubesphere-system",
+			},
+			filter:       "kubesphere.io/workspace=",
+			expectResult: false,
+		},
+		{
+			labels: map[string]string{
+				"kubesphere.io/workspace": "kubesphere-system",
+			},
+			filter:       "kubesphere.io/workspace!=",
+			expectResult: true,
+		},
+		{
+			labels: map[string]string{
+				"kubesphere.io/workspace": "kubesphere-system",
+			},
+			filter:       "kubesphere.io/workspace!=kubesphere-system",
+			expectResult: false,
+		},
+		{
+			labels: map[string]string{
+				"kubesphere.io/workspace": "kubesphere-system",
+			},
+			filter:       "kubesphere.io/workspace=kubesphere-system",
+			expectResult: true,
+		},
+		{
+			labels: map[string]string{
+				"kubesphere.io/workspace": "kubesphere-system",
+			},
+			filter:       "kubesphere.io/workspace=system",
+			expectResult: false,
+		},
+	}
+	for i, test := range tests {
+		result := labelMatch(test.labels, test.filter)
+		if result != test.expectResult {
+			t.Errorf("case %d, got %#v, expected %#v", i, result, test.expectResult)
+		}
+	}
+}

--- a/pkg/models/resources/v1alpha3/node/nodes.go
+++ b/pkg/models/resources/v1alpha3/node/nodes.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/informers"
 	resourceheper "k8s.io/kubectl/pkg/util/resource"
 	"kubesphere.io/kubesphere/pkg/api"
-	clusterv1alpha1 "kubesphere.io/kubesphere/pkg/apis/cluster/v1alpha1"
 	"kubesphere.io/kubesphere/pkg/apiserver/query"
 	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3"
 )
@@ -104,12 +103,12 @@ func (c nodesGetter) compare(left runtime.Object, right runtime.Object, field qu
 }
 
 func (c nodesGetter) filter(object runtime.Object, filter query.Filter) bool {
-	cluster, ok := object.(*clusterv1alpha1.Cluster)
+	node, ok := object.(*v1.Node)
 	if !ok {
 		return false
 	}
 
-	return v1alpha3.DefaultObjectMetaFilter(cluster.ObjectMeta, filter)
+	return v1alpha3.DefaultObjectMetaFilter(node.ObjectMeta, filter)
 }
 
 // annotateNode adds cpu/memory requests usage data to node's annotations


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

**What type of PR is this?**

/kind api-change
/kind bug


**What this PR does / why we need it**:

Refine label selector logic, use label filter as k8s label selector.

` https://lb.kubesphere.local:6443/api/v1/namespaces?labelSelector=kubesphere.io/workspace` means label `kubesphere.io/workspace` exist.

`https://lb.kubesphere.local:6443/api/v1/namespaces?labelSelector=kubesphere.io/workspace=`
means label `kubesphere.io/workspace` value is empty.