### PR TITLE
use root for controller manager cause we need to access csi plugins sock

### DIFF
--- a/build/ks-controller-manager/Dockerfile
+++ b/build/ks-controller-manager/Dockerfile
@@ -2,19 +2,11 @@
 # Use of this source code is governed by an Apache license
 # that can be found in the LICENSE file.
 FROM alpine:3.11
-ENV USER=kubesphere
-ENV UID=1002
-# docker group
-ENV GID=998
 
 COPY  /bin/cmd/controller-manager /usr/local/bin/
 
-RUN apk add --no-cache ca-certificates && \
-    addgroup --gid "$GID" "$USER" && \
-    adduser -D -g "" --ingroup "$USER" -u "$UID" "$USER" && \
-    chown -R kubesphere:"$GID" /usr/local/bin/controller-manager
+RUN apk add --no-cache ca-certificates
 
 EXPOSE 8443 8080
 
-USER kubesphere
 CMD ["sh"]


### PR DESCRIPTION
Signed-off-by: Jeff <zw0948@gmail.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Kubelet csi plugins requires root permission to access, need to use root for controller image 

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
