### PR TITLE
Make the issues template can keep comment section

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,16 +3,16 @@ name: Bug report
 about: Create a report to help us improve
 ---
 
-## English only!
+<!--
+You don't need to remove this comment section, it's invisible on the issues page.
 
-**注意！GitHub Issue 仅支持英文，中文 Issue 请在 [论坛](https://kubesphere.com.cn/forum/) 提交。**
+## General remarks
 
-**General remarks**
-
-> Please delete this section including header before submitting
->
-> This form is to report bugs. For general usage questions you can join our Slack channel
->        [KubeSphere-users](https://join.slack.com/t/kubesphere/shared_invite/enQtNTE3MDIxNzUxNzQ0LTZkNTdkYWNiYTVkMTM5ZThhODY1MjAyZmVlYWEwZmQ3ODQ1NmM1MGVkNWEzZTRhNzk0MzM5MmY4NDc3ZWVhMjE)
+* Attention, please fill out this issues form using English only!
+* 注意！GitHub Issue 仅支持英文，中文 Issue 请在 [论坛](https://kubesphere.com.cn/forum/) 提交。
+* This form is to report bugs. For general usage questions you can join our Slack channel
+       [KubeSphere-users](https://join.slack.com/t/kubesphere/shared_invite/enQtNTE3MDIxNzUxNzQ0LTZkNTdkYWNiYTVkMTM5ZThhODY1MjAyZmVlYWEwZmQ3ODQ1NmM1MGVkNWEzZTRhNzk0MzM5MmY4NDc3ZWVhMjE)
+-->
 
 **Describe the Bug**
 A clear and concise description of what the bug is.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Improve the experience of writing a bug issue.

Always clean the unnecessary part of the issues template is really a boring thing. But we can just keep it by using comment syntax of markdown

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None.

**Special notes for reviewers**:
None.

**Additional documentation, usage docs, etc.**:
None.

