### PR TITLE
remove LastAppliedConfig annotation after password encrypted

### DIFF
--- a/pkg/controller/user/user_controller.go
+++ b/pkg/controller/user/user_controller.go
@@ -367,6 +367,8 @@ func (c *Controller) ensurePasswordIsEncrypted(user *iamv1alpha2.User) (*iamv1al
 		if user.Annotations == nil {
 			user.Annotations = make(map[string]string, 0)
 		}
+		// ensure plain text password won't be kept anywhere
+		delete(user.Annotations, corev1.LastAppliedConfigAnnotation)
 		user.Annotations[iamv1alpha2.PasswordEncryptedAnnotation] = "true"
 		user.Status = iamv1alpha2.UserStatus{
 			State:              iamv1alpha2.UserActive,


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:

Remove `LastAppliedConfigAnnotation` annotation after password encrypted, make sure that plain text password is not stored anywhere.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
