### PR TITLE
just filter out namespace started with kube-

### DIFF
--- a/cmd/ks-apiserver/app/server.go
+++ b/cmd/ks-apiserver/app/server.go
@@ -107,7 +107,7 @@ func initializeServicemeshConfig(s *options.ServerRunOptions) {
 	}
 
 	// Exclude system namespaces
-	config.API.Namespaces.Exclude = []string{"istio-system", "kubesphere*", "kube*"}
+	config.API.Namespaces.Exclude = []string{"istio-system", "kube-.*"}
 	config.InCluster = true
 
 	// Set default prometheus service url


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

When the namespace is started with "kubesphere-", it' always failed when use kiali tracing.


/assign @zryfish 
/area microservice


