### PR TITLE
Feat: support runnig ks-apiserver without redis option && change log level

### DIFF
--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -129,7 +129,7 @@ func run(s *options.KubeSphereControllerManagerOptions, stopCh <-chan struct{}) 
 			}
 		}
 	} else {
-		klog.Info("Kubesphere-controller-manager starts without ldap option, it will not sync user into ldap")
+		klog.Warning("ks-controller-manager starts without ldap provided, it will not sync user into ldap")
 	}
 
 	var openpitrixClient openpitrix.Client

--- a/cmd/ks-apiserver/app/options/options.go
+++ b/cmd/ks-apiserver/app/options/options.go
@@ -155,9 +155,7 @@ func (s *ServerRunOptions) NewAPIServer(stopCh <-chan struct{}) (*apiserver.APIS
 	}
 
 	var cacheClient cache.Interface
-	if s.RedisOptions == nil || len(s.RedisOptions.Host) == 0 {
-		return nil, fmt.Errorf("redis service address MUST not be empty, please check configmap/kubesphere-config in kubesphere-system namespace")
-	} else {
+	if s.RedisOptions != nil && len(s.RedisOptions.Host) != 0 {
 		if s.RedisOptions.Host == fakeInterface && s.DebugMode {
 			apiServer.CacheClient = cache.NewSimpleCache()
 		} else {
@@ -167,6 +165,10 @@ func (s *ServerRunOptions) NewAPIServer(stopCh <-chan struct{}) (*apiserver.APIS
 			}
 			apiServer.CacheClient = cacheClient
 		}
+	} else {
+		klog.Warning("ks-apiserver starts without redis provided, it will use in memory cache. " +
+			"This may cause inconsistencies when running ks-apiserver with multiple replicas.")
+		apiServer.CacheClient = cache.NewSimpleCache()
 	}
 
 	if s.EventsOptions.Host != "" {


### PR DESCRIPTION
Signed-off-by: yuswift <yuswiftli@yunify.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
To lightweight member cluster installation, this pr helps us to run ks-apiserver without redis option.
**Which issue(s) this PR fixes**:
Fixes #3056 

