### PR TITLE
fix: add nil check for storage class name

### DIFF
--- a/pkg/models/resources/v1alpha2/storageclass/storageclasses.go
+++ b/pkg/models/resources/v1alpha2/storageclass/storageclasses.go
@@ -107,7 +107,7 @@ func (s *storageClassesSearcher) countPersistentVolumeClaims(name string) int {
 	var count int
 
 	for _, pvc := range pvcs {
-		if *pvc.Spec.StorageClassName == name || (pvc.Annotations != nil && pvc.Annotations[corev1.BetaStorageClassAnnotation] == name) {
+		if (pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName == name) || (pvc.Annotations != nil && pvc.Annotations[corev1.BetaStorageClassAnnotation] == name) {
 			count++
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Avoid panic(Internal server error) when searching PVCs with an empty storage class name.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubesphere/ks-installer/issues/1109

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
