### PR TITLE
disable federatedworkspace informer if multi cluster not enabled

### DIFF
--- a/pkg/controller/workspacetemplate/workspacetemplate_controller.go
+++ b/pkg/controller/workspacetemplate/workspacetemplate_controller.go
@@ -107,26 +107,28 @@ func NewController(k8sClient kubernetes.Interface, ksClient kubesphere.Interface
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: k8sClient.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerName})
 	ctl := &Controller{
-		k8sClient:                  k8sClient,
-		ksClient:                   ksClient,
-		workspaceTemplateInformer:  workspaceTemplateInformer,
-		workspaceTemplateLister:    workspaceTemplateInformer.Lister(),
-		workspaceTemplateSynced:    workspaceTemplateInformer.Informer().HasSynced,
-		workspaceInformer:          workspaceInformer,
-		workspaceLister:            workspaceInformer.Lister(),
-		workspaceSynced:            workspaceInformer.Informer().HasSynced,
-		workspaceRoleInformer:      workspaceRoleInformer,
-		workspaceRoleLister:        workspaceRoleInformer.Lister(),
-		workspaceRoleSynced:        workspaceRoleInformer.Informer().HasSynced,
-		roleBaseInformer:           roleBaseInformer,
-		roleBaseLister:             roleBaseInformer.Lister(),
-		roleBaseSynced:             roleBaseInformer.Informer().HasSynced,
-		federatedWorkspaceInformer: federatedWorkspaceInformer,
-		federatedWorkspaceLister:   federatedWorkspaceInformer.Lister(),
-		federatedWorkspaceSynced:   federatedWorkspaceInformer.Informer().HasSynced,
-		multiClusterEnabled:        multiClusterEnabled,
-		workqueue:                  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "WorkspaceTemplate"),
-		recorder:                   recorder,
+		k8sClient:                 k8sClient,
+		ksClient:                  ksClient,
+		workspaceTemplateInformer: workspaceTemplateInformer,
+		workspaceTemplateLister:   workspaceTemplateInformer.Lister(),
+		workspaceTemplateSynced:   workspaceTemplateInformer.Informer().HasSynced,
+		workspaceInformer:         workspaceInformer,
+		workspaceLister:           workspaceInformer.Lister(),
+		workspaceSynced:           workspaceInformer.Informer().HasSynced,
+		workspaceRoleInformer:     workspaceRoleInformer,
+		workspaceRoleLister:       workspaceRoleInformer.Lister(),
+		workspaceRoleSynced:       workspaceRoleInformer.Informer().HasSynced,
+		roleBaseInformer:          roleBaseInformer,
+		roleBaseLister:            roleBaseInformer.Lister(),
+		roleBaseSynced:            roleBaseInformer.Informer().HasSynced,
+		multiClusterEnabled:       multiClusterEnabled,
+		workqueue:                 workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "WorkspaceTemplate"),
+		recorder:                  recorder,
+	}
+	if multiClusterEnabled {
+		ctl.federatedWorkspaceInformer = federatedWorkspaceInformer
+		ctl.federatedWorkspaceLister = federatedWorkspaceInformer.Lister()
+		ctl.federatedWorkspaceSynced = federatedWorkspaceInformer.Informer().HasSynced
 	}
 	klog.Info("Setting up event handlers")
 	workspaceTemplateInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Disable federatedworkspace informer if multi-cluster not enabled.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
