### PR TITLE
use non root user for building image

### DIFF
--- a/build/ks-apiserver/Dockerfile
+++ b/build/ks-apiserver/Dockerfile
@@ -1,7 +1,14 @@
-# Copyright 2018 The KubeSphere Authors. All rights reserved.
+# Copyright 2020 The KubeSphere Authors. All rights reserved.
 # Use of this source code is governed by an Apache license
 # that can be found in the LICENSE file.
 FROM alpine:3.9
-RUN apk add --update ca-certificates && update-ca-certificates
+
 COPY  /bin/cmd/ks-apiserver /usr/local/bin/
+
+RUN apk add --update ca-certificates && \
+    update-ca-certificates && \
+    adduser -D -g kubesphere -u 1002 kubesphere && \
+    chown -R kubesphere:kubesphere /usr/local/bin/ks-apiserver
+
+USER kubesphere
 CMD ["sh"]

--- a/build/ks-controller-manager/Dockerfile
+++ b/build/ks-controller-manager/Dockerfile
@@ -1,7 +1,14 @@
-# Copyright 2018 The KubeSphere Authors. All rights reserved.
+# Copyright 2020 The KubeSphere Authors. All rights reserved.
 # Use of this source code is governed by an Apache license
 # that can be found in the LICENSE file.
 FROM alpine:3.7
-RUN apk add --update ca-certificates && update-ca-certificates
+
 COPY  /bin/cmd/controller-manager /usr/local/bin/
+
+RUN apk add --update ca-certificates && \
+    update-ca-certificates && \
+    adduser -D -g kubesphere -u 1002 kubesphere && \
+    chown -R kubesphere:kubesphere /usr/local/bin/controller-manager
+
+USER kubesphere
 CMD controller-manager


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Use non root user `kubesphere` when building docker images


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
