### PR TITLE
Fix the errors found by go vet

### DIFF
--- a/pkg/controller/storage/expansion/expansion_controller_test.go
+++ b/pkg/controller/storage/expansion/expansion_controller_test.go
@@ -67,16 +67,16 @@ func TestSyncHandler(t *testing.T) {
 	}{
 		{
 			name: "mount pvc on deploy",
-			pvc:  getFakePersistentVolumeClaim("fake-pvc", "vol-12345", "fake-sc", types.UID(123)),
+			pvc:  getFakePersistentVolumeClaim("fake-pvc", "vol-12345", "fake-sc", types.UID(fmt.Sprintf("%d", 123))),
 			sc:   getFakeStorageClass("fake-sc", "fake.sc.com"),
 			deploy: getFakeDeployment("fake-deploy", "234", 1,
-				getFakePersistentVolumeClaim("fake-pvc", "vol-12345", "fake-sc", types.UID(123))),
+				getFakePersistentVolumeClaim("fake-pvc", "vol-12345", "fake-sc", types.UID(fmt.Sprintf("%d", 123)))),
 			pvcKey:   "default/fake-pvc",
 			hasError: false,
 		},
 		{
 			name:     "unmounted pvc",
-			pvc:      getFakePersistentVolumeClaim("fake-pvc", "vol-12345", "fake-sc", types.UID(123)),
+			pvc:      getFakePersistentVolumeClaim("fake-pvc", "vol-12345", "fake-sc", types.UID(fmt.Sprintf("%d", 123))),
 			sc:       getFakeStorageClass("fake-sc", "fake.sc.com"),
 			pvcKey:   "default/fake-pvc",
 			hasError: true,

--- a/pkg/models/registries/blob.go
+++ b/pkg/models/registries/blob.go
@@ -49,7 +49,7 @@ func (r *Registry) ImageBlob(image Image, token string) (*ImageBlob, error) {
 	respBody, _ := GetRespBody(resp)
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
-		log.Error("got response: " + string(resp.StatusCode) + string(respBody))
+		log.Errorf("got response: statusCode is '%d', body is '%s'\n", resp.StatusCode, respBody)
 		return nil, fmt.Errorf("got image blob faild")
 	}
 

--- a/pkg/models/registries/manifest.go
+++ b/pkg/models/registries/manifest.go
@@ -55,7 +55,7 @@ func (r *Registry) ImageManifest(image Image, token string) (*ImageManifest, err
 			log.Error(statusUnauthorized)
 			return nil, restful.NewError(resp.StatusCode, statusUnauthorized)
 		}
-		log.Error("got response: " + string(resp.StatusCode) + string(respBody))
+		log.Errorf("got response: statusCode is '%d', body is '%s'\n", resp.StatusCode, respBody)
 		return nil, restful.NewError(resp.StatusCode, "got image manifest failed")
 	}
 


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix the errors found by go vet:

```
# kubesphere.io/kubesphere/pkg/controller/storage/expansion
pkg/controller/storage/expansion/expansion_controller_test.go:70:75: conversion from untyped int to UID (string) yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
pkg/controller/storage/expansion/expansion_controller_test.go:73:70: conversion from untyped int to UID (string) yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
pkg/controller/storage/expansion/expansion_controller_test.go:79:79: conversion from untyped int to UID (string) yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
# kubesphere.io/kubesphere/pkg/models/registries
pkg/models/registries/blob.go:52:32: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
pkg/models/registries/manifest.go:58:32: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
make: *** [vet] Error 2
```

**Which issue(s) this PR fixes**:
None

**Special notes for reviewers**:

**Additional documentation, usage docs, etc.**:
Too minor, no need to record this as a release note.
