### PR TITLE
Feat: support runnig ks-controller-manager without ldap option

### DIFF
--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -118,9 +118,8 @@ func run(s *options.KubeSphereControllerManagerOptions, stopCh <-chan struct{}) 
 	}
 
 	var ldapClient ldapclient.Interface
-	if s.LdapOptions == nil || len(s.LdapOptions.Host) == 0 {
-		return fmt.Errorf("ldap service address MUST not be empty")
-	} else {
+	// when there is no ldapOption, we set ldapClient as nil, which means we don't need to sync user info into ldap.
+	if s.LdapOptions != nil && len(s.LdapOptions.Host) != 0 {
 		if s.LdapOptions.Host == ldapclient.FAKE_HOST { // for debug only
 			ldapClient = ldapclient.NewSimpleLdap()
 		} else {
@@ -129,6 +128,8 @@ func run(s *options.KubeSphereControllerManagerOptions, stopCh <-chan struct{}) 
 				return fmt.Errorf("failed to connect to ldap service, please check ldap status, error: %v", err)
 			}
 		}
+	} else {
+		klog.Info("Kubesphere-controller-manager starts without ldap option, it will not sync user into ldap")
 	}
 
 	var openpitrixClient openpitrix.Client

--- a/pkg/apiserver/authentication/authenticators/jwttoken/jwt_token.go
+++ b/pkg/apiserver/authentication/authenticators/jwttoken/jwt_token.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/klog"
+
 	iamv1alpha2listers "kubesphere.io/kubesphere/pkg/client/listers/iam/v1alpha2"
 	"kubesphere.io/kubesphere/pkg/models/iam/im"
 )


### PR DESCRIPTION
Signed-off-by: yuswift <yuswiftli@yunify.com>

**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
To lightweight member cluster installation, this pr help us to run ks-controller-manager without ldap option.
**Which issue(s) this PR fixes**:
Fixes #3056 

**Special notes for reviewers**:
```
This pr is only for ldap. I will create another one for redis.
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
