### PR TITLE
remove istio-pilot config

### DIFF
--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -205,7 +205,7 @@ func run(s *options.KubeSphereControllerManagerOptions, stopCh <-chan struct{}) 
 	}
 
 	// TODO(jeff): refactor config with CRD
-	servicemeshEnabled := s.ServiceMeshOptions != nil && len(s.ServiceMeshOptions.IstioPilotHost) != 0
+	servicemeshEnabled := s.ServiceMeshOptions != nil
 	if err = addControllers(mgr,
 		kubernetesClient,
 		informerFactory,

--- a/cmd/ks-apiserver/app/server.go
+++ b/cmd/ks-apiserver/app/server.go
@@ -106,8 +106,5 @@ func initializeServicemeshConfig(s *options.ServerRunOptions) {
 	config.ExternalServices.PrometheusServiceURL = s.ServiceMeshOptions.ServicemeshPrometheusHost
 	config.ExternalServices.PrometheusCustomMetricsURL = config.ExternalServices.PrometheusServiceURL
 
-	// Set istio pilot discovery service url
-	config.ExternalServices.Istio.UrlServiceVersion = s.ServiceMeshOptions.IstioPilotHost
-
 	kconfig.Set(config)
 }

--- a/pkg/apiserver/config/config.go
+++ b/pkg/apiserver/config/config.go
@@ -207,7 +207,7 @@ func (conf *Config) stripEmptyOptions() {
 		conf.NetworkOptions = nil
 	}
 
-	if conf.ServiceMeshOptions != nil && conf.ServiceMeshOptions.IstioPilotHost == "" &&
+	if conf.ServiceMeshOptions != nil &&
 		conf.ServiceMeshOptions.ServicemeshPrometheusHost == "" &&
 		conf.ServiceMeshOptions.JaegerQueryHost == "" {
 		conf.ServiceMeshOptions = nil

--- a/pkg/apiserver/config/config_test.go
+++ b/pkg/apiserver/config/config_test.go
@@ -65,7 +65,6 @@ func newTestConfig() (*Config, error) {
 			Burst:      1e6,
 		},
 		ServiceMeshOptions: &servicemesh.Options{
-			IstioPilotHost:            "http://istio-pilot.istio-system.svc:9090",
 			JaegerQueryHost:           "http://jaeger-query.istio-system.svc:80",
 			ServicemeshPrometheusHost: "http://prometheus-k8s.kubesphere-monitoring-system.svc",
 		},

--- a/pkg/simple/client/servicemesh/options.go
+++ b/pkg/simple/client/servicemesh/options.go
@@ -20,9 +20,6 @@ import "github.com/spf13/pflag"
 
 type Options struct {
 
-	// istio pilot discovery service url
-	IstioPilotHost string `json:"istioPilotHost,omitempty" yaml:"istioPilotHost"`
-
 	// jaeger query service url
 	JaegerQueryHost string `json:"jaegerQueryHost,omitempty" yaml:"jaegerQueryHost"`
 
@@ -33,7 +30,6 @@ type Options struct {
 // NewServiceMeshOptions returns a `zero` instance
 func NewServiceMeshOptions() *Options {
 	return &Options{
-		IstioPilotHost:            "",
 		JaegerQueryHost:           "",
 		ServicemeshPrometheusHost: "",
 	}
@@ -54,14 +50,9 @@ func (s *Options) ApplyTo(options *Options) {
 		options.JaegerQueryHost = s.JaegerQueryHost
 	}
 
-	if s.IstioPilotHost != "" {
-		options.IstioPilotHost = s.IstioPilotHost
-	}
 }
 
 func (s *Options) AddFlags(fs *pflag.FlagSet, c *Options) {
-	fs.StringVar(&s.IstioPilotHost, "istio-pilot-host", c.IstioPilotHost, ""+
-		"istio pilot discovery service url")
 
 	fs.StringVar(&s.JaegerQueryHost, "jaeger-query-host", c.JaegerQueryHost, ""+
 		"jaeger query service url")


### PR DESCRIPTION
Signed-off-by: zackzhangkai <zackzhang@yunify.com>

**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

this API indeed is no need, it's only be used by kiali to get the istio version, but we didn't use this API  actually, so remove it to simplify our configuration


