### PR TITLE
fix: exported logs are incomplete

### DIFF
--- a/pkg/simple/client/logging/elasticsearch/elasticsearch.go
+++ b/pkg/simple/client/logging/elasticsearch/elasticsearch.go
@@ -295,15 +295,14 @@ func (es *Elasticsearch) ExportLogs(sf logging.SearchFilter, w io.Writer) error 
 	for _, hit := range res.AllHits {
 		data = append(data, hit.Log)
 	}
-	if len(data) == 0 {
-		return nil
-	}
 
 	// limit to retrieve max 100k records
 	for i := 0; i < 100; i++ {
-		data, id, err = es.scroll(id)
-		if err != nil {
-			return err
+		if i != 0 {
+			data, id, err = es.scroll(id)
+			if err != nil {
+				return err
+			}
 		}
 		if len(data) == 0 {
 			return nil


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

 /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Issue: exported logs always miss 1000 line records. 

It is becasuse, in the loop, we didn't write the initial 1000 records to response body. 

To implement log exporting, we are using Scroll API which requires an initial search to fetch `_scroll_id`. The result from initial search (those missing 1000 line logs) **MATTERS** ! They should be included.

KS 2.x doesn't have this issue. It is unforturnately introduced during code refactor in 3.0.

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
