### PR TITLE
fix cluster import validation bug

### DIFF
--- a/pkg/kapis/cluster/v1alpha1/handler_test.go
+++ b/pkg/kapis/cluster/v1alpha1/handler_test.go
@@ -89,9 +89,10 @@ spec:
         - --name=gondor
         - --token=randomtoken
         - --proxy-server=http://139.198.121.121:8080
-        - --keepalive=30s
+        - --keepalive=10s
         - --kubesphere-service=ks-apiserver.kubesphere-system.svc:80
         - --kubernetes-service=kubernetes.default.svc:443
+        - --v=0
         image: kubesphere/tower:v1.0
         name: agent
         resources:

--- a/pkg/kapis/cluster/v1alpha1/register.go
+++ b/pkg/kapis/cluster/v1alpha1/register.go
@@ -30,7 +30,7 @@ func AddToContainer(container *restful.Container,
 	webservice.Route(webservice.GET("/clusters/{cluster}/agent/deployment").
 		Doc("Return deployment yaml for cluster agent.").
 		Param(webservice.PathParameter("cluster", "Name of the cluster.").Required(true)).
-		To(h.GenerateAgentDeployment).
+		To(h.generateAgentDeployment).
 		Returns(http.StatusOK, api.StatusOK, nil))
 
 	webservice.Route(webservice.POST("/clusters/validation").


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
Fix cluster import bug, when importing a cluster, validation failed if kubesphere apiserver endpoint not provided which is allowed.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
