### PR TITLE
significantly improve log search performance

### DIFF
--- a/pkg/simple/client/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/simple/client/logging/elasticsearch/elasticsearch_test.go
@@ -224,17 +224,14 @@ func mockElasticsearchService(pattern, fakeResp string, fakeCode int) *httptest.
 }
 
 func newElasticsearchClient(srv *httptest.Server, version string) *Elasticsearch {
-	var es *Elasticsearch
+	es := &Elasticsearch{index: "ks-logstash-log"}
 	switch version {
 	case ElasticV5:
-		client, _ := v5.New(srv.URL, "ks-logstash-log")
-		es = &Elasticsearch{c: client}
+		es.c, _ = v5.New(srv.URL, "ks-logstash-log")
 	case ElasticV6:
-		client, _ := v6.New(srv.URL, "ks-logstash-log")
-		es = &Elasticsearch{c: client}
+		es.c, _ = v6.New(srv.URL, "ks-logstash-log")
 	case ElasticV7:
-		client, _ := v7.New(srv.URL, "ks-logstash-log")
-		es = &Elasticsearch{c: client}
+		es.c, _ = v7.New(srv.URL, "ks-logstash-log")
 	}
 	return es
 }

--- a/pkg/simple/client/logging/elasticsearch/versions/v5/v5.go
+++ b/pkg/simple/client/logging/elasticsearch/versions/v5/v5.go
@@ -24,10 +24,11 @@ func New(address string, index string) (*Elastic, error) {
 	return &Elastic{client: client, index: index}, err
 }
 
