### PR TITLE
fix unauthorized if using token kubeconfig

### DIFF
--- a/pkg/apiserver/dispatch/dispatch.go
+++ b/pkg/apiserver/dispatch/dispatch.go
@@ -153,6 +153,12 @@ func (c *clusterDispatch) Dispatch(w http.ResponseWriter, req *http.Request, han
 		// req.Header['Authorization'] before authentication.
 		req.Header.Set("X-KubeSphere-Authorization", req.Header.Get("Authorization"))
 
+		// If cluster kubeconfig using token authentication, transport will not override authorization header,
+		// this will cause requests reject by kube-apiserver since kubesphere authorization header is not
+		// acceptable. Delete this header is safe since we are using X-KubeSphere-Authorization.
+		// https://github.com/kubernetes/client-go/blob/master/transport/round_trippers.go#L285
+		req.Header.Del("Authorization")
+
 		// Dirty trick again. The kube-apiserver apiserver proxy rejects all proxy requests with dryRun parameter
 		// https://github.com/kubernetes/kubernetes/pull/66083
 		// Really don't understand why they do this. And here we are, bypass with replacing 'dryRun'


### PR DESCRIPTION
Signed-off-by: Jeff <jeffzhang@yunify.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Remove KubeSphere authorization header before sending to member cluster kube-apiserver

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubesphere/kubesphere/issues/2929

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
