### PR TITLE
chore: docker build cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+DOCKER_TAG=latest
+
 OUTPUT_DIR=bin
 GOFLAGS=-mod=vendor
 define ALL_HELP_INFO
@@ -82,7 +84,10 @@ openapi:
 	go run ./tools/cmd/crd-doc-gen/main.go
 # Build the docker image
 docker-build: all
-	hack/docker_build.sh
+	hack/docker_build.sh ${DOCKER_TAG}
+
+docker-release: all
+	hack/docker_build.sh ${DOCKER_TAG} true
 
 # Run tests
 test: fmt vet

--- a/build/hypersphere/Dockerfile
+++ b/build/hypersphere/Dockerfile
@@ -2,6 +2,9 @@
 # Use of this source code is governed by an Apache license
 # that can be found in the LICENSE file.
 
+FROM alpine:3.9
+RUN apk add --update ca-certificates && update-ca-certificates
+
 FROM golang:1.12 as hypersphere-builder
 
 COPY / /go/src/kubesphere.io/kubesphere
@@ -9,7 +12,5 @@ COPY / /go/src/kubesphere.io/kubesphere
 WORKDIR /go/src/kubesphere.io/kubesphere
 RUN CGO_ENABLED=0 GO111MODULE=on GOOS=linux GOARCH=amd64 GOFLAGS=-mod=vendor go build -i -ldflags '-w -s' -o hypersphere cmd/hypersphere/hypersphere.go
 
-FROM alpine:3.9
-RUN apk add --update ca-certificates && update-ca-certificates
 COPY --from=hypersphere-builder /go/src/kubesphere.io/kubesphere/hypersphere /usr/local/bin/
 CMD ["sh"]

--- a/build/ks-apiserver/Dockerfile
+++ b/build/ks-apiserver/Dockerfile
@@ -7,12 +7,13 @@ ENV UID=1002
 # docker group
 ENV GID=998
 
-COPY  /bin/cmd/ks-apiserver /usr/local/bin/
-
 RUN apk add --no-cache ca-certificates && \
     addgroup --gid "$GID" "$USER" && \
-    adduser -D -g "" --ingroup "$USER" -u "$UID" "$USER" && \
-    chown -R kubesphere:"$GID" /usr/local/bin/ks-apiserver
+    adduser -D -g "" --ingroup "$USER" -u "$UID" "$USER"
+
+COPY  /bin/cmd/ks-apiserver /usr/local/bin/
+
+RUN chown -R kubesphere:"$GID" /usr/local/bin/ks-apiserver
 
 EXPOSE 9090
 

--- a/build/ks-controller-manager/Dockerfile
+++ b/build/ks-controller-manager/Dockerfile
@@ -3,9 +3,9 @@
 # that can be found in the LICENSE file.
 FROM alpine:3.11
 
-COPY  /bin/cmd/controller-manager /usr/local/bin/
-
 RUN apk add --no-cache ca-certificates
+
+COPY  /bin/cmd/controller-manager /usr/local/bin/
 
 EXPOSE 8443 8080
 

--- a/hack/docker_build.sh
+++ b/hack/docker_build.sh
@@ -14,11 +14,14 @@ tag_for_branch() {
 # push to kubespheredev with default latest tag
 REPO=${REPO:-kubespheredev}
 TAG=$(tag_for_branch $1)
+RELEASE=${2:-false}
 
 docker build -f build/ks-apiserver/Dockerfile -t $REPO/ks-apiserver:$TAG .
 docker build -f build/ks-controller-manager/Dockerfile -t $REPO/ks-controller-manager:$TAG .
 
-# Push image to dockerhub, need to support multiple push
-echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker push $REPO/ks-apiserver:$TAG
-docker push $REPO/ks-controller-manager:$TAG
+if [ $RELEASE ] {
+	# Push image to dockerhub, need to support multiple push
+	echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+	docker push $REPO/ks-apiserver:$TAG
+	docker push $REPO/ks-controller-manager:$TAG
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind document

**What this PR does / why we need it**:
At present, the basic principle of docker using cache is that if the parent node has a cache, the current dockerfile statement has been built before and can use cache. So, to speed up compilation, some basic operations should be advanced.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
