### PR TITLE
using /v1alpha2/jenkins replace /jenkins.kubesphere.io api

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -195,7 +195,8 @@ func (s *APIServer) installKubeSphereAPIs() {
 		s.DevopsClient,
 		s.SonarClient,
 		s.KubernetesClient.KubeSphere(),
-		s.S3Client))
+		s.S3Client,
+		s.Config.DevopsOptions.Host))
 	urlruntime.Must(devopsv1alpha3.AddToContainer(s.container,
 		s.DevopsClient,
 		s.KubernetesClient.Kubernetes(),

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -17,20 +17,25 @@ limitations under the License.
 package v1alpha2
 
 import (
+	"fmt"
 	"github.com/emicklei/go-restful"
 	"github.com/emicklei/go-restful-openapi"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/proxy"
+	"k8s.io/klog"
 	devopsv1alpha1 "kubesphere.io/kubesphere/pkg/apis/devops/v1alpha1"
 	"kubesphere.io/kubesphere/pkg/apiserver/runtime"
 	"kubesphere.io/kubesphere/pkg/client/clientset/versioned"
 	"kubesphere.io/kubesphere/pkg/client/informers/externalversions"
 	"kubesphere.io/kubesphere/pkg/constants"
+	"kubesphere.io/kubesphere/pkg/simple/client/devops/jenkins"
 	"kubesphere.io/kubesphere/pkg/simple/client/s3"
 	"kubesphere.io/kubesphere/pkg/simple/client/sonarqube"
+	"net/url"
+	"strings"
 
 	//"kubesphere.io/kubesphere/pkg/models/devops"
 	"kubesphere.io/kubesphere/pkg/simple/client/devops"
-
 	"net/http"
 )
 
@@ -41,7 +46,7 @@ const (
 
 var GroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha2"}
 
-func AddToContainer(container *restful.Container, ksInformers externalversions.SharedInformerFactory, devopsClient devops.Interface, sonarqubeClient sonarqube.SonarInterface, ksClient versioned.Interface, s3Client s3.Interface) error {
+func AddToContainer(container *restful.Container, ksInformers externalversions.SharedInformerFactory, devopsClient devops.Interface, sonarqubeClient sonarqube.SonarInterface, ksClient versioned.Interface, s3Client s3.Interface, endpoint string) error {
 	ws := runtime.NewWebService(GroupVersion)
 
 	err := AddPipelineToWebService(ws, devopsClient)
@@ -55,6 +60,11 @@ func AddToContainer(container *restful.Container, ksInformers externalversions.S
 	}
 
 	err = AddS2IToWebService(ws, ksClient, ksInformers, s3Client)
+	if err != nil {
+		return err
+	}
+
+	err = AddJenkinsToContainer(ws, devopsClient, endpoint)
 	if err != nil {
 		return err
 	}
@@ -684,4 +694,32 @@ func AddS2IToWebService(webservice *restful.WebService, ksClient versioned.Inter
 			Returns(http.StatusOK, RespOK, nil))
 	}
 	return nil
+}
+
+func AddJenkinsToContainer(webservice *restful.WebService, devopsClient devops.Interface, endpoint string) error {
+	if devopsClient == nil {
+		return nil
+	}
+	parse, err := url.Parse(endpoint)
+	if err != nil {
+		return err
+	}
+	parse.Path = strings.Trim(parse.Path, "/")
+	webservice.Route(webservice.GET("/jenkins/{path:*}").
+		To(func(request *restful.Request, response *restful.Response) {
+			u := request.Request.URL
+			u.Host = parse.Host
+			u.Scheme = parse.Scheme
+			jenkins.SetBasicBearTokenHeader(&request.Request.Header)
+			u.Path = strings.Replace(request.Request.URL.Path, fmt.Sprintf("/kapis/%s/%s/jenkins", GroupVersion.Group, GroupVersion.Version), "", 1)
+			httpProxy := proxy.NewUpgradeAwareHandler(u, http.DefaultTransport, false, false, &errorResponder{})
+			httpProxy.ServeHTTP(response, request.Request)
+		}).Returns(http.StatusOK, RespOK, nil))
+	return nil
+}
+
+type errorResponder struct{}
+
+func (e *errorResponder) Error(w http.ResponseWriter, req *http.Request, err error) {
+	klog.Error(err)
 }

--- a/pkg/simple/client/devops/jenkins/pure_request.go
+++ b/pkg/simple/client/devops/jenkins/pure_request.go
@@ -1,15 +1,10 @@
 package jenkins
 
 import (
-	"encoding/base64"
-	"fmt"
-	"github.com/dgrijalva/jwt-go"
 	"k8s.io/klog"
-	authtoken "kubesphere.io/kubesphere/pkg/apiserver/authentication/token"
 	"kubesphere.io/kubesphere/pkg/simple/client/devops"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 )
 
@@ -32,23 +27,7 @@ func (j *Jenkins) SendPureRequestWithHeaderResp(path string, httpParameters *dev
 	client := &http.Client{Timeout: 30 * time.Second}
 
 	header := httpParameters.Header
-	bearTokenArray := strings.Split(header.Get("Authorization"), " ")
-	bearFlag := bearTokenArray[0]
-	if strings.ToLower(bearFlag) == "bearer" {
-		bearToken := bearTokenArray[1]
-		if err != nil {
-			klog.Error(err)
-			return nil, nil, err
-		}
-		claim := authtoken.Claims{}
-		parser := jwt.Parser{}
-		_, _, err = parser.ParseUnverified(bearToken, &claim)
-		if err != nil {
-			return nil, nil, err
-		}
-		creds := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", claim.Username, bearToken)))
-		header.Set("Authorization", fmt.Sprintf("Basic %s", creds))
-	}
+	SetBasicBearTokenHeader(&header)
 
 	newRequest := &http.Request{
 		Method:   httpParameters.Method,


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:

There are some APIs forwarding by caddy in 2.1.1.  Now，we can use /kapis/devops.kubesphere.io/v1alpha2/jenkins to replace it.