### PR TITLE
fix: total in histogram response of events search

### DIFF
--- a/pkg/simple/client/events/elasticsearch/elasticsearch.go
+++ b/pkg/simple/client/events/elasticsearch/elasticsearch.go
@@ -108,7 +108,7 @@ func (es *Elasticsearch) CountOverTime(filter *events.Filter, interval string) (
 	if err := json.Unmarshal(raw, &agg); err != nil {
 		return nil, err
 	}
-	histo := events.Histogram{Total: int64(len(agg.Buckets))}
+	histo := events.Histogram{Total: resp.Hits.Total}
 	for _, b := range agg.Buckets {
 		histo.Buckets = append(histo.Buckets,
 			events.Bucket{Time: b.Key, Count: b.DocCount})


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
Change `total` in histogram response to events count instead of buckets count when search events with param `operation=histogram`

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
