### PR TITLE
Fix controller manager docker permission denied

### DIFF
--- a/build/ks-apiserver/Dockerfile
+++ b/build/ks-apiserver/Dockerfile
@@ -1,14 +1,18 @@
 # Copyright 2020 The KubeSphere Authors. All rights reserved.
 # Use of this source code is governed by an Apache license
 # that can be found in the LICENSE file.
-FROM alpine:3.9
+FROM alpine:3.11
+ENV USER=kubesphere
+ENV UID=1002
+# docker group
+ENV GID=998
 
 COPY  /bin/cmd/ks-apiserver /usr/local/bin/
 
-RUN apk add --update ca-certificates && \
-    update-ca-certificates && \
-    adduser -D -g kubesphere -u 1002 kubesphere && \
-    chown -R kubesphere:kubesphere /usr/local/bin/ks-apiserver
+RUN apk add --no-cache ca-certificates && \
+    addgroup --gid "$GID" "$USER" && \
+    adduser -D -g "" --ingroup "$USER" -u "$UID" "$USER" && \
+    chown -R kubesphere:"$GID" /usr/local/bin/ks-apiserver
 
 EXPOSE 9090
 

--- a/build/ks-controller-manager/Dockerfile
+++ b/build/ks-controller-manager/Dockerfile
@@ -1,17 +1,20 @@
 # Copyright 2020 The KubeSphere Authors. All rights reserved.
 # Use of this source code is governed by an Apache license
 # that can be found in the LICENSE file.
-FROM alpine:3.7
+FROM alpine:3.11
+ENV USER=kubesphere
+ENV UID=1002
+# docker group
+ENV GID=998
 
 COPY  /bin/cmd/controller-manager /usr/local/bin/
 
-RUN apk add --update ca-certificates && \
-    update-ca-certificates && \
-    adduser -D -g kubesphere -u 1002 kubesphere && \
-    chown -R kubesphere:kubesphere /usr/local/bin/controller-manager
-
-USER kubesphere
+RUN apk add --no-cache ca-certificates && \
+    addgroup --gid "$GID" "$USER" && \
+    adduser -D -g "" --ingroup "$USER" -u "$UID" "$USER" && \
+    chown -R kubesphere:"$GID" /usr/local/bin/controller-manager
 
 EXPOSE 8443 8080
 
-CMD controller-manager
+USER kubesphere
+CMD ["sh"]


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
we are using docker socket inside pod, add image user kubesphere to group docker is required, otherwise, we will have a permission denied issue

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://kubesphere.com.cn/forum/d/1763-got-permission-denied-while-trying-to-connect-to-the-docker-daemon-socket

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
