### PR TITLE
fix: empty server host

### DIFF
--- a/pkg/models/kubeconfig/kubeconfig.go
+++ b/pkg/models/kubeconfig/kubeconfig.go
@@ -181,7 +181,7 @@ func (o *operator) GetKubeConfig(username string) (string, error) {
 	masterURL := o.masterURL
 
 	// server host override
-	if cluster := kubeconfig.Clusters[defaultClusterName]; cluster != nil {
+	if cluster := kubeconfig.Clusters[defaultClusterName]; cluster != nil && masterURL != "" {
 		cluster.Server = masterURL
 	}
 


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Override server host in kubeconfig if `masterURL` is not empty.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2336

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
