### PR TITLE
Feat: support runnig ks-controller-manager without ldap option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,16 +3,16 @@ name: Bug report
 about: Create a report to help us improve
 ---
 
-## English only!
+<!--
+You don't need to remove this comment section, it's invisible on the issues page.
 
-**注意！GitHub Issue 仅支持英文，中文 Issue 请在 [论坛](https://kubesphere.com.cn/forum/) 提交。**
+## General remarks
 
-**General remarks**
-
-> Please delete this section including header before submitting
->
-> This form is to report bugs. For general usage questions you can join our Slack channel
->        [KubeSphere-users](https://join.slack.com/t/kubesphere/shared_invite/enQtNTE3MDIxNzUxNzQ0LTZkNTdkYWNiYTVkMTM5ZThhODY1MjAyZmVlYWEwZmQ3ODQ1NmM1MGVkNWEzZTRhNzk0MzM5MmY4NDc3ZWVhMjE)
+* Attention, please fill out this issues form using English only!
+* 注意！GitHub Issue 仅支持英文，中文 Issue 请在 [论坛](https://kubesphere.com.cn/forum/) 提交。
+* This form is to report bugs. For general usage questions you can join our Slack channel
+       [KubeSphere-users](https://join.slack.com/t/kubesphere/shared_invite/enQtNTE3MDIxNzUxNzQ0LTZkNTdkYWNiYTVkMTM5ZThhODY1MjAyZmVlYWEwZmQ3ODQ1NmM1MGVkNWEzZTRhNzk0MzM5MmY4NDc3ZWVhMjE)
+-->
 
 **Describe the Bug**
 A clear and concise description of what the bug is.

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,11 @@ controller-manager: fmt vet
 	hack/gobuild.sh cmd/controller-manager
 
 # Run go fmt against code 
-fmt: generate
+fmt:
 	gofmt -w ./pkg ./cmd ./tools ./api
 
 # Run go vet against code
-vet: generate
+vet:
 	go vet ./pkg/... ./cmd/...
 
 # Generate manifests e.g. CRD, RBAC etc.
@@ -59,11 +59,6 @@ manifests:
 deploy: manifests
 	kubectl apply -f config/crds
 	kustomize build config/default | kubectl apply -f -
-
-# generate will generate crds' deepcopy & go openapi structs
-# Futher more about go:genreate . https://blog.golang.org/generate
-generate:
-	go generate ./pkg/... ./cmd/...
 
 mockgen:
 	mockgen -package=openpitrix -source=pkg/simple/client/openpitrix/openpitrix.go -destination=pkg/simple/client/openpitrix/mock.go

--- a/cmd/controller-manager/app/controllers.go
+++ b/cmd/controller-manager/app/controllers.go
@@ -31,6 +31,8 @@ import (
 	"kubesphere.io/kubesphere/pkg/controller/devopsproject"
 	"kubesphere.io/kubesphere/pkg/controller/globalrole"
 	"kubesphere.io/kubesphere/pkg/controller/globalrolebinding"
+	"kubesphere.io/kubesphere/pkg/controller/group"
+	"kubesphere.io/kubesphere/pkg/controller/groupbinding"
 	"kubesphere.io/kubesphere/pkg/controller/job"
 	"kubesphere.io/kubesphere/pkg/controller/network/ippool"
 	"kubesphere.io/kubesphere/pkg/controller/network/nsnetworkpolicy"
@@ -258,6 +260,12 @@ func addControllers(
 		kubesphereInformer.Types().V1beta1().FederatedWorkspaces(),
 		multiClusterEnabled)
 
+	groupBindingController := groupbinding.NewController(client.Kubernetes(), client.KubeSphere(),
+		kubesphereInformer.Iam().V1alpha2().GroupBindings())
+
+	groupController := group.NewController(client.Kubernetes(), client.KubeSphere(),
+		kubesphereInformer.Iam().V1alpha2().Groups())
+
 	var clusterController manager.Runnable
 	if multiClusterEnabled {
 		clusterController = cluster.NewClusterController(
@@ -319,6 +327,8 @@ func addControllers(
 		"workspacerole-controller":        workspaceRoleController,
 		"workspacerolebinding-controller": workspaceRoleBindingController,
 		"ippool-controller":               ippoolController,
+		"groupbinding-controller":         groupBindingController,
+		"group-controller":                groupController,
 	}
 
 	if devopsClient != nil {

--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -118,9 +118,8 @@ func run(s *options.KubeSphereControllerManagerOptions, stopCh <-chan struct{}) 
 	}
 
 	var ldapClient ldapclient.Interface
-	if s.LdapOptions == nil || len(s.LdapOptions.Host) == 0 {
-		return fmt.Errorf("ldap service address MUST not be empty")
-	} else {
+	// when there is no ldapOption, we set ldapClient as nil, which means we don't need to sync user info into ldap.
+	if s.LdapOptions != nil && len(s.LdapOptions.Host) != 0 {
 		if s.LdapOptions.Host == ldapclient.FAKE_HOST { // for debug only
 			ldapClient = ldapclient.NewSimpleLdap()
 		} else {
@@ -129,6 +128,8 @@ func run(s *options.KubeSphereControllerManagerOptions, stopCh <-chan struct{}) 
 				return fmt.Errorf("failed to connect to ldap service, please check ldap status, error: %v", err)
 			}
 		}
+	} else {
+		klog.Info("Kubesphere-controller-manager starts without ldap option, it will not sync user into ldap")
 	}
 
 	var openpitrixClient openpitrix.Client

--- a/cmd/ks-apiserver/app/server.go
+++ b/cmd/ks-apiserver/app/server.go
@@ -18,10 +18,13 @@ package app
 
 import (
 	"fmt"
-
+	"github.com/kiali/kiali/business"
 	kconfig "github.com/kiali/kiali/config"
+	"github.com/kiali/kiali/kubernetes"
+	"github.com/kiali/kiali/prometheus"
 	"github.com/spf13/cobra"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/clientcmd"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog"
 
@@ -115,4 +118,16 @@ func initializeServicemeshConfig(s *options.ServerRunOptions) {
 	config.ExternalServices.Istio.UrlServiceVersion = s.ServiceMeshOptions.IstioPilotHost
 
 	kconfig.Set(config)
+
+	// Set kiali config
+	kubeconfig, err := clientcmd.BuildConfigFromFlags("", s.KubernetesOptions.KubeConfig)
+	if err != nil {
+		fmt.Println(err)
+	}
+	k8sClient, err := kubernetes.NewClientFromConfig(kubeconfig)
+	if err != nil {
+		fmt.Println(err)
+	}
+	prometheusClient, _ := prometheus.NewClient()
+	business.SetWithBackends(k8sClient, prometheusClient)
 }

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/hashicorp/go-version v1.2.0 // indirect
 	github.com/json-iterator/go v1.1.9
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
-	github.com/kiali/kiali v0.15.1-0.20200520152915-769a61d75460
+	github.com/kiali/kiali v1.25.0
 	github.com/kubernetes-csi/external-snapshotter/v2 v2.1.0
 	github.com/kubesphere/sonargo v0.0.2
 	github.com/lib/pq v1.2.0 // indirect
@@ -283,7 +283,7 @@ replace (
 	github.com/kelseyhightower/envconfig => github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kevinburke/ssh_config => github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e
 	github.com/keybase/go-ps => github.com/keybase/go-ps v0.0.0-20161005175911-668c8856d999
-	github.com/kiali/kiali => github.com/kubesphere/kiali v0.15.1-0.20200520152915-769a61d75460
+	github.com/kiali/kiali => github.com/kubesphere/kiali v0.15.1-0.20201030070213-04b6506d6c7d
 	github.com/kisielk/errcheck => github.com/kisielk/errcheck v1.2.0
 	github.com/kisielk/gotool => github.com/kisielk/gotool v1.0.0
 	github.com/koding/multiconfig => github.com/koding/multiconfig v0.0.0-20171124222453-69c27309b2d7

--- a/go.sum
+++ b/go.sum
@@ -296,8 +296,8 @@ github.com/kubernetes-csi/csi-lib-utils v0.7.0/go.mod h1:bze+2G9+cmoHxN6+WyG1qT4
 github.com/kubernetes-csi/csi-test v2.0.0+incompatible/go.mod h1:YxJ4UiuPWIhMBkxUKY5c267DyA0uDZ/MtAimhx/2TA0=
 github.com/kubernetes-csi/external-snapshotter/v2 v2.1.0 h1:a1cpbNAdOTHO7Lk5UO5tjcbYPEEamIxmzATt+pKoDhc=
 github.com/kubernetes-csi/external-snapshotter/v2 v2.1.0/go.mod h1:dV5oB3U62KBdlf9ADWkMmjGd3USauqQtwIm2OZb5mqI=
-github.com/kubesphere/kiali v0.15.1-0.20200520152915-769a61d75460 h1:EcC/7blefyiDDDq3xfBlQj/vHL2ytz/JEpgHkeXKbpc=
-github.com/kubesphere/kiali v0.15.1-0.20200520152915-769a61d75460/go.mod h1:Y1EqeixoXkKkU8I+yvOfhdh21+8+etFE6wYOVT2XFdI=
+github.com/kubesphere/kiali v0.15.1-0.20201030070213-04b6506d6c7d h1:/q8KYXKrLMfK4izrP3dzy6Uq8dQF8IbowRWDKiI1/Rg=
+github.com/kubesphere/kiali v0.15.1-0.20201030070213-04b6506d6c7d/go.mod h1:Y1EqeixoXkKkU8I+yvOfhdh21+8+etFE6wYOVT2XFdI=
 github.com/kubesphere/sonargo v0.0.2 h1:hsSRE3sv3mkPcUAeSABdp7rtfcNW2zzeHXzFa01CTkU=
 github.com/kubesphere/sonargo v0.0.2/go.mod h1:ww8n9ANlDXhX5PBZ18iaRnCgEkXN0GMml3/KZXOZ11w=
 github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=

--- a/pkg/apis/iam/v1alpha2/group_test.go
+++ b/pkg/apis/iam/v1alpha2/group_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	"golang.org/x/net/context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestStorageGroup(t *testing.T) {
+	key := types.NamespacedName{
+		Name: "foo",
+	}
+	created := &Group{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		}}
+	g := gomega.NewGomegaWithT(t)
+
+	// Test Create
+	fetched := &Group{}
+	g.Expect(c.Create(context.TODO(), created)).To(gomega.Succeed())
+
+	g.Expect(c.Get(context.TODO(), key, fetched)).To(gomega.Succeed())
+	g.Expect(fetched).To(gomega.Equal(created))
+
+	// Test Updating the Labels
+	updated := fetched.DeepCopy()
+	updated.Labels = map[string]string{"hello": "world"}
+	g.Expect(c.Update(context.TODO(), updated)).To(gomega.Succeed())
+
+	g.Expect(c.Get(context.TODO(), key, fetched)).To(gomega.Succeed())
+	g.Expect(fetched).To(gomega.Equal(updated))
+
+	// Test Delete
+	g.Expect(c.Delete(context.TODO(), fetched)).To(gomega.Succeed())
+	g.Expect(c.Get(context.TODO(), key, fetched)).ToNot(gomega.Succeed())
+}

--- a/pkg/apis/iam/v1alpha2/groupbinding_test.go
+++ b/pkg/apis/iam/v1alpha2/groupbinding_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	"golang.org/x/net/context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestStorageGroupBinding(t *testing.T) {
+	key := types.NamespacedName{
+		Name: "foo",
+	}
+	created := &GroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		GroupRef: GroupRef{Name: "bar"},
+		Users:    []string{"user"},
+	}
+	g := gomega.NewGomegaWithT(t)
+
+	// Test Create
+	fetched := &GroupBinding{}
+	g.Expect(c.Create(context.TODO(), created)).To(gomega.Succeed())
+
+	g.Expect(c.Get(context.TODO(), key, fetched)).To(gomega.Succeed())
+	g.Expect(fetched).To(gomega.Equal(created))
+
+	// Test Updating the Labels
+	updated := fetched.DeepCopy()
+	updated.Labels = map[string]string{"hello": "world"}
+	g.Expect(c.Update(context.TODO(), updated)).To(gomega.Succeed())
+
+	g.Expect(c.Get(context.TODO(), key, fetched)).To(gomega.Succeed())
+	g.Expect(fetched).To(gomega.Equal(updated))
+
+	// Test Delete
+	g.Expect(c.Delete(context.TODO(), fetched)).To(gomega.Succeed())
+	g.Expect(c.Get(context.TODO(), key, fetched)).ToNot(gomega.Succeed())
+}

--- a/pkg/apis/iam/v1alpha2/groupbinding_types.go
+++ b/pkg/apis/iam/v1alpha2/groupbinding_types.go
@@ -20,6 +20,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	ResourcePluralGroupBinding = "groupbindings"
+)
+
 // GroupRef defines the desired relation of GroupBinding
 type GroupRef struct {
 	APIGroup string `json:"apiGroup,omitempty"`

--- a/pkg/apiserver/authentication/authenticators/basic/basic.go
+++ b/pkg/apiserver/authentication/authenticators/basic/basic.go
@@ -18,6 +18,7 @@ package basic
 
 import (
 	"context"
+
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"kubesphere.io/kubesphere/pkg/models/iam/im"
@@ -50,7 +51,7 @@ func (t *basicAuthenticator) AuthenticatePassword(ctx context.Context, username,
 		User: &user.DefaultInfo{
 			Name:   providedUser.GetName(),
 			UID:    providedUser.GetUID(),
-			Groups: []string{user.AllAuthenticated},
+			Groups: append(providedUser.GetGroups(), user.AllAuthenticated),
 		},
 	}, true, nil
 }

--- a/pkg/apiserver/authentication/authenticators/jwttoken/jwt_token.go
+++ b/pkg/apiserver/authentication/authenticators/jwttoken/jwt_token.go
@@ -18,9 +18,12 @@ package jwttoken
 
 import (
 	"context"
+
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/klog"
+
+	iamv1alpha2listers "kubesphere.io/kubesphere/pkg/client/listers/iam/v1alpha2"
 	"kubesphere.io/kubesphere/pkg/models/iam/im"
 )
 
@@ -31,11 +34,13 @@ import (
 // because some resources are public accessible.
 type tokenAuthenticator struct {
 	tokenOperator im.TokenManagementInterface
+	userLister    iamv1alpha2listers.UserLister
 }
 
-func NewTokenAuthenticator(tokenOperator im.TokenManagementInterface) authenticator.Token {
+func NewTokenAuthenticator(tokenOperator im.TokenManagementInterface, userLister iamv1alpha2listers.UserLister) authenticator.Token {
 	return &tokenAuthenticator{
 		tokenOperator: tokenOperator,
+		userLister:    userLister,
 	}
 }
 
@@ -46,11 +51,16 @@ func (t *tokenAuthenticator) AuthenticateToken(ctx context.Context, token string
 		return nil, false, err
 	}
 
+	dbUser, err := t.userLister.Get(providedUser.GetName())
+	if err != nil {
+		return nil, false, err
+	}
+
 	return &authenticator.Response{
 		User: &user.DefaultInfo{
 			Name:   providedUser.GetName(),
 			UID:    providedUser.GetUID(),
-			Groups: []string{user.AllAuthenticated},
+			Groups: append(dbUser.Spec.Groups, user.AllAuthenticated),
 		},
 	}, true, nil
 }

--- a/pkg/apiserver/authorization/authorizerfactory/rbac.go
+++ b/pkg/apiserver/authorization/authorizerfactory/rbac.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	"github.com/open-policy-agent/opa/rego"
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	iamv1alpha2 "kubesphere.io/kubesphere/pkg/apis/iam/v1alpha2"
@@ -259,7 +260,7 @@ func (r *RBACAuthorizer) visitRulesFor(requestAttributes authorizer.Attributes, 
 			workspace = requestAttributes.GetWorkspace()
 		}
 
-		if workspaceRoleBindings, err := r.am.ListWorkspaceRoleBindings("", workspace); err != nil {
+		if workspaceRoleBindings, err := r.am.ListWorkspaceRoleBindings("", nil, workspace); err != nil {
 			if !visitor(nil, "", nil, err) {
 				return
 			}
@@ -304,7 +305,7 @@ func (r *RBACAuthorizer) visitRulesFor(requestAttributes authorizer.Attributes, 
 			}
 		}
 
-		if roleBindings, err := r.am.ListRoleBindings("", namespace); err != nil {
+		if roleBindings, err := r.am.ListRoleBindings("", nil, namespace); err != nil {
 			if !visitor(nil, "", nil, err) {
 				return
 			}

--- a/pkg/controller/group/group_controller.go
+++ b/pkg/controller/group/group_controller.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2020 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+	iam1alpha2 "kubesphere.io/kubesphere/pkg/apis/iam/v1alpha2"
+	kubesphere "kubesphere.io/kubesphere/pkg/client/clientset/versioned"
+	iamv1alpha2informers "kubesphere.io/kubesphere/pkg/client/informers/externalversions/iam/v1alpha2"
+	iamv1alpha1listers "kubesphere.io/kubesphere/pkg/client/listers/iam/v1alpha2"
+	"kubesphere.io/kubesphere/pkg/utils/sliceutil"
+)
+
+const (
+	successSynced         = "Synced"
+	messageResourceSynced = "Group synced successfully"
+	controllerName        = "groupbinding-controller"
+	finalizer             = "finalizers.kubesphere.io/groups"
+)
+
+type Controller struct {
+	scheme        *runtime.Scheme
+	k8sClient     kubernetes.Interface
+	ksClient      kubesphere.Interface
+	groupInformer iamv1alpha2informers.GroupInformer
+	groupLister   iamv1alpha1listers.GroupLister
+	groupSynced   cache.InformerSynced
+	workqueue     workqueue.RateLimitingInterface
+	recorder      record.EventRecorder
+}
+
+// NewController creates Group Controller instance
+func NewController(k8sClient kubernetes.Interface, ksClient kubesphere.Interface, groupInformer iamv1alpha2informers.GroupInformer) *Controller {
+
+	klog.V(4).Info("Creating event broadcaster")
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(klog.Infof)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: k8sClient.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerName})
+	ctl := &Controller{
+		k8sClient:     k8sClient,
+		ksClient:      ksClient,
+		groupInformer: groupInformer,
+		groupLister:   groupInformer.Lister(),
+		groupSynced:   groupInformer.Informer().HasSynced,
+		workqueue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Group"),
+		recorder:      recorder,
+	}
+	klog.Info("Setting up event handlers")
+	groupInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: ctl.enqueueGroup,
+		UpdateFunc: func(old, new interface{}) {
+			ctl.enqueueGroup(new)
+		},
+		DeleteFunc: ctl.enqueueGroup,
+	})
+	return ctl
+}
+
+func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+	defer c.workqueue.ShutDown()
+
+	klog.Info("Starting Group controller")
+	klog.Info("Waiting for informer caches to sync")
+	synced := []cache.InformerSynced{c.groupSynced}
+	if ok := cache.WaitForCacheSync(stopCh, synced...); !ok {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	klog.Info("Starting workers")
+	for i := 0; i < threadiness; i++ {
+		go wait.Until(c.runWorker, time.Second, stopCh)
+	}
+
+	klog.Info("Started workers")
+	<-stopCh
+	klog.Info("Shutting down workers")
+	return nil
+}
+
+func (c *Controller) enqueueGroup(obj interface{}) {
+	var key string
+	var err error
+	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	c.workqueue.Add(key)
+}
+
+func (c *Controller) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *Controller) processNextWorkItem() bool {
+	obj, shutdown := c.workqueue.Get()
+
+	if shutdown {
+		return false
+	}
+	err := func(obj interface{}) error {
+		defer c.workqueue.Done(obj)
+		var key string
+		var ok bool
+
+		if key, ok = obj.(string); !ok {
+			c.workqueue.Forget(obj)
+			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			return nil
+		}
+		if err := c.reconcile(key); err != nil {
+			c.workqueue.AddRateLimited(key)
+			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
+		}
+		c.workqueue.Forget(obj)
+		klog.Infof("Successfully synced %s:%s", "key", key)
+		return nil
+	}(obj)
+
+	if err != nil {
+		utilruntime.HandleError(err)
+		return true
+	}
+
+	return true
+}
+
+// reconcile handles Group informer events, clear up related reource when group is being deleted.
+func (c *Controller) reconcile(key string) error {
+
+	group, err := c.groupLister.Get(key)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			utilruntime.HandleError(fmt.Errorf("group '%s' in work queue no longer exists", key))
+			return nil
+		}
+		klog.Error(err)
+		return err
+	}
+	if group.ObjectMeta.DeletionTimestamp.IsZero() {
+		if !sliceutil.HasString(group.Finalizers, finalizer) {
+			group.ObjectMeta.Finalizers = append(group.ObjectMeta.Finalizers, finalizer)
+
+			if group, err = c.ksClient.IamV1alpha2().Groups().Update(group); err != nil {
+				return err
+			}
+			// Skip reconcile when group is updated.
+			return nil
+		}
+	} else {
+		// The object is being deleted
+		if sliceutil.HasString(group.ObjectMeta.Finalizers, finalizer) {
+			if err = c.deleteGroupBindings(group); err != nil {
+				klog.Error(err)
+				return err
+			}
+
+			if err = c.deleteRoleBindings(group); err != nil {
+				klog.Error(err)
+				return err
+			}
+
+			group.Finalizers = sliceutil.RemoveString(group.ObjectMeta.Finalizers, func(item string) bool {
+				return item == finalizer
+			})
+
+			if group, err = c.ksClient.IamV1alpha2().Groups().Update(group); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	c.recorder.Event(group, corev1.EventTypeNormal, successSynced, messageResourceSynced)
+	return nil
+}
+
+func (c *Controller) Start(stopCh <-chan struct{}) error {
+	return c.Run(1, stopCh)
+}
+
+func (c *Controller) deleteGroupBindings(group *iam1alpha2.Group) error {
+
+	// Groupbindings that created by kubeshpere will be deleted directly.
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{iam1alpha2.GroupReferenceLabel: group.Name}).String(),
+	}
+	deleteOptions := metav1.NewDeleteOptions(0)
+
+	if err := c.ksClient.IamV1alpha2().GroupBindings().
+		DeleteCollection(deleteOptions, listOptions); err != nil {
+		klog.Error(err)
+		return err
+	}
+	return nil
+}
+
+// remove all RoleBindings.
+func (c *Controller) deleteRoleBindings(group *iam1alpha2.Group) error {
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{iam1alpha2.GroupReferenceLabel: group.Name}).String(),
+	}
+	deleteOptions := metav1.NewDeleteOptions(0)
+
+	if err := c.ksClient.IamV1alpha2().WorkspaceRoleBindings().
+		DeleteCollection(deleteOptions, listOptions); err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	if err := c.k8sClient.RbacV1().ClusterRoleBindings().
+		DeleteCollection(deleteOptions, listOptions); err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	if result, err := c.k8sClient.CoreV1().Namespaces().List(metav1.ListOptions{}); err != nil {
+		klog.Error(err)
+		return err
+	} else {
+		for _, namespace := range result.Items {
+			if err = c.k8sClient.RbacV1().RoleBindings(namespace.Name).DeleteCollection(deleteOptions, listOptions); err != nil {
+				klog.Error(err)
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/group/group_controller_test.go
+++ b/pkg/controller/group/group_controller_test.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2019 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/diff"
+	kubeinformers "k8s.io/client-go/informers"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	v1alpha2 "kubesphere.io/kubesphere/pkg/apis/iam/v1alpha2"
+	"kubesphere.io/kubesphere/pkg/client/clientset/versioned/fake"
+	ksinformers "kubesphere.io/kubesphere/pkg/client/informers/externalversions"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	alwaysReady        = func() bool { return true }
+	noResyncPeriodFunc = func() time.Duration { return 0 }
+)
+
+type fixture struct {
+	t *testing.T
+
+	ksclient  *fake.Clientset
+	k8sclient *k8sfake.Clientset
+	// Objects to put in the store.
+	groupLister []*v1alpha2.Group
+	// Actions expected to happen on the client.
+	kubeactions []core.Action
+	actions     []core.Action
+	// Objects from here preloaded into NewSimpleFake.
+	kubeobjects []runtime.Object
+	objects     []runtime.Object
+}
+
+func newFixture(t *testing.T) *fixture {
+	f := &fixture{}
+	f.t = t
+	f.objects = []runtime.Object{}
+	f.kubeobjects = []runtime.Object{}
+	return f
+}
+
+func newGroup(name string) *v1alpha2.Group {
+	return &v1alpha2.Group{
+		TypeMeta: metav1.TypeMeta{APIVersion: v1alpha2.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1alpha2.GroupSpec{},
+	}
+}
+
+func (f *fixture) newController() (*Controller, ksinformers.SharedInformerFactory, kubeinformers.SharedInformerFactory) {
+	f.ksclient = fake.NewSimpleClientset(f.objects...)
+	f.k8sclient = k8sfake.NewSimpleClientset(f.kubeobjects...)
+
+	ksinformers := ksinformers.NewSharedInformerFactory(f.ksclient, noResyncPeriodFunc())
+	k8sinformers := kubeinformers.NewSharedInformerFactory(f.k8sclient, noResyncPeriodFunc())
+
+	for _, group := range f.groupLister {
+		err := ksinformers.Iam().V1alpha2().Groups().Informer().GetIndexer().Add(group)
+		if err != nil {
+			f.t.Errorf("add group:%s", err)
+		}
+	}
+
+	c := NewController(f.k8sclient, f.ksclient,
+		ksinformers.Iam().V1alpha2().Groups())
+	c.groupSynced = alwaysReady
+	c.recorder = &record.FakeRecorder{}
+
+	return c, ksinformers, k8sinformers
+}
+
+func (f *fixture) run(userName string) {
+	f.runController(userName, true, false)
+}
+
+func (f *fixture) runExpectError(userName string) {
+	f.runController(userName, true, true)
+}
+
+func (f *fixture) runController(group string, startInformers bool, expectError bool) {
+	c, i, k8sI := f.newController()
+	if startInformers {
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		i.Start(stopCh)
+		k8sI.Start(stopCh)
+	}
+
+	err := c.reconcile(group)
+	if !expectError && err != nil {
+		f.t.Errorf("error syncing group: %v", err)
+	} else if expectError && err == nil {
+		f.t.Error("expected error syncing group, got nil")
+	}
+
+	actions := filterInformerActions(f.ksclient.Actions())
+	for i, action := range actions {
+		if len(f.actions) < i+1 {
+			f.t.Errorf("%d unexpected actions: %+v", len(actions)-len(f.actions), actions[i:])
+			break
+		}
+
+		expectedAction := f.actions[i]
+		checkAction(expectedAction, action, f.t)
+	}
+
+	if len(f.actions) > len(actions) {
+		f.t.Errorf("%d additional expected actions:%+v", len(f.actions)-len(actions), f.actions[len(actions):])
+	}
+
+	k8sActions := filterInformerActions(f.k8sclient.Actions())
+	for i, action := range k8sActions {
+		if len(f.kubeactions) < i+1 {
+			f.t.Errorf("%d unexpected actions: %+v", len(k8sActions)-len(f.kubeactions), k8sActions[i:])
+			break
+		}
+
+		expectedAction := f.kubeactions[i]
+		checkAction(expectedAction, action, f.t)
+	}
+
+	if len(f.kubeactions) > len(k8sActions) {
+		f.t.Errorf("%d additional expected actions:%+v", len(f.kubeactions)-len(k8sActions), f.kubeactions[len(k8sActions):])
+	}
+}
+
+// checkAction verifies that expected and actual actions are equal and both have
+// same attached resources
+func checkAction(expected, actual core.Action, t *testing.T) {
+	if !(expected.Matches(actual.GetVerb(), actual.GetResource().Resource) && actual.GetSubresource() == expected.GetSubresource()) {
+		t.Errorf("Expected\n\t%#v\ngot\n\t%#v", expected, actual)
+		return
+	}
+
+	if reflect.TypeOf(actual) != reflect.TypeOf(expected) {
+		t.Errorf("Action has wrong type. Expected: %t. Got: %t", expected, actual)
+		return
+	}
+
+	switch a := actual.(type) {
+	case core.CreateActionImpl:
+		e, _ := expected.(core.CreateActionImpl)
+		expObject := e.GetObject()
+		object := a.GetObject()
+
+		if !reflect.DeepEqual(expObject, object) {
+			t.Errorf("Action %s %s has wrong object\nDiff:\n %s",
+				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintSideBySide(expObject, object))
+		}
+	case core.UpdateActionImpl:
+		e, _ := expected.(core.UpdateActionImpl)
+		expObject := e.GetObject()
+		object := a.GetObject()
+		expUser := expObject.(*v1alpha2.Group)
+		group := object.(*v1alpha2.Group)
+
+		if !reflect.DeepEqual(expUser, group) {
+			t.Errorf("Action %s %s has wrong object\nDiff:\n %s",
+				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintSideBySide(expObject, object))
+		}
+	case core.PatchActionImpl:
+		e, _ := expected.(core.PatchActionImpl)
+		expPatch := e.GetPatch()
+		patch := a.GetPatch()
+
+		if !reflect.DeepEqual(expPatch, patch) {
+			t.Errorf("Action %s %s has wrong patch\nDiff:\n %s",
+				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintSideBySide(expPatch, patch))
+		}
+	default:
+		t.Errorf("Uncaptured Action %s %s, you should explicitly add a case to capture it",
+			actual.GetVerb(), actual.GetResource().Resource)
+	}
+}
+
+// filterInformerActions filters list and watch actions for testing resources.
+// Since list and watch don't change resource state we can filter it to lower
+// nose level in our tests.
+func filterInformerActions(actions []core.Action) []core.Action {
+	var ret []core.Action
+	for _, action := range actions {
+		if !action.Matches("update", "groups") {
+			continue
+		}
+		ret = append(ret, action)
+	}
+
+	return ret
+}
+
+func (f *fixture) expectUpdateGroupsFinalizerAction(group *v1alpha2.Group) {
+	expect := group.DeepCopy()
+	expect.Finalizers = []string{"finalizers.kubesphere.io/groups"}
+	action := core.NewUpdateAction(schema.GroupVersionResource{Resource: "groups"}, "", expect)
+	f.actions = append(f.actions, action)
+}
+
+func (f *fixture) expectUpdateGroupsDeleteAction(group *v1alpha2.Group) {
+	expect := group.DeepCopy()
+	expect.Finalizers = []string{}
+	action := core.NewUpdateAction(schema.GroupVersionResource{Resource: "groups"}, "", expect)
+	f.actions = append(f.actions, action)
+}
+
+func getKey(group *v1alpha2.Group, t *testing.T) string {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(group)
+	if err != nil {
+		t.Errorf("Unexpected error getting key for group %v: %v", group.Name, err)
+		return ""
+	}
+	return key
+}
+
+func TestDeletesGroup(t *testing.T) {
+	f := newFixture(t)
+	group := newGroup("test")
+
+	f.groupLister = append(f.groupLister, group)
+	f.objects = append(f.objects, group)
+
+	f.expectUpdateGroupsFinalizerAction(group)
+	f.run(getKey(group, t))
+
+	f = newFixture(t)
+
+	deletedGroup := group.DeepCopy()
+	deletedGroup.Finalizers = []string{"finalizers.kubesphere.io/groups"}
+	now := metav1.Now()
+	deletedGroup.ObjectMeta.DeletionTimestamp = &now
+
+	f.groupLister = append(f.groupLister, deletedGroup)
+	f.objects = append(f.objects, deletedGroup)
+	f.expectUpdateGroupsDeleteAction(deletedGroup)
+	f.run(getKey(deletedGroup, t))
+}
+
+func TestDoNothing(t *testing.T) {
+	f := newFixture(t)
+	group := newGroup("test")
+
+	f.groupLister = append(f.groupLister, group)
+	f.objects = append(f.objects, group)
+
+	f.expectUpdateGroupsFinalizerAction(group)
+	f.run(getKey(group, t))
+}

--- a/pkg/controller/groupbinding/groupbinding_controller.go
+++ b/pkg/controller/groupbinding/groupbinding_controller.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2020 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package groupbinding
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+	iamv1alpha2 "kubesphere.io/kubesphere/pkg/apis/iam/v1alpha2"
+	kubesphere "kubesphere.io/kubesphere/pkg/client/clientset/versioned"
+	iamv1alpha2informers "kubesphere.io/kubesphere/pkg/client/informers/externalversions/iam/v1alpha2"
+	iamv1alpha2listers "kubesphere.io/kubesphere/pkg/client/listers/iam/v1alpha2"
+	"kubesphere.io/kubesphere/pkg/utils/sliceutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	successSynced         = "Synced"
+	messageResourceSynced = "GroupBinding synced successfully"
+	controllerName        = "groupbinding-controller"
+	finalizer             = "finalizers.kubesphere.io/groupsbindings"
+)
+
+type Controller struct {
+	scheme               *runtime.Scheme
+	k8sClient            kubernetes.Interface
+	ksClient             kubesphere.Interface
+	groupBindingInformer iamv1alpha2informers.GroupBindingInformer
+	groupBindingLister   iamv1alpha2listers.GroupBindingLister
+	groupBindingSynced   cache.InformerSynced
+	workqueue            workqueue.RateLimitingInterface
+	recorder             record.EventRecorder
+}
+
+// NewController creates GroupBinding Controller instance
+func NewController(k8sClient kubernetes.Interface, ksClient kubesphere.Interface, groupBindingInformer iamv1alpha2informers.GroupBindingInformer) *Controller {
+	klog.V(4).Info("Creating event broadcaster")
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(klog.Infof)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: k8sClient.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerName})
+	ctl := &Controller{
+		k8sClient:            k8sClient,
+		ksClient:             ksClient,
+		groupBindingInformer: groupBindingInformer,
+		groupBindingLister:   groupBindingInformer.Lister(),
+		groupBindingSynced:   groupBindingInformer.Informer().HasSynced,
+		workqueue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "GroupBinding"),
+		recorder:             recorder,
+	}
+	klog.Info("Setting up event handlers")
+	groupBindingInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: ctl.enqueueGroupBinding,
+		UpdateFunc: func(old, new interface{}) {
+			ctl.enqueueGroupBinding(new)
+		},
+		DeleteFunc: ctl.enqueueGroupBinding,
+	})
+	return ctl
+}
+
+func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+	defer c.workqueue.ShutDown()
+
+	klog.Info("Starting GroupBinding controller")
+	klog.Info("Waiting for informer caches to sync")
+
+	synced := []cache.InformerSynced{c.groupBindingSynced}
+
+	if ok := cache.WaitForCacheSync(stopCh, synced...); !ok {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	klog.Info("Starting workers")
+	for i := 0; i < threadiness; i++ {
+		go wait.Until(c.runWorker, time.Second, stopCh)
+	}
+
+	klog.Info("Started workers")
+	<-stopCh
+	klog.Info("Shutting down workers")
+	return nil
+}
+
+func (c *Controller) enqueueGroupBinding(obj interface{}) {
+	var key string
+	var err error
+	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	c.workqueue.Add(key)
+}
+
+func (c *Controller) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *Controller) processNextWorkItem() bool {
+	obj, shutdown := c.workqueue.Get()
+
+	if shutdown {
+		return false
+	}
+
+	err := func(obj interface{}) error {
+		defer c.workqueue.Done(obj)
+		var key string
+		var ok bool
+		if key, ok = obj.(string); !ok {
+			c.workqueue.Forget(obj)
+			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			return nil
+		}
+		if err := c.reconcile(key); err != nil {
+			c.workqueue.AddRateLimited(key)
+			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
+		}
+		c.workqueue.Forget(obj)
+		klog.Infof("Successfully synced %s:%s", "key", key)
+		return nil
+	}(obj)
+
+	if err != nil {
+		utilruntime.HandleError(err)
+		return true
+	}
+
+	return true
+}
+
+// reconcile handles GroupBinding informer events, it updates user's Groups property with the current GroupBinding.
+func (c *Controller) reconcile(key string) error {
+
+	groupBinding, err := c.groupBindingLister.Get(key)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			utilruntime.HandleError(fmt.Errorf("groupbinding '%s' in work queue no longer exists", key))
+			return nil
+		}
+		klog.Error(err)
+		return err
+	}
+	if groupBinding.ObjectMeta.DeletionTimestamp.IsZero() {
+		if !sliceutil.HasString(groupBinding.Finalizers, finalizer) {
+			groupBinding.ObjectMeta.Finalizers = append(groupBinding.ObjectMeta.Finalizers, finalizer)
+			if groupBinding, err = c.ksClient.IamV1alpha2().GroupBindings().Update(groupBinding); err != nil {
+				return err
+			}
+			// Skip reconcile when groupbinding is updated.
+			return nil
+		}
+	} else {
+		// The object is being deleted
+		if sliceutil.HasString(groupBinding.ObjectMeta.Finalizers, finalizer) {
+			if err = c.unbindUser(groupBinding); err != nil {
+				klog.Error(err)
+				return err
+			}
+
+			groupBinding.Finalizers = sliceutil.RemoveString(groupBinding.ObjectMeta.Finalizers, func(item string) bool {
+				return item == finalizer
+			})
+
+			if groupBinding, err = c.ksClient.IamV1alpha2().GroupBindings().Update(groupBinding); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if err = c.bindUser(groupBinding); err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	c.recorder.Event(groupBinding, corev1.EventTypeNormal, successSynced, messageResourceSynced)
+	return nil
+}
+
+func (c *Controller) Start(stopCh <-chan struct{}) error {
+	return c.Run(2, stopCh)
+}
+
+func (c *Controller) unbindUser(groupBinding *iamv1alpha2.GroupBinding) error {
+	return c.updateUserGroups(groupBinding, func(groups []string, group string) (bool, []string) {
+		// remove a group from the groups
+		if sliceutil.HasString(groups, group) {
+			groups := sliceutil.RemoveString(groups, func(item string) bool {
+				return item == group
+			})
+			return true, groups
+		}
+		return false, groups
+	})
+}
+
+func (c *Controller) bindUser(groupBinding *iamv1alpha2.GroupBinding) error {
+	return c.updateUserGroups(groupBinding, func(groups []string, group string) (bool, []string) {
+		// add group to the groups
+		if !sliceutil.HasString(groups, group) {
+			groups := append(groups, group)
+			return true, groups
+		}
+		return false, groups
+	})
+}
+
+// Udpate user's Group property. So no need to query user's groups when authorizing.
+func (c *Controller) updateUserGroups(groupBinding *iamv1alpha2.GroupBinding, operator func(groups []string, group string) (bool, []string)) error {
+
+	for _, u := range groupBinding.Users {
+		// Ignore the user if the user if being deleted.
+		if user, err := c.ksClient.IamV1alpha2().Users().Get(u, metav1.GetOptions{}); err == nil && user.ObjectMeta.DeletionTimestamp.IsZero() {
+
+			if errors.IsNotFound(err) {
+				klog.Infof("user %s doesn't exist any more", u)
+				continue
+			}
+
+			if changed, groups := operator(user.Spec.Groups, groupBinding.GroupRef.Name); changed {
+
+				if err := c.patchUser(user, groups); err != nil {
+					if errors.IsNotFound(err) {
+						klog.Infof("user %s doesn't exist any more", u)
+						continue
+					}
+					klog.Error(err)
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (c *Controller) patchUser(user *iamv1alpha2.User, groups []string) error {
+	newUser := user.DeepCopy()
+	newUser.Spec.Groups = groups
+	patch := client.MergeFrom(user)
+	patchData, _ := patch.Data(newUser)
+	if _, err := c.ksClient.IamV1alpha2().Users().
+		Patch(user.Name, patch.Type(), patchData); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/controller/groupbinding/groupbinding_controller_test.go
+++ b/pkg/controller/groupbinding/groupbinding_controller_test.go
@@ -1,0 +1,338 @@
+/*
+Copyright 2020 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package groupbinding
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/diff"
+	kubeinformers "k8s.io/client-go/informers"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	v1alpha2 "kubesphere.io/kubesphere/pkg/apis/iam/v1alpha2"
+	"kubesphere.io/kubesphere/pkg/client/clientset/versioned/fake"
+	ksinformers "kubesphere.io/kubesphere/pkg/client/informers/externalversions"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	alwaysReady        = func() bool { return true }
+	noResyncPeriodFunc = func() time.Duration { return 0 }
+)
+
+type fixture struct {
+	t *testing.T
+
+	ksclient  *fake.Clientset
+	k8sclient *k8sfake.Clientset
+	// Objects to put in the store.
+	groupBindingLister []*v1alpha2.GroupBinding
+	userLister         []*v1alpha2.User
+	// Actions expected to happen on the client.
+	kubeactions []core.Action
+	actions     []core.Action
+	// Objects from here preloaded into NewSimpleFake.
+	kubeobjects []runtime.Object
+	objects     []runtime.Object
+}
+
+func newFixture(t *testing.T) *fixture {
+	f := &fixture{}
+	f.t = t
+	f.objects = []runtime.Object{}
+	f.kubeobjects = []runtime.Object{}
+	return f
+}
+
+func newGroupBinding(name string, users []string) *v1alpha2.GroupBinding {
+	return &v1alpha2.GroupBinding{
+		TypeMeta: metav1.TypeMeta{APIVersion: v1alpha2.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-binding", name),
+		},
+		GroupRef: v1alpha2.GroupRef{
+			Name: name,
+		},
+		Users: users,
+	}
+}
+
+func newUser(name string) *v1alpha2.User {
+	return &v1alpha2.User{
+		TypeMeta: metav1.TypeMeta{APIVersion: v1alpha2.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1alpha2.UserSpec{
+			Email:       fmt.Sprintf("%s@kubesphere.io", name),
+			Lang:        "zh-CN",
+			Description: "fake user",
+		},
+	}
+}
+
+func (f *fixture) newController() (*Controller, ksinformers.SharedInformerFactory, kubeinformers.SharedInformerFactory) {
+	f.ksclient = fake.NewSimpleClientset(f.objects...)
+	f.k8sclient = k8sfake.NewSimpleClientset(f.kubeobjects...)
+
+	ksinformers := ksinformers.NewSharedInformerFactory(f.ksclient, noResyncPeriodFunc())
+	k8sinformers := kubeinformers.NewSharedInformerFactory(f.k8sclient, noResyncPeriodFunc())
+
+	for _, groupBinding := range f.groupBindingLister {
+		err := ksinformers.Iam().V1alpha2().GroupBindings().Informer().GetIndexer().Add(groupBinding)
+		if err != nil {
+			f.t.Errorf("add groupBinding:%s", err)
+		}
+	}
+
+	for _, u := range f.userLister {
+		err := ksinformers.Iam().V1alpha2().Users().Informer().GetIndexer().Add(u)
+		if err != nil {
+			f.t.Errorf("add groupBinding:%s", err)
+		}
+	}
+
+	c := NewController(f.k8sclient, f.ksclient,
+		ksinformers.Iam().V1alpha2().GroupBindings())
+	c.groupBindingSynced = alwaysReady
+	c.recorder = &record.FakeRecorder{}
+
+	return c, ksinformers, k8sinformers
+}
+
+func (f *fixture) run(userName string) {
+	f.runController(userName, true, false)
+}
+
+func (f *fixture) runExpectError(userName string) {
+	f.runController(userName, true, true)
+}
+
+func (f *fixture) runController(groupBinding string, startInformers bool, expectError bool) {
+	c, i, k8sI := f.newController()
+	if startInformers {
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		i.Start(stopCh)
+		k8sI.Start(stopCh)
+	}
+
+	err := c.reconcile(groupBinding)
+	if !expectError && err != nil {
+		f.t.Errorf("error syncing groupBinding: %v", err)
+	} else if expectError && err == nil {
+		f.t.Error("expected error syncing groupBinding, got nil")
+	}
+
+	actions := filterInformerActions(f.ksclient.Actions())
+	for i, action := range actions {
+		if len(f.actions) < i+1 {
+			f.t.Errorf("%d unexpected actions: %+v", len(actions)-len(f.actions), actions[i:])
+			break
+		}
+
+		expectedAction := f.actions[i]
+		checkAction(expectedAction, action, f.t)
+	}
+
+	if len(f.actions) > len(actions) {
+		f.t.Errorf("%d additional expected actions:%+v", len(f.actions)-len(actions), f.actions[len(actions):])
+	}
+
+	k8sActions := filterInformerActions(f.k8sclient.Actions())
+	for i, action := range k8sActions {
+		if len(f.kubeactions) < i+1 {
+			f.t.Errorf("%d unexpected actions: %+v", len(k8sActions)-len(f.kubeactions), k8sActions[i:])
+			break
+		}
+
+		expectedAction := f.kubeactions[i]
+		checkAction(expectedAction, action, f.t)
+	}
+
+	if len(f.kubeactions) > len(k8sActions) {
+		f.t.Errorf("%d additional expected actions:%+v", len(f.kubeactions)-len(k8sActions), f.kubeactions[len(k8sActions):])
+	}
+}
+
+// checkAction verifies that expected and actual actions are equal and both have
+// same attached resources
+func checkAction(expected, actual core.Action, t *testing.T) {
+	if !(expected.Matches(actual.GetVerb(), actual.GetResource().Resource) && actual.GetSubresource() == expected.GetSubresource()) {
+		t.Errorf("Expected\n\t%#v\ngot\n\t%#v", expected, actual)
+		return
+	}
+
+	if reflect.TypeOf(actual) != reflect.TypeOf(expected) {
+		t.Errorf("Action has wrong type. Expected: %t. Got: %t", expected, actual)
+		return
+	}
+
+	switch a := actual.(type) {
+	case core.CreateActionImpl:
+		e, _ := expected.(core.CreateActionImpl)
+		expObject := e.GetObject()
+		object := a.GetObject()
+
+		if !reflect.DeepEqual(expObject, object) {
+			t.Errorf("Action %s %s has wrong object\nDiff:\n %s",
+				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintSideBySide(expObject, object))
+		}
+	case core.UpdateActionImpl:
+		e, _ := expected.(core.UpdateActionImpl)
+		expObject := e.GetObject()
+		object := a.GetObject()
+		expUser := expObject.(*v1alpha2.GroupBinding)
+		groupBinding := object.(*v1alpha2.GroupBinding)
+
+		if !reflect.DeepEqual(expUser, groupBinding) {
+			t.Errorf("Action %s %s has wrong object\nDiff:\n %s",
+				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintSideBySide(expObject, object))
+		}
+	case core.PatchActionImpl:
+		e, _ := expected.(core.PatchActionImpl)
+		expPatch := e.GetPatch()
+		patch := a.GetPatch()
+
+		if !reflect.DeepEqual(expPatch, patch) {
+			t.Errorf("Action %s %s has wrong patch\nDiff:\n %s",
+				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintSideBySide(expPatch, patch))
+		}
+	default:
+		t.Errorf("Uncaptured Action %s %s, you should explicitly add a case to capture it",
+			actual.GetVerb(), actual.GetResource().Resource)
+	}
+}
+
+// filterInformerActions filters list and watch actions for testing resources.
+// Since list and watch don't change resource state we can filter it to lower
+// nose level in our tests.
+func filterInformerActions(actions []core.Action) []core.Action {
+	var ret []core.Action
+	for _, action := range actions {
+		if len(action.GetNamespace()) == 0 &&
+			(action.Matches("list", "groupbindings") ||
+				action.Matches("watch", "groupbindings") ||
+				action.Matches("list", "users") ||
+				action.Matches("watch", "users") ||
+				action.Matches("get", "users")) {
+			continue
+		}
+		ret = append(ret, action)
+	}
+
+	return ret
+}
+
+func (f *fixture) expectUpdateGroupsFinalizerAction(groupBinding *v1alpha2.GroupBinding) {
+	expect := groupBinding.DeepCopy()
+	expect.Finalizers = []string{"finalizers.kubesphere.io/groupsbindings"}
+	action := core.NewUpdateAction(schema.GroupVersionResource{Group: "iam.kubesphere.io", Version: "v1alpha2", Resource: "groupbindings"}, "", expect)
+	f.actions = append(f.actions, action)
+}
+
+func (f *fixture) expectUpdateGroupsDeleteAction(groupBinding *v1alpha2.GroupBinding) {
+	expect := groupBinding.DeepCopy()
+	expect.Finalizers = []string{}
+	action := core.NewUpdateAction(schema.GroupVersionResource{Group: "iam.kubesphere.io", Version: "v1alpha2", Resource: "groupbindings"}, "", expect)
+	f.actions = append(f.actions, action)
+}
+
+func (f *fixture) expectPatchUserAction(user *v1alpha2.User, groups []string) {
+	newUser := user.DeepCopy()
+	newUser.Spec.Groups = groups
+	patch := client.MergeFrom(user)
+	patchData, _ := patch.Data(newUser)
+
+	f.actions = append(f.actions, core.NewPatchAction(schema.GroupVersionResource{Group: "iam.kubesphere.io", Resource: "users", Version: "v1alpha2"}, user.Namespace, user.Name, patch.Type(), patchData))
+}
+
+func getKey(groupBinding *v1alpha2.GroupBinding, t *testing.T) string {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(groupBinding)
+	if err != nil {
+		t.Errorf("Unexpected error getting key for groupBinding %v: %v", groupBinding.Name, err)
+		return ""
+	}
+	return key
+}
+
+func TestCreatesGroupBinding(t *testing.T) {
+	f := newFixture(t)
+
+	users := []string{"user1"}
+	groupbinding := newGroupBinding("test", users)
+	groupbinding.ObjectMeta.Finalizers = append(groupbinding.ObjectMeta.Finalizers, finalizer)
+	f.groupBindingLister = append(f.groupBindingLister, groupbinding)
+	f.objects = append(f.objects, groupbinding)
+
+	user := newUser("user1")
+	f.userLister = append(f.userLister, user)
+
+	f.objects = append(f.objects, user)
+
+	excepctGroups := []string{"test"}
+	f.expectPatchUserAction(user, excepctGroups)
+
+	f.run(getKey(groupbinding, t))
+}
+
+func TestDeletesGroupBinding(t *testing.T) {
+	f := newFixture(t)
+
+	users := []string{"user1"}
+	groupbinding := newGroupBinding("test", users)
+	deletedGroup := groupbinding.DeepCopy()
+	deletedGroup.Finalizers = append(groupbinding.ObjectMeta.Finalizers, finalizer)
+
+	now := metav1.Now()
+	deletedGroup.ObjectMeta.DeletionTimestamp = &now
+
+	f.groupBindingLister = append(f.groupBindingLister, deletedGroup)
+	f.objects = append(f.objects, deletedGroup)
+
+	user := newUser("user1")
+	user.Spec.Groups = []string{"test"}
+	f.userLister = append(f.userLister, user)
+	f.objects = append(f.objects, user)
+
+	f.expectPatchUserAction(user, nil)
+	f.expectUpdateGroupsDeleteAction(deletedGroup)
+
+	f.run(getKey(deletedGroup, t))
+}
+
+func TestDoNothing(t *testing.T) {
+	f := newFixture(t)
+	users := []string{"user1"}
+	groupBinding := newGroupBinding("test", users)
+
+	f.groupBindingLister = append(f.groupBindingLister, groupBinding)
+	f.objects = append(f.objects, groupBinding)
+
+	f.expectUpdateGroupsFinalizerAction(groupBinding)
+	f.run(getKey(groupBinding, t))
+
+}

--- a/pkg/controller/user/user_controller.go
+++ b/pkg/controller/user/user_controller.go
@@ -19,6 +19,10 @@ package user
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"strconv"
+	"time"
+
 	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -49,10 +53,7 @@ import (
 	"kubesphere.io/kubesphere/pkg/simple/client/devops"
 	ldapclient "kubesphere.io/kubesphere/pkg/simple/client/ldap"
 	"kubesphere.io/kubesphere/pkg/utils/sliceutil"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strconv"
-	"time"
 )
 
 const (
@@ -286,12 +287,20 @@ func (c *Controller) reconcile(key string) error {
 		if sliceutil.HasString(user.ObjectMeta.Finalizers, finalizer) {
 
 			klog.V(4).Infof("delete user %s", key)
-			if err = c.ldapClient.Delete(key); err != nil && err != ldapclient.ErrUserNotExists {
+			// we do not need to delete the user from ldapServer when ldapClient is nil
+			if c.ldapClient != nil {
+				if err = c.ldapClient.Delete(key); err != nil && err != ldapclient.ErrUserNotExists {
+					klog.Error(err)
+					return err
+				}
+			}
+
+			if err = c.deleteRoleBindings(user); err != nil {
 				klog.Error(err)
 				return err
 			}
 
-			if err = c.deleteRoleBindings(user); err != nil {
+			if err = c.deleteGroupBindings(user); err != nil {
 				klog.Error(err)
 				return err
 			}
@@ -323,9 +332,12 @@ func (c *Controller) reconcile(key string) error {
 		return nil
 	}
 
-	if err = c.ldapSync(user); err != nil {
-		klog.Error(err)
-		return err
+	// we do not need to sync ldap info when ldapClient is nil
+	if c.ldapClient != nil {
+		if err = c.ldapSync(user); err != nil {
+			klog.Error(err)
+			return err
+		}
 	}
 
 	if user, err = c.ensurePasswordIsEncrypted(user); err != nil {
@@ -550,6 +562,22 @@ func (c *Controller) ldapSync(user *iamv1alpha2.User) error {
 		klog.V(4).Infof("update user %s", user.Name)
 		return c.ldapClient.Update(user)
 	}
+}
+
+func (c *Controller) deleteGroupBindings(user *iamv1alpha2.User) error {
+
+	// Groupbindings that created by kubeshpere will be deleted directly.
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{iamv1alpha2.UserReferenceLabel: user.Name}).String(),
+	}
+	deleteOptions := metav1.NewDeleteOptions(0)
+
+	if err := c.ksClient.IamV1alpha2().GroupBindings().
+		DeleteCollection(deleteOptions, listOptions); err != nil {
+		klog.Error(err)
+		return err
+	}
+	return nil
 }
 
 func (c *Controller) deleteRoleBindings(user *iamv1alpha2.User) error {

--- a/pkg/models/iam/group/group.go
+++ b/pkg/models/iam/group/group.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2020 KubeSphere Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+	"kubesphere.io/kubesphere/pkg/api"
+	iamv1alpha2 "kubesphere.io/kubesphere/pkg/apis/iam/v1alpha2"
+	tenantv1alpha1 "kubesphere.io/kubesphere/pkg/apis/tenant/v1alpha1"
+	"kubesphere.io/kubesphere/pkg/apiserver/query"
+	kubesphere "kubesphere.io/kubesphere/pkg/client/clientset/versioned"
+	"kubesphere.io/kubesphere/pkg/informers"
+	resourcesv1alpha3 "kubesphere.io/kubesphere/pkg/models/resources/v1alpha3/resource"
+)
+
+type GroupOperator interface {
+	ListGroups(workspace string, queryParam *query.Query) (*api.ListResult, error)
+	CreateGroup(workspace string, namespace *iamv1alpha2.Group) (*iamv1alpha2.Group, error)
+	DescribeGroup(workspace, group string) (*iamv1alpha2.Group, error)
+	DeleteGroup(workspace, group string) error
+	UpdateGroup(workspace string, group *iamv1alpha2.Group) (*iamv1alpha2.Group, error)
+	PatchGroup(workspace string, group *iamv1alpha2.Group) (*iamv1alpha2.Group, error)
+	DeleteGroupBinding(workspace, name string) error
+	CreateGroupBinding(workspace, groupName, userName string) error
+	ListGroupBindings(workspace, group string, queryParam *query.Query) (*api.ListResult, error)
+}
+
+type groupOperator struct {
+	k8sclient      kubernetes.Interface
+	ksclient       kubesphere.Interface
+	resourceGetter *resourcesv1alpha3.ResourceGetter
+}
+
+func New(informers informers.InformerFactory, ksclient kubesphere.Interface, k8sclient kubernetes.Interface) GroupOperator {
+	return &groupOperator{
+		resourceGetter: resourcesv1alpha3.NewResourceGetter(informers),
+		k8sclient:      k8sclient,
+		ksclient:       ksclient,
+	}
+}
+
+func (t *groupOperator) ListGroups(workspace string, queryParam *query.Query) (*api.ListResult, error) {
+
+	if workspace != "" {
+		// filter by workspace
+		queryParam.Filters[query.FieldLabel] = query.Value(fmt.Sprintf("%s=%s", tenantv1alpha1.WorkspaceLabel, workspace))
+	}
+
+	result, err := t.resourceGetter.List("groups", "", queryParam)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+	return result, nil
+}
+
+// CreateGroup adds a workspace label to group which indicates group is under the workspace
+func (t *groupOperator) CreateGroup(workspace string, namespace *iamv1alpha2.Group) (*iamv1alpha2.Group, error) {
+	return t.ksclient.IamV1alpha2().Groups().Create(labelGroupWithWorkspaceName(namespace, workspace))
+}
+
+func (t *groupOperator) DescribeGroup(workspace, group string) (*iamv1alpha2.Group, error) {
+	obj, err := t.resourceGetter.Get("groups", "", group)
+	if err != nil {
+		return nil, err
+	}
+	ns := obj.(*iamv1alpha2.Group)
+	if ns.Labels[tenantv1alpha1.WorkspaceLabel] != workspace {
+		err := errors.NewNotFound(corev1.Resource("group"), group)
+		klog.Error(err)
+		return nil, err
+	}
+	return ns, nil
+}
+
+func (t *groupOperator) DeleteGroup(workspace, group string) error {
+	_, err := t.DescribeGroup(workspace, group)
+	if err != nil {
+		return err
+	}
+	return t.ksclient.IamV1alpha2().Groups().Delete(group, metav1.NewDeleteOptions(0))
+}
+
+func (t *groupOperator) UpdateGroup(workspace string, group *iamv1alpha2.Group) (*iamv1alpha2.Group, error) {
+	_, err := t.DescribeGroup(workspace, group.Name)
+	if err != nil {
+		return nil, err
+	}
+	group = labelGroupWithWorkspaceName(group, workspace)
+	return t.ksclient.IamV1alpha2().Groups().Update(group)
+}
+
+func (t *groupOperator) PatchGroup(workspace string, group *iamv1alpha2.Group) (*iamv1alpha2.Group, error) {
+	_, err := t.DescribeGroup(workspace, group.Name)
+	if err != nil {
+		return nil, err
+	}
+	if group.Labels != nil {
+		group.Labels[tenantv1alpha1.WorkspaceLabel] = workspace
+	}
+	data, err := json.Marshal(group)
+	if err != nil {
+		return nil, err
+	}
+	return t.ksclient.IamV1alpha2().Groups().Patch(group.Name, types.MergePatchType, data)
+}
+
+func (t *groupOperator) DeleteGroupBinding(workspace, name string) error {
+	obj, err := t.resourceGetter.Get("groupbindings", "", name)
+	if err != nil {
+		return err
+	}
+	ns := obj.(*iamv1alpha2.GroupBinding)
+	if ns.Labels[tenantv1alpha1.WorkspaceLabel] != workspace {
+		err := errors.NewNotFound(corev1.Resource("groupbinding"), name)
+		klog.Error(err)
+		return err
+	}
+
+	return t.ksclient.IamV1alpha2().GroupBindings().Delete(name, metav1.NewDeleteOptions(0))
+}
+
+func (t *groupOperator) CreateGroupBinding(workspace, groupName, userName string) error {
+
+	groupBinding := iamv1alpha2.GroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-%s", groupName, userName),
+			Labels: map[string]string{
+				iamv1alpha2.UserReferenceLabel:  userName,
+				iamv1alpha2.GroupReferenceLabel: groupName,
+				tenantv1alpha1.WorkspaceLabel:   workspace,
+			},
+		},
+		Users: []string{userName},
+		GroupRef: iamv1alpha2.GroupRef{
+			APIGroup: iamv1alpha2.SchemeGroupVersion.Group,
+			Kind:     iamv1alpha2.ResourcePluralGroup,
+			Name:     groupName,
+		},
+	}
+
+	if _, err := t.ksclient.IamV1alpha2().GroupBindings().Create(&groupBinding); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *groupOperator) ListGroupBindings(workspace, group string, queryParam *query.Query) (*api.ListResult, error) {
+
+	if group != "" && workspace != "" {
+		// filter by group
+		queryParam.Filters[query.FieldLabel] = query.Value(fmt.Sprintf("%s=%s", iamv1alpha2.GroupReferenceLabel, group))
+	}
+
+	result, err := t.resourceGetter.List("groupbindings", "", queryParam)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+	return result, nil
+}
+
+// labelGroupWithWorkspaceName adds a kubesphere.io/workspace=[workspaceName] label to namespace which
+// indicates namespace is under the workspace
+func labelGroupWithWorkspaceName(namespace *iamv1alpha2.Group, workspaceName string) *iamv1alpha2.Group {
+	if namespace.Labels == nil {
+		namespace.Labels = make(map[string]string, 0)
+	}
+
+	namespace.Labels[tenantv1alpha1.WorkspaceLabel] = workspaceName // label namespace with workspace name
+
+	return namespace
+}

--- a/pkg/models/iam/im/authenticator.go
+++ b/pkg/models/iam/im/authenticator.go
@@ -20,6 +20,8 @@ package im
 
 import (
 	"fmt"
+	"net/mail"
+
 	"github.com/go-ldap/ldap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -32,7 +34,6 @@ import (
 	kubesphere "kubesphere.io/kubesphere/pkg/client/clientset/versioned"
 	iamv1alpha2listers "kubesphere.io/kubesphere/pkg/client/listers/iam/v1alpha2"
 	"kubesphere.io/kubesphere/pkg/constants"
-	"net/mail"
 )
 
 var (
@@ -131,8 +132,9 @@ func (im *passwordAuthenticator) Authenticate(username, password string) (authus
 
 	if checkPasswordHash(password, user.Spec.EncryptedPassword) {
 		return &authuser.DefaultInfo{
-			Name: user.Name,
-			UID:  string(user.UID),
+			Name:   user.Name,
+			UID:    string(user.UID),
+			Groups: user.Spec.Groups,
 		}, nil
 	}
 

--- a/pkg/models/resources/v1alpha3/group/group.go
+++ b/pkg/models/resources/v1alpha3/group/group.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 KubeSphere Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"kubesphere.io/kubesphere/pkg/api"
+	"kubesphere.io/kubesphere/pkg/apis/iam/v1alpha2"
+	"kubesphere.io/kubesphere/pkg/apiserver/query"
+	informers "kubesphere.io/kubesphere/pkg/client/informers/externalversions"
+	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3"
+)
+
+type groupGetter struct {
+	sharedInformers informers.SharedInformerFactory
+}
+
+func New(sharedInformers informers.SharedInformerFactory) v1alpha3.Interface {
+	return &groupGetter{sharedInformers: sharedInformers}
+}
+
+func (d *groupGetter) Get(_, name string) (runtime.Object, error) {
+	return d.sharedInformers.Iam().V1alpha2().Groups().Lister().Get(name)
+}
+
+func (d *groupGetter) List(_ string, query *query.Query) (*api.ListResult, error) {
+
+	groups, err := d.sharedInformers.Iam().V1alpha2().Groups().Lister().List(query.Selector())
+	if err != nil {
+		return nil, err
+	}
+
+	var result []runtime.Object
+	for _, group := range groups {
+		result = append(result, group)
+	}
+
+	return v1alpha3.DefaultList(result, query, d.compare, d.filter), nil
+}
+
+func (d *groupGetter) compare(left runtime.Object, right runtime.Object, field query.Field) bool {
+
+	leftGroup, ok := left.(*v1alpha2.Group)
+	if !ok {
+		return false
+	}
+
+	rightGroup, ok := right.(*v1alpha2.Group)
+	if !ok {
+		return false
+	}
+
+	return v1alpha3.DefaultObjectMetaCompare(leftGroup.ObjectMeta, rightGroup.ObjectMeta, field)
+}
+
+func (d *groupGetter) filter(object runtime.Object, filter query.Filter) bool {
+	group, ok := object.(*v1alpha2.Group)
+
+	if !ok {
+		return false
+	}
+
+	return v1alpha3.DefaultObjectMetaFilter(group.ObjectMeta, filter)
+}

--- a/pkg/models/resources/v1alpha3/group/group_test.go
+++ b/pkg/models/resources/v1alpha3/group/group_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2020 KubeSphere Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kubesphere.io/kubesphere/pkg/api"
+	"kubesphere.io/kubesphere/pkg/apis/iam/v1alpha2"
+	"kubesphere.io/kubesphere/pkg/apiserver/query"
+	"kubesphere.io/kubesphere/pkg/client/clientset/versioned/fake"
+	informers "kubesphere.io/kubesphere/pkg/client/informers/externalversions"
+	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3"
+)
+
+func TestListWorkspaces(t *testing.T) {
+	tests := []struct {
+		description string
+		namespace   string
+		query       *query.Query
+		expected    *api.ListResult
+		expectedErr error
+	}{
+		{
+			"test name filter",
+			"bar",
+			&query.Query{
+				Pagination: &query.Pagination{
+					Limit:  1,
+					Offset: 0,
+				},
+				SortBy:    query.FieldName,
+				Ascending: false,
+				Filters:   map[query.Field]query.Value{query.FieldName: query.Value("foo2")},
+			},
+			&api.ListResult{
+				Items: []interface{}{
+					foo2,
+				},
+				TotalItems: 1,
+			},
+			nil,
+		},
+	}
+
+	getter := prepare()
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+
+			got, err := getter.List(test.namespace, test.query)
+
+			if test.expectedErr != nil && err != test.expectedErr {
+				t.Errorf("expected error, got nothing")
+			} else if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("%T differ (-got, +want): %s", test.expected, diff)
+			}
+		})
+	}
+}
+
+var (
+	foo1 = &v1alpha2.Group{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo1",
+		},
+	}
+
+	foo2 = &v1alpha2.Group{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo2",
+		},
+	}
+	bar1 = &v1alpha2.Group{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bar1",
+		},
+	}
+
+	groups = []interface{}{foo1, foo2, bar1}
+)
+
+func prepare() v1alpha3.Interface {
+	client := fake.NewSimpleClientset()
+	informer := informers.NewSharedInformerFactory(client, 0)
+
+	for _, group := range groups {
+		informer.Iam().V1alpha2().Groups().Informer().GetIndexer().Add(group)
+	}
+	return New(informer)
+}

--- a/pkg/models/resources/v1alpha3/groupbinding/groupbinding.go
+++ b/pkg/models/resources/v1alpha3/groupbinding/groupbinding.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 KubeSphere Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package groupbinding
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"kubesphere.io/kubesphere/pkg/api"
+	"kubesphere.io/kubesphere/pkg/apis/iam/v1alpha2"
+	"kubesphere.io/kubesphere/pkg/apiserver/query"
+	informers "kubesphere.io/kubesphere/pkg/client/informers/externalversions"
+	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3"
+)
+
+type groupBindingGetter struct {
+	sharedInformers informers.SharedInformerFactory
+}
+
+func New(sharedInformers informers.SharedInformerFactory) v1alpha3.Interface {
+	return &groupBindingGetter{sharedInformers: sharedInformers}
+}
+
+func (d *groupBindingGetter) Get(_, name string) (runtime.Object, error) {
+	return d.sharedInformers.Iam().V1alpha2().GroupBindings().Lister().Get(name)
+}
+
+func (d *groupBindingGetter) List(_ string, query *query.Query) (*api.ListResult, error) {
+
+	groupBindings, err := d.sharedInformers.Iam().V1alpha2().GroupBindings().Lister().List(query.Selector())
+	if err != nil {
+		return nil, err
+	}
+
+	var result []runtime.Object
+	for _, groupBinding := range groupBindings {
+		result = append(result, groupBinding)
+	}
+
+	return v1alpha3.DefaultList(result, query, d.compare, d.filter), nil
+}
+
+func (d *groupBindingGetter) compare(left runtime.Object, right runtime.Object, field query.Field) bool {
+
+	leftGroupBinding, ok := left.(*v1alpha2.GroupBinding)
+	if !ok {
+		return false
+	}
+
+	rightGroupBinding, ok := right.(*v1alpha2.GroupBinding)
+	if !ok {
+		return false
+	}
+
+	return v1alpha3.DefaultObjectMetaCompare(leftGroupBinding.ObjectMeta, rightGroupBinding.ObjectMeta, field)
+}
+
+func (d *groupBindingGetter) filter(object runtime.Object, filter query.Filter) bool {
+	groupbinding, ok := object.(*v1alpha2.GroupBinding)
+
+	if !ok {
+		return false
+	}
+
+	return v1alpha3.DefaultObjectMetaFilter(groupbinding.ObjectMeta, filter)
+}

--- a/pkg/models/resources/v1alpha3/groupbinding/groupbinding_test.go
+++ b/pkg/models/resources/v1alpha3/groupbinding/groupbinding_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2020 KubeSphere Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package groupbinding
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kubesphere.io/kubesphere/pkg/api"
+	"kubesphere.io/kubesphere/pkg/apis/iam/v1alpha2"
+	"kubesphere.io/kubesphere/pkg/apiserver/query"
+	"kubesphere.io/kubesphere/pkg/client/clientset/versioned/fake"
+	informers "kubesphere.io/kubesphere/pkg/client/informers/externalversions"
+	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3"
+)
+
+func TestListWorkspaces(t *testing.T) {
+	tests := []struct {
+		description string
+		namespace   string
+		query       *query.Query
+		expected    *api.ListResult
+		expectedErr error
+	}{
+		{
+			"test name filter",
+			"bar",
+			&query.Query{
+				Pagination: &query.Pagination{
+					Limit:  1,
+					Offset: 0,
+				},
+				SortBy:    query.FieldName,
+				Ascending: false,
+				Filters:   map[query.Field]query.Value{query.FieldName: query.Value("foo2")},
+			},
+			&api.ListResult{
+				Items: []interface{}{
+					foo2,
+				},
+				TotalItems: 1,
+			},
+			nil,
+		},
+	}
+
+	getter := prepare()
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+
+			got, err := getter.List(test.namespace, test.query)
+
+			if test.expectedErr != nil && err != test.expectedErr {
+				t.Errorf("expected error, got nothing")
+			} else if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("%T differ (-got, +want): %s", test.expected, diff)
+			}
+		})
+	}
+}
+
+var (
+	foo1 = &v1alpha2.GroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo1",
+		},
+	}
+
+	foo2 = &v1alpha2.GroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo2",
+		},
+	}
+	bar1 = &v1alpha2.GroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bar1",
+		},
+	}
+
+	groupBindings = []interface{}{foo1, foo2, bar1}
+)
+
+func prepare() v1alpha3.Interface {
+	client := fake.NewSimpleClientset()
+	informer := informers.NewSharedInformerFactory(client, 0)
+
+	for _, groupBinding := range groupBindings {
+		informer.Iam().V1alpha2().GroupBindings().Informer().GetIndexer().Add(groupBinding)
+	}
+	return New(informer)
+}

--- a/pkg/models/resources/v1alpha3/resource/resource.go
+++ b/pkg/models/resources/v1alpha3/resource/resource.go
@@ -18,6 +18,7 @@ package resource
 
 import (
 	"errors"
+
 	snapshotv1beta1 "github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -51,6 +52,8 @@ import (
 	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3/federatedstatefulset"
 	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3/globalrole"
 	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3/globalrolebinding"
+	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3/group"
+	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3/groupbinding"
 	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3/ingress"
 	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3/job"
 	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3/loginrecord"
@@ -103,6 +106,8 @@ func NewResourceGetter(factory informers.InformerFactory) *ResourceGetter {
 	getters[iamv1alpha2.SchemeGroupVersion.WithResource(iamv1alpha2.ResourcesPluralGlobalRoleBinding)] = globalrolebinding.New(factory.KubeSphereSharedInformerFactory())
 	getters[iamv1alpha2.SchemeGroupVersion.WithResource(iamv1alpha2.ResourcesPluralWorkspaceRoleBinding)] = workspacerolebinding.New(factory.KubeSphereSharedInformerFactory())
 	getters[iamv1alpha2.SchemeGroupVersion.WithResource(iamv1alpha2.ResourcesPluralLoginRecord)] = loginrecord.New(factory.KubeSphereSharedInformerFactory())
+	getters[iamv1alpha2.SchemeGroupVersion.WithResource(iamv1alpha2.ResourcePluralGroup)] = group.New(factory.KubeSphereSharedInformerFactory())
+	getters[iamv1alpha2.SchemeGroupVersion.WithResource(iamv1alpha2.ResourcePluralGroupBinding)] = groupbinding.New(factory.KubeSphereSharedInformerFactory())
 	getters[rbacv1.SchemeGroupVersion.WithResource(iamv1alpha2.ResourcesPluralRole)] = role.New(factory.KubernetesSharedInformerFactory())
 	getters[rbacv1.SchemeGroupVersion.WithResource(iamv1alpha2.ResourcesPluralClusterRole)] = clusterrole.New(factory.KubernetesSharedInformerFactory())
 	getters[rbacv1.SchemeGroupVersion.WithResource(iamv1alpha2.ResourcesPluralRoleBinding)] = rolebinding.New(factory.KubernetesSharedInformerFactory())

--- a/pkg/models/tenant/devops.go
+++ b/pkg/models/tenant/devops.go
@@ -18,6 +18,7 @@ package tenant
 
 import (
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -66,7 +67,7 @@ func (t *tenantOperator) ListDevOpsProjects(user user.Info, workspace string, qu
 		return result, nil
 	}
 
-	roleBindings, err := t.am.ListRoleBindings(user.GetName(), "")
+	roleBindings, err := t.am.ListRoleBindings(user.GetName(), user.GetGroups(), "")
 	if err != nil {
 		klog.Error(err)
 		return nil, err

--- a/pkg/models/tenant/tenant.go
+++ b/pkg/models/tenant/tenant.go
@@ -20,6 +20,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,8 +56,6 @@ import (
 	eventsclient "kubesphere.io/kubesphere/pkg/simple/client/events"
 	loggingclient "kubesphere.io/kubesphere/pkg/simple/client/logging"
 	"kubesphere.io/kubesphere/pkg/utils/stringutils"
-	"strings"
-	"time"
 )
 
 type Interface interface {
@@ -134,7 +135,7 @@ func (t *tenantOperator) ListWorkspaces(user user.Info, queryParam *query.Query)
 	}
 
 	// retrieving associated resources through role binding
-	workspaceRoleBindings, err := t.am.ListWorkspaceRoleBindings(user.GetName(), "")
+	workspaceRoleBindings, err := t.am.ListWorkspaceRoleBindings(user.GetName(), user.GetGroups(), "")
 	if err != nil {
 		klog.Error(err)
 		return nil, err
@@ -205,7 +206,7 @@ func (t *tenantOperator) ListFederatedNamespaces(user user.Info, workspace strin
 	}
 
 	// retrieving associated resources through role binding
-	roleBindings, err := t.am.ListRoleBindings(user.GetName(), "")
+	roleBindings, err := t.am.ListRoleBindings(user.GetName(), user.GetGroups(), "")
 	if err != nil {
 		klog.Error(err)
 		return nil, err
@@ -273,7 +274,7 @@ func (t *tenantOperator) ListNamespaces(user user.Info, workspace string, queryP
 	}
 
 	// retrieving associated resources through role binding
-	roleBindings, err := t.am.ListRoleBindings(user.GetName(), "")
+	roleBindings, err := t.am.ListRoleBindings(user.GetName(), user.GetGroups(), "")
 	if err != nil {
 		klog.Error(err)
 		return nil, err
@@ -472,7 +473,7 @@ func (t *tenantOperator) ListClusters(user user.Info) (*api.ListResult, error) {
 		return result, nil
 	}
 
-	workspaceRoleBindings, err := t.am.ListWorkspaceRoleBindings(user.GetName(), "")
+	workspaceRoleBindings, err := t.am.ListWorkspaceRoleBindings(user.GetName(), user.GetGroups(), "")
 
 	if err != nil {
 		klog.Error(err)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -145,10 +145,10 @@ var _ = Describe("E2e for network policy", func() {
 		job := obj.(*batchv1.Job)
 		selector, _ := labels.Parse("app=nginx")
 		podlist := &corev1.PodList{}
-		Expect(ctx.Client.List(context.TODO(), &client.ListOptions{
+		Expect(ctx.Client.List(context.TODO(), podlist, &client.ListOptions{
 			Namespace:     deploy.Namespace,
 			LabelSelector: selector,
-		}, podlist)).ShouldNot(HaveOccurred())
+		})).ShouldNot(HaveOccurred())
 		Expect(podlist.Items).To(HaveLen(int(*deploy.Spec.Replicas)))
 		podip := podlist.Items[0].Status.PodIP
 		job.Spec.Template.Spec.Containers[0].Command = []string{"ping", "-c", "4", podip}

--- a/tools/cmd/doc-gen/main.go
+++ b/tools/cmd/doc-gen/main.go
@@ -21,14 +21,16 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"log"
+
 	"github.com/emicklei/go-restful"
-	"github.com/emicklei/go-restful-openapi"
+	restfulspec "github.com/emicklei/go-restful-openapi"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/validate"
 	"github.com/pkg/errors"
-	"io/ioutil"
 	urlruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog"
 	authoptions "kubesphere.io/kubesphere/pkg/apiserver/authentication/options"
@@ -50,13 +52,13 @@ import (
 	tenantv1alpha2 "kubesphere.io/kubesphere/pkg/kapis/tenant/v1alpha2"
 	terminalv1alpha2 "kubesphere.io/kubesphere/pkg/kapis/terminal/v1alpha2"
 	"kubesphere.io/kubesphere/pkg/models/iam/am"
+	"kubesphere.io/kubesphere/pkg/models/iam/group"
 	"kubesphere.io/kubesphere/pkg/models/iam/im"
 	fakedevops "kubesphere.io/kubesphere/pkg/simple/client/devops/fake"
 	"kubesphere.io/kubesphere/pkg/simple/client/k8s"
 	"kubesphere.io/kubesphere/pkg/simple/client/openpitrix"
 	fakes3 "kubesphere.io/kubesphere/pkg/simple/client/s3/fake"
 	"kubesphere.io/kubesphere/pkg/version"
-	"log"
 )
 
 var output string
@@ -119,7 +121,7 @@ func generateSwaggerJson() []byte {
 		informerFactory.KubeSphereSharedInformerFactory(), "", "", ""))
 	urlruntime.Must(devopsv1alpha2.AddToContainer(container, informerFactory.KubeSphereSharedInformerFactory(), &fakedevops.Devops{}, nil, clientsets.KubeSphere(), fakes3.NewFakeS3(), ""))
 	urlruntime.Must(devopsv1alpha3.AddToContainer(container, &fakedevops.Devops{}, clientsets.Kubernetes(), clientsets.KubeSphere(), informerFactory.KubeSphereSharedInformerFactory(), informerFactory.KubernetesSharedInformerFactory()))
-	urlruntime.Must(iamv1alpha2.AddToContainer(container, im.NewOperator(clientsets.KubeSphere(), informerFactory, nil), am.NewReadOnlyOperator(informerFactory), authoptions.NewAuthenticateOptions()))
+	urlruntime.Must(iamv1alpha2.AddToContainer(container, im.NewOperator(clientsets.KubeSphere(), informerFactory, nil), am.NewReadOnlyOperator(informerFactory), group.New(informerFactory, clientsets.KubeSphere(), clientsets.Kubernetes()), authoptions.NewAuthenticateOptions()))
 	urlruntime.Must(monitoringv1alpha3.AddToContainer(container, clientsets.Kubernetes(), nil, informerFactory, nil))
 	urlruntime.Must(openpitrixv1.AddToContainer(container, informerFactory, openpitrix.NewMockClient(nil)))
 	urlruntime.Must(operationsv1alpha2.AddToContainer(container, clientsets.Kubernetes()))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -136,9 +136,9 @@ github.com/elastic/go-elasticsearch/v7/estransport
 github.com/elastic/go-elasticsearch/v7/internal/version
 # github.com/emicklei/go-restful v2.14.3+incompatible => github.com/emicklei/go-restful v2.14.3+incompatible
 github.com/emicklei/go-restful
+github.com/emicklei/go-restful/log
 # github.com/emicklei/go-restful-openapi v1.4.1 => github.com/emicklei/go-restful-openapi v1.4.1
 github.com/emicklei/go-restful-openapi
-github.com/emicklei/go-restful/log
 # github.com/emirpasic/gods v1.12.0 => github.com/emirpasic/gods v1.12.0
 github.com/emirpasic/gods/containers
 github.com/emirpasic/gods/lists
@@ -304,7 +304,7 @@ github.com/jmespath/go-jmespath
 github.com/json-iterator/go
 # github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e => github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e
 github.com/kevinburke/ssh_config
-# github.com/kiali/kiali v0.15.1-0.20200520152915-769a61d75460 => github.com/kubesphere/kiali v0.15.1-0.20200520152915-769a61d75460
+# github.com/kiali/kiali v1.25.0 => github.com/kubesphere/kiali v0.15.1-0.20201030070213-04b6506d6c7d
 github.com/kiali/kiali/business
 github.com/kiali/kiali/business/checkers
 github.com/kiali/kiali/business/checkers/destinationrules


### PR DESCRIPTION
Signed-off-by: yuswift <yuswiftli@yunify.com>

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
To lightweight member cluster installation, this pr help us to run ks-controller-manager without ldap option.
**Which issue(s) this PR fixes**:
Fixes #3056 

**Special notes for reviewers**:
```
This pr is only for ldap. I will create another one for redis.
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
