### PR TITLE
fix: calulating days between two timestamps

### DIFF
--- a/pkg/utils/esutil/esutil.go
+++ b/pkg/utils/esutil/esutil.go
@@ -26,6 +26,7 @@ import (
 // KubeSphere uses the layout `yyyy.MM.dd`.
 const layoutISO = "2006.01.02"
 
+// Always do calculation based on UTC.
 func ResolveIndexNames(prefix string, start, end time.Time) string {
 	if end.IsZero() {
 		end = time.Now()
@@ -37,8 +38,12 @@ func ResolveIndexNames(prefix string, start, end time.Time) string {
 	}
 
 	var indices []string
-	for i := 0; i <= int(end.Sub(start).Hours()/24); i++ {
-		suffix := end.Add(time.Duration(-i) * 24 * time.Hour).Format(layoutISO)
+	days := int(end.Sub(start).Hours() / 24)
+	if start.Add(time.Duration(days)*24*time.Hour).UTC().Day() != end.UTC().Day() {
+		days++
+	}
+	for i := 0; i <= days; i++ {
+		suffix := end.Add(time.Duration(-i) * 24 * time.Hour).UTC().Format(layoutISO)
 		indices = append(indices, fmt.Sprintf("%s-%s", prefix, suffix))
 	}
 

--- a/pkg/utils/esutil/esutil_test.go
+++ b/pkg/utils/esutil/esutil_test.go
@@ -59,6 +59,30 @@ func TestResolveIndexNames(t *testing.T) {
 			end:      time.Date(2020, time.February, 1, 0, 0, 0, 0, time.UTC),
 			expected: "",
 		},
+		{
+			prefix:   "ks-logstash-log",
+			start:    time.Date(2020, time.August, 6, 22, 0, 0, 0, time.UTC),
+			end:      time.Date(2020, time.August, 7, 04, 0, 0, 0, time.UTC),
+			expected: "ks-logstash-log-2020.08.07,ks-logstash-log-2020.08.06",
+		},
+		{
+			prefix:   "ks-logstash-log",
+			start:    time.Date(2020, time.August, 6, 22, 0, 0, 0, time.FixedZone("UTC+8", 8*3600)),
+			end:      time.Date(2020, time.August, 7, 04, 0, 0, 0, time.FixedZone("UTC+8", 8*3600)),
+			expected: "ks-logstash-log-2020.08.06",
+		},
+		{
+			prefix:   "ks-logstash-log",
+			start:    time.Date(2020, time.August, 7, 02, 0, 0, 0, time.FixedZone("UTC+8", 8*3600)),
+			end:      time.Date(2020, time.August, 7, 04, 0, 0, 0, time.FixedZone("UTC+8", 8*3600)),
+			expected: "ks-logstash-log-2020.08.06",
+		},
+		{
+			prefix:   "ks-logstash-log",
+			start:    time.Date(2020, time.August, 7, 12, 0, 0, 0, time.FixedZone("UTC+8", 8*3600)),
+			end:      time.Date(2020, time.August, 7, 14, 0, 0, 0, time.FixedZone("UTC+8", 8*3600)),
+			expected: "ks-logstash-log-2020.08.07",
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Issue: For users based on **UTC-8** time zones, they cannot see logs, events and audits bewteen 0:00 ~ 08:00 AM.

We have two problems about how we make index filter: 
1. It is possible that the two timestamps end up in two different dates. So we need to return two indices, though their difference might be less 24h. eg. [08.06:23:00:00, 08.07:02:00:00] -> [ks-logstash-log-2020.08.06, ks-logstash-log-2020.08.07]

2. Logs, events and audits produced between 0:00 ~ 08:00 AM will end up with yesterday's index. So when doing calculation, we should always be based on UTC regradless  whether host time is mounted or not.
```
# kubesphere-system/reids (pods with UTC)
{"log":"1:M 06 Aug 2020 22:37:16.958 * 100 changes in 300 seconds. Saving...\n","stream":"stdout","time":"2020-08-06T22:37:16.958432374Z"}
{"log":"1:M 06 Aug 2020 22:37:16.959 * Background saving started by pid 52\n","stream":"stdout","time":"2020-08-06T22:37:16.959187883Z"}
{"log":"52:C 06 Aug 2020 22:37:16.976 * DB saved on disk\n","stream":"stdout","time":"2020-08-06T22:37:16.976229Z"}


# kubesphere-system/ks-apiserver (pods with host time)
{"log":"W0807 16:52:43.612123       1 client_config.go:543] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.\n","stream":"stderr","time":"2020-08-07T08:52:43.613714771Z"}
{"log":"I0807 16:52:43.640355       1 apiserver.go:300] Start cache objects\n","stream":"stderr","time":"2020-08-07T08:52:43.640518632Z"}
{"log":"W0807 16:52:43.975227       1 apiserver.go:433] resource types.kubefed.io/v1beta1, Resource=federatedresourcequotas not exists in the cluster\n","stream":"stderr","time":"2020-08-07T08:52:43.975377195Z"}
```

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
``` 
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
