### PR TITLE
fix: type errors

### DIFF
--- a/pkg/controller/storage/expansion/expansion_controller_test.go
+++ b/pkg/controller/storage/expansion/expansion_controller_test.go
@@ -22,8 +22,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
+	"testing"
+	"time"
+
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,9 +38,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
-	"os"
-	"testing"
-	"time"
 )
 
 func TestMain(m *testing.M) {
@@ -67,16 +68,16 @@ func TestSyncHandler(t *testing.T) {
 	}{
 		{
 			name: "mount pvc on deploy",
-			pvc:  getFakePersistentVolumeClaim("fake-pvc", "vol-12345", "fake-sc", types.UID(123)),
+			pvc:  getFakePersistentVolumeClaim("fake-pvc", "vol-12345", "fake-sc", types.UID("123")),
 			sc:   getFakeStorageClass("fake-sc", "fake.sc.com"),
 			deploy: getFakeDeployment("fake-deploy", "234", 1,
-				getFakePersistentVolumeClaim("fake-pvc", "vol-12345", "fake-sc", types.UID(123))),
+				getFakePersistentVolumeClaim("fake-pvc", "vol-12345", "fake-sc", types.UID("123"))),
 			pvcKey:   "default/fake-pvc",
 			hasError: false,
 		},
 		{
 			name:     "unmounted pvc",
-			pvc:      getFakePersistentVolumeClaim("fake-pvc", "vol-12345", "fake-sc", types.UID(123)),
+			pvc:      getFakePersistentVolumeClaim("fake-pvc", "vol-12345", "fake-sc", types.UID("123")),
 			sc:       getFakeStorageClass("fake-sc", "fake.sc.com"),
 			pvcKey:   "default/fake-pvc",
 			hasError: true,

--- a/pkg/models/registries/blob.go
+++ b/pkg/models/registries/blob.go
@@ -19,9 +19,10 @@ package registries
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	"github.com/docker/distribution/manifest/schema2"
 	log "k8s.io/klog"
-	"net/http"
 )
 
 // Digest returns the digest for an image.
@@ -49,7 +50,7 @@ func (r *Registry) ImageBlob(image Image, token string) (*ImageBlob, error) {
 	respBody, _ := GetRespBody(resp)
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
-		log.Error("got response: " + string(resp.StatusCode) + string(respBody))
+		log.Errorf("got response: %d%s", resp.StatusCode, respBody)
 		return nil, fmt.Errorf("got image blob faild")
 	}
 

--- a/pkg/models/registries/manifest.go
+++ b/pkg/models/registries/manifest.go
@@ -55,7 +55,8 @@ func (r *Registry) ImageManifest(image Image, token string) (*ImageManifest, err
 			log.Error(statusUnauthorized)
 			return nil, restful.NewError(resp.StatusCode, statusUnauthorized)
 		}
-		log.Error("got response: " + string(resp.StatusCode) + string(respBody))
+
+		log.Errorf("got response: %d%s", resp.StatusCode, respBody)
 		return nil, restful.NewError(resp.StatusCode, "got image manifest failed")
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When I execute `make ks-apiserver V=true` through the Makefile make ks-apiserver by Makefile, i see the following error: 

```
# kubesphere.io/kubesphere/pkg/controller/storage/expansion
pkg/controller/storage/expansion/expansion_controller_test.go:70:75: conversion from untyped int to UID (string) yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
pkg/controller/storage/expansion/expansion_controller_test.go:73:70: conversion from untyped int to UID (string) yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
pkg/controller/storage/expansion/expansion_controller_test.go:79:79: conversion from untyped int to UID (string) yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
# kubesphere.io/kubesphere/pkg/models/registries
pkg/models/registries/blob.go:52:32: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
pkg/models/registries/manifest.go:58:32: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```

**Which issue(s) this PR fixes**:

 I modified some mismatched codes, and When I it again, it is ok on all my environments.

**Special notes for reviewers**:

My build environment is:
```
OS: centos7
Go version: go1.15 linux/amd64
```
But, it is ok when I execute on `go1.14.3 windows/amd64`.