### PR TITLE
fix virtualservice and destinationrule controller

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -6,13 +6,13 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog"
-	kubesphereconfig "kubesphere.io/kubesphere/pkg/apiserver/config"
 	"kubesphere.io/kubesphere/pkg/simple/client/devops/jenkins"
 	"kubesphere.io/kubesphere/pkg/simple/client/k8s"
 	"kubesphere.io/kubesphere/pkg/simple/client/multicluster"
 	"kubesphere.io/kubesphere/pkg/simple/client/network"
 	"kubesphere.io/kubesphere/pkg/simple/client/openpitrix"
 	"kubesphere.io/kubesphere/pkg/simple/client/s3"
+	"kubesphere.io/kubesphere/pkg/simple/client/servicemesh"
 	"strings"
 	"time"
 )
@@ -24,6 +24,7 @@ type KubeSphereControllerManagerOptions struct {
 	OpenPitrixOptions   *openpitrix.Options
 	NetworkOptions      *network.Options
 	MultiClusterOptions *multicluster.Options
+	ServiceMeshOptions  *servicemesh.Options
 	LeaderElect         bool
 	LeaderElection      *leaderelection.LeaderElectionConfig
 	WebhookCertDir      string
@@ -37,6 +38,7 @@ func NewKubeSphereControllerManagerOptions() *KubeSphereControllerManagerOptions
 		OpenPitrixOptions:   openpitrix.NewOptions(),
 		NetworkOptions:      network.NewNetworkOptions(),
 		MultiClusterOptions: multicluster.NewOptions(),
+		ServiceMeshOptions:  servicemesh.NewServiceMeshOptions(),
 		LeaderElection: &leaderelection.LeaderElectionConfig{
 			LeaseDuration: 30 * time.Second,
 			RenewDeadline: 15 * time.Second,
@@ -49,13 +51,6 @@ func NewKubeSphereControllerManagerOptions() *KubeSphereControllerManagerOptions
 	return s
 }
 
-func (s *KubeSphereControllerManagerOptions) ApplyTo(conf *kubesphereconfig.Config) {
-	s.S3Options.ApplyTo(conf.S3Options)
-	s.KubernetesOptions.ApplyTo(conf.KubernetesOptions)
-	s.DevopsOptions.ApplyTo(conf.DevopsOptions)
-	s.OpenPitrixOptions.ApplyTo(conf.OpenPitrixOptions)
-}
-
 func (s *KubeSphereControllerManagerOptions) Flags() cliflag.NamedFlagSets {
 	fss := cliflag.NamedFlagSets{}
 
@@ -65,6 +60,7 @@ func (s *KubeSphereControllerManagerOptions) Flags() cliflag.NamedFlagSets {
 	s.OpenPitrixOptions.AddFlags(fss.FlagSet("openpitrix"), s.OpenPitrixOptions)
 	s.NetworkOptions.AddFlags(fss.FlagSet("network"), s.NetworkOptions)
 	s.MultiClusterOptions.AddFlags(fss.FlagSet("multicluster"), s.MultiClusterOptions)
+	s.ServiceMeshOptions.AddFlags(fss.FlagSet("servicemesh"), s.ServiceMeshOptions)
 
 	fs := fss.FlagSet("leaderelection")
 	s.bindLeaderElectionFlags(s.LeaderElection, fs)

--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -61,6 +61,7 @@ func NewControllerManagerCommand() *cobra.Command {
 			OpenPitrixOptions:   conf.OpenPitrixOptions,
 			NetworkOptions:      conf.NetworkOptions,
 			MultiClusterOptions: conf.MultiClusterOptions,
+			ServiceMeshOptions:  conf.ServiceMeshOptions,
 			LeaderElection:      s.LeaderElection,
 			LeaderElect:         s.LeaderElect,
 		}
@@ -157,7 +158,9 @@ func Run(s *options.KubeSphereControllerManagerOptions, stopCh <-chan struct{}) 
 			klog.Fatal("Unable to create namespace controller")
 		}
 
-		if err := addControllers(mgr, kubernetesClient, informerFactory, devopsClient, s3Client, openpitrixClient, s.MultiClusterOptions.Enable, s.NetworkOptions.EnableNetworkPolicy, stopCh); err != nil {
+		// TODO(jeff): refactor config with CRD
+		servicemeshEnabled := s.ServiceMeshOptions != nil && len(s.ServiceMeshOptions.IstioPilotHost) != 0
+		if err = addControllers(mgr, kubernetesClient, informerFactory, devopsClient, s3Client, openpitrixClient, s.MultiClusterOptions.Enable, s.NetworkOptions.EnableNetworkPolicy, servicemeshEnabled, stopCh); err != nil {
 			klog.Fatalf("unable to register controllers to the manager: %v", err)
 		}
 


### PR DESCRIPTION

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
only run virtualservice and destinationrule controller when servicemesh is enabled

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
