### PR TITLE
change crd version to v1beta1

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -455,7 +455,7 @@ func (s *APIServer) waitForResourceSync(stopCh <-chan struct{}) error {
 
 	apiextensionsInformerFactory := s.InformerFactory.ApiExtensionSharedInformerFactory()
 	apiextensionsGVRs := []schema.GroupVersionResource{
-		{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"},
+		{Group: "apiextensions.k8s.io", Version: "v1beta1", Resource: "customresourcedefinitions"},
 	}
 
 	for _, gvr := range apiextensionsGVRs {


### PR DESCRIPTION
Signed-off-by: Jeff <zw0948@gmail.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
cache v1beta1 crd instead of v1 version, cause v1 is not available in kubernetes v1.15.x
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