-func (e *Elastic) Search(body []byte, scroll bool) ([]byte, error) {
+func (e *Elastic) Search(indices string, body []byte, scroll bool) ([]byte, error) {
 	opts := []func(*esapi.SearchRequest){
 		e.client.Search.WithContext(context.Background()),
-		e.client.Search.WithIndex(fmt.Sprintf("%s*", e.index)),
+		e.client.Search.WithIndex(indices),
+		e.client.Search.WithIgnoreUnavailable(true),
 		e.client.Search.WithBody(bytes.NewBuffer(body)),
 	}
 	if scroll {

--- a/pkg/simple/client/logging/elasticsearch/versions/v6/v6.go
+++ b/pkg/simple/client/logging/elasticsearch/versions/v6/v6.go
@@ -24,10 +24,11 @@ func New(address string, index string) (*Elastic, error) {
 	return &Elastic{Client: client, index: index}, err
 }
 
-func (e *Elastic) Search(body []byte, scroll bool) ([]byte, error) {
+func (e *Elastic) Search(indices string, body []byte, scroll bool) ([]byte, error) {
 	opts := []func(*esapi.SearchRequest){
 		e.Client.Search.WithContext(context.Background()),
-		e.Client.Search.WithIndex(fmt.Sprintf("%s*", e.index)),
+		e.Client.Search.WithIndex(indices),
+		e.Client.Search.WithIgnoreUnavailable(true),
 		e.Client.Search.WithBody(bytes.NewBuffer(body)),
 	}
 	if scroll {

--- a/pkg/simple/client/logging/elasticsearch/versions/v7/v7.go
+++ b/pkg/simple/client/logging/elasticsearch/versions/v7/v7.go
@@ -24,10 +24,11 @@ func New(address string, index string) (*Elastic, error) {
 	return &Elastic{client: client, index: index}, err
 }
 
-func (e *Elastic) Search(body []byte, scroll bool) ([]byte, error) {
+func (e *Elastic) Search(indices string, body []byte, scroll bool) ([]byte, error) {
 	opts := []func(*esapi.SearchRequest){
 		e.client.Search.WithContext(context.Background()),
-		e.client.Search.WithIndex(fmt.Sprintf("%s*", e.index)),
+		e.client.Search.WithIndex(indices),
+		e.client.Search.WithIgnoreUnavailable(true),
 		e.client.Search.WithBody(bytes.NewBuffer(body)),
 	}
 	if scroll {

--- a/pkg/utils/esutil/esutil.go
+++ b/pkg/utils/esutil/esutil.go
@@ -1,0 +1,32 @@
+// TODO: refactor
+package esutil
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// KubeSphere uses the layout `yyyy.MM.dd`.
+const layoutISO = "2006.01.02"
+
+func ResolveIndexNames(prefix string, start, end time.Time) string {
+	if end.IsZero() {
+		end = time.Now()
+	}
+
+	// In case of no start time or a broad query range over 30 days, search all indices.
+	if start.IsZero() || end.Sub(start).Hours() > 24*30 {
+		return fmt.Sprintf("%s*", prefix)
+	}
+
+	var indices []string
+	for i := 0; i <= int(end.Sub(start).Hours()/24); i++ {
+		suffix := end.Add(time.Duration(-i) * 24 * time.Hour).Format(layoutISO)
+		indices = append(indices, fmt.Sprintf("%s-%s", prefix, suffix))
+	}
+
+	// If start is after end, ResolveIndexNames returns "".
+	// However, query parameter validation will prevent it from happening at the very beginning (Bad Request).
+	return strings.Join(indices, ",")
+}

--- a/pkg/utils/esutil/esutil_test.go
+++ b/pkg/utils/esutil/esutil_test.go
@@ -1,0 +1,56 @@
+package esutil
+
+import (
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"testing"
+	"time"
+)
+
+func TestResolveIndexNames(t *testing.T) {
+	var tests = []struct {
+		prefix   string
+		start    time.Time
+		end      time.Time
+		expected string
+	}{
+		{
+			prefix:   "ks-logstash-log",
+			start:    time.Date(2020, time.February, 1, 0, 0, 0, 0, time.UTC),
+			end:      time.Date(2020, time.February, 1, 0, 0, 0, 0, time.UTC),
+			expected: "ks-logstash-log-2020.02.01",
+		},
+		{
+			prefix:   "ks-logstash-log",
+			start:    time.Date(2020, time.February, 1, 0, 0, 0, 0, time.UTC),
+			end:      time.Date(2020, time.February, 3, 0, 0, 0, 0, time.UTC),
+			expected: "ks-logstash-log-2020.02.03,ks-logstash-log-2020.02.02,ks-logstash-log-2020.02.01",
+		},
+		{
+			prefix:   "ks-logstash-log",
+			end:      time.Date(2020, time.February, 3, 0, 0, 0, 0, time.UTC),
+			expected: "ks-logstash-log*",
+		},
+		{
+			prefix:   "ks-logstash-log",
+			start:    time.Date(2000, time.February, 1, 0, 0, 0, 0, time.UTC),
+			end:      time.Date(2020, time.February, 3, 0, 0, 0, 0, time.UTC),
+			expected: "ks-logstash-log*",
+		},
+		{
+			prefix:   "ks-logstash-log",
+			start:    time.Date(2020, time.February, 3, 0, 0, 0, 0, time.UTC),
+			end:      time.Date(2020, time.February, 1, 0, 0, 0, 0, time.UTC),
+			expected: "",
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			result := ResolveIndexNames(test.prefix, test.start, test.end)
+			if diff := cmp.Diff(result, test.expected); diff != "" {
+				t.Fatalf("%T differ (-got, +want): %s", test.expected, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

**What type of PR is this?**

 /kind bug
 /kind cleanup

**What this PR does / why we need it**:
Instead of query against all indices, search indices that are within query time span only.

Example: 
```
# logging kapis: start_time=1594390613&end_time=1594638672

GET localhost:9200/ks-logstash-log*/_search

 --> 

GET localhost:9200/ks-logstash-log-2020.07.13,ks-logstash-log-2020.07.12,ks-logstash-log-2020.07.11,ks-logstash-log-2020.07.10/_search?ignore_unavailable=true
```

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refer to KubeSphere forum: https://kubesphere.com.cn/forum/d/1074/15

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
