### PR TITLE
fix wrong total audit event number

### DIFF
--- a/pkg/models/tenant/tenant.go
+++ b/pkg/models/tenant/tenant.go
@@ -702,10 +702,9 @@ func (t *tenantOperator) Auditing(user user.Info, queryParam *auditingv1alpha1.Q
 		listEvts := authorizer.AttributesRecord{
 			User:            user,
 			Verb:            "list",
-			APIGroup:        "",
-			APIVersion:      "v1",
 			Resource:        "namespaces",
 			ResourceRequest: true,
+			ResourceScope:   request.ClusterScope,
 		}
 		decision, _, err := t.authorizer.Authorize(listEvts)
 		if err != nil {

--- a/pkg/models/tenant/tenant.go
+++ b/pkg/models/tenant/tenant.go
@@ -702,9 +702,10 @@ func (t *tenantOperator) Auditing(user user.Info, queryParam *auditingv1alpha1.Q
 		listEvts := authorizer.AttributesRecord{
 			User:            user,
 			Verb:            "list",
+			APIGroup:        "",
+			APIVersion:      "v1",
 			Resource:        "namespaces",
 			ResourceRequest: true,
-			ResourceScope:   request.ClusterScope,
 		}
 		decision, _, err := t.authorizer.Authorize(listEvts)
 		if err != nil {

--- a/pkg/simple/client/auditing/elasticsearch/elasticsearch.go
+++ b/pkg/simple/client/auditing/elasticsearch/elasticsearch.go
@@ -123,7 +123,7 @@ func (es *Elasticsearch) CountOverTime(filter *auditing.Filter, interval string)
 	if err := json.Unmarshal(raw, &agg); err != nil {
 		return nil, err
 	}
-	histo := auditing.Histogram{Total: int64(len(agg.Buckets))}
+	histo := auditing.Histogram{Total: resp.Hits.Total}
 	for _, b := range agg.Buckets {
 		histo.Buckets = append(histo.Buckets,
 			auditing.Bucket{Time: b.Key, Count: b.DocCount})


### PR DESCRIPTION
Signed-off-by: wanjunlei wanjunlei@yunify.com

What type of PR is this?
> /kind bug

**Which issue(s) this PR fixes**:
Change total in histogram response to auditing  events count instead of buckets count when search auditing with param operation=histogram