### PR TITLE
Restrict only specific users or admin can approve a pipeline

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/kubernetes-csi/external-snapshotter/v2 v2.1.0
 	github.com/kubesphere/sonargo v0.0.2
 	github.com/lib/pq v1.2.0 // indirect
+	github.com/mitchellh/mapstructure v1.2.2
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
 	github.com/open-policy-agent/opa v0.18.0
@@ -80,6 +81,7 @@ require (
 	gopkg.in/src-d/go-git.v4 v4.11.0
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
+	gotest.tools v2.2.0+incompatible
 	istio.io/api v0.0.0-20191111210003-35e06ef8d838
 	istio.io/client-go v0.0.0-20191113122552-9bd0ba57c3d2
 	k8s.io/api v0.17.5

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -210,7 +210,8 @@ func (s *APIServer) installKubeSphereAPIs() {
 		s.SonarClient,
 		s.KubernetesClient.KubeSphere(),
 		s.S3Client,
-		s.Config.DevopsOptions.Host))
+		s.Config.DevopsOptions.Host,
+		am.NewOperator(s.InformerFactory, s.KubernetesClient.KubeSphere(), s.KubernetesClient.Kubernetes())))
 	urlruntime.Must(devopsv1alpha3.AddToContainer(s.container,
 		s.DevopsClient,
 		s.KubernetesClient.Kubernetes(),

--- a/pkg/kapis/devops/v1alpha2/devops.go
+++ b/pkg/kapis/devops/v1alpha2/devops.go
@@ -236,7 +236,7 @@ func (h *ProjectPipelineHandler) createdBy(projectName string, pipelineName stri
 			return creator == currentUserName
 		}
 	} else {
-		log.Error(fmt.Sprintf("cannot get pipeline %s/%s, error %#v", projectName, pipelineName, err))
+		log.V(4).Infof("cannot get pipeline %s/%s, error %#v", projectName, pipelineName, err)
 	}
 	return false
 }
@@ -298,7 +298,7 @@ func (h *ProjectPipelineHandler) hasSubmitPermission(req *restful.Request) (hasP
 			break
 		}
 	} else {
-		log.Errorf("cannot get nodes detail, error: %v", err)
+		log.V(4).Infof("cannot get nodes detail, error: %v", err)
 		err = errors.New("cannot get the submitters of current pipeline run")
 		return
 	}
@@ -312,11 +312,9 @@ func (h *ProjectPipelineHandler) SubmitInputStep(req *restful.Request, resp *res
 	nodeId := req.PathParameter("node")
 	stepId := req.PathParameter("step")
 
-	var (
-		response []byte
-		err      error
-		ok       bool
-	)
+	var response []byte
+	var err error
+	var ok bool
 
 	if ok, err = h.hasSubmitPermission(req); !ok || err != nil {
 		msg := map[string]string{
@@ -520,11 +518,9 @@ func (h *ProjectPipelineHandler) SubmitBranchInputStep(req *restful.Request, res
 	nodeId := req.PathParameter("node")
 	stepId := req.PathParameter("step")
 
-	var (
-		response []byte
-		err      error
-		ok       bool
-	)
+	var response []byte
+	var err error
+	var ok bool
 
 	if ok, err = h.hasSubmitPermission(req); !ok || err != nil {
 		msg := map[string]string{

--- a/pkg/kapis/devops/v1alpha2/handler.go
+++ b/pkg/kapis/devops/v1alpha2/handler.go
@@ -29,18 +29,18 @@ import (
 type ProjectPipelineHandler struct {
 	devopsOperator          devops.DevopsOperator
 	projectCredentialGetter devops.ProjectCredentialGetter
-	abc                     am.AccessManagementInterface
+	amInterface             am.AccessManagementInterface
 }
 
 type PipelineSonarHandler struct {
 	pipelineSonarGetter devops.PipelineSonarGetter
 }
 
-func NewProjectPipelineHandler(devopsClient devopsClient.Interface, abc am.AccessManagementInterface) ProjectPipelineHandler {
+func NewProjectPipelineHandler(devopsClient devopsClient.Interface, amInterface am.AccessManagementInterface) ProjectPipelineHandler {
 	return ProjectPipelineHandler{
 		devopsOperator:          devops.NewDevopsOperator(devopsClient, nil, nil, nil, nil),
 		projectCredentialGetter: devops.NewProjectCredentialOperator(devopsClient),
-		abc:                     abc,
+		amInterface:             amInterface,
 	}
 }
 

--- a/pkg/kapis/devops/v1alpha2/handler.go
+++ b/pkg/kapis/devops/v1alpha2/handler.go
@@ -36,9 +36,9 @@ type PipelineSonarHandler struct {
 	pipelineSonarGetter devops.PipelineSonarGetter
 }
 
-func NewProjectPipelineHandler(devopsClient devopsClient.Interface, amInterface am.AccessManagementInterface) ProjectPipelineHandler {
+func NewProjectPipelineHandler(devopsClient devopsClient.Interface, ksInformers externalversions.SharedInformerFactory, amInterface am.AccessManagementInterface) ProjectPipelineHandler {
 	return ProjectPipelineHandler{
-		devopsOperator:          devops.NewDevopsOperator(devopsClient, nil, nil, nil, nil),
+		devopsOperator:          devops.NewDevopsOperator(devopsClient, nil, nil, ksInformers, nil),
 		projectCredentialGetter: devops.NewProjectCredentialOperator(devopsClient),
 		amInterface:             amInterface,
 	}

--- a/pkg/kapis/devops/v1alpha2/handler.go
+++ b/pkg/kapis/devops/v1alpha2/handler.go
@@ -20,6 +20,7 @@ import (
 	"kubesphere.io/kubesphere/pkg/client/clientset/versioned"
 	"kubesphere.io/kubesphere/pkg/client/informers/externalversions"
 	"kubesphere.io/kubesphere/pkg/models/devops"
+	"kubesphere.io/kubesphere/pkg/models/iam/am"
 	devopsClient "kubesphere.io/kubesphere/pkg/simple/client/devops"
 	"kubesphere.io/kubesphere/pkg/simple/client/s3"
 	"kubesphere.io/kubesphere/pkg/simple/client/sonarqube"
@@ -28,16 +29,18 @@ import (
 type ProjectPipelineHandler struct {
 	devopsOperator          devops.DevopsOperator
 	projectCredentialGetter devops.ProjectCredentialGetter
+	abc                     am.AccessManagementInterface
 }
 
 type PipelineSonarHandler struct {
 	pipelineSonarGetter devops.PipelineSonarGetter
 }
 
-func NewProjectPipelineHandler(devopsClient devopsClient.Interface) ProjectPipelineHandler {
+func NewProjectPipelineHandler(devopsClient devopsClient.Interface, abc am.AccessManagementInterface) ProjectPipelineHandler {
 	return ProjectPipelineHandler{
 		devopsOperator:          devops.NewDevopsOperator(devopsClient, nil, nil, nil, nil),
 		projectCredentialGetter: devops.NewProjectCredentialOperator(devopsClient),
+		abc:                     abc,
 	}
 }
 

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -28,6 +28,7 @@ import (
 	"kubesphere.io/kubesphere/pkg/client/clientset/versioned"
 	"kubesphere.io/kubesphere/pkg/client/informers/externalversions"
 	"kubesphere.io/kubesphere/pkg/constants"
+	"kubesphere.io/kubesphere/pkg/models/iam/am"
 	"kubesphere.io/kubesphere/pkg/simple/client/devops/jenkins"
 	"kubesphere.io/kubesphere/pkg/simple/client/s3"
 	"kubesphere.io/kubesphere/pkg/simple/client/sonarqube"
@@ -46,10 +47,10 @@ const (
 
 var GroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha2"}
 
-func AddToContainer(container *restful.Container, ksInformers externalversions.SharedInformerFactory, devopsClient devops.Interface, sonarqubeClient sonarqube.SonarInterface, ksClient versioned.Interface, s3Client s3.Interface, endpoint string) error {
+func AddToContainer(container *restful.Container, ksInformers externalversions.SharedInformerFactory, devopsClient devops.Interface, sonarqubeClient sonarqube.SonarInterface, ksClient versioned.Interface, s3Client s3.Interface, endpoint string, abc am.AccessManagementInterface) error {
 	ws := runtime.NewWebService(GroupVersion)
 
-	err := AddPipelineToWebService(ws, devopsClient)
+	err := AddPipelineToWebService(ws, devopsClient, abc)
 	if err != nil {
 		return err
 	}
@@ -74,12 +75,12 @@ func AddToContainer(container *restful.Container, ksInformers externalversions.S
 	return nil
 }
 
-func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops.Interface) error {
+func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops.Interface, abc am.AccessManagementInterface) error {
 
 	projectPipelineEnable := devopsClient != nil
 
 	if projectPipelineEnable {
-		projectPipelineHandler := NewProjectPipelineHandler(devopsClient)
+		projectPipelineHandler := NewProjectPipelineHandler(devopsClient, abc)
 
 		webservice.Route(webservice.GET("/devops/{devops}/credentials/{credential}/usage").
 			To(projectPipelineHandler.GetProjectCredentialUsage).

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -50,7 +50,7 @@ var GroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha2"}
 func AddToContainer(container *restful.Container, ksInformers externalversions.SharedInformerFactory, devopsClient devops.Interface, sonarqubeClient sonarqube.SonarInterface, ksClient versioned.Interface, s3Client s3.Interface, endpoint string, amInterface am.AccessManagementInterface) error {
 	ws := runtime.NewWebService(GroupVersion)
 
-	err := AddPipelineToWebService(ws, devopsClient, amInterface)
+	err := AddPipelineToWebService(ws, devopsClient, ksInformers, amInterface)
 	if err != nil {
 		return err
 	}
@@ -75,12 +75,12 @@ func AddToContainer(container *restful.Container, ksInformers externalversions.S
 	return nil
 }
 
-func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops.Interface, amInterface am.AccessManagementInterface) error {
+func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops.Interface, ksInformers externalversions.SharedInformerFactory, amInterface am.AccessManagementInterface) error {
 
 	projectPipelineEnable := devopsClient != nil
 
 	if projectPipelineEnable {
-		projectPipelineHandler := NewProjectPipelineHandler(devopsClient, amInterface)
+		projectPipelineHandler := NewProjectPipelineHandler(devopsClient, ksInformers, amInterface)
 
 		webservice.Route(webservice.GET("/devops/{devops}/credentials/{credential}/usage").
 			To(projectPipelineHandler.GetProjectCredentialUsage).

--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -47,10 +47,10 @@ const (
 
 var GroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha2"}
 
-func AddToContainer(container *restful.Container, ksInformers externalversions.SharedInformerFactory, devopsClient devops.Interface, sonarqubeClient sonarqube.SonarInterface, ksClient versioned.Interface, s3Client s3.Interface, endpoint string, abc am.AccessManagementInterface) error {
+func AddToContainer(container *restful.Container, ksInformers externalversions.SharedInformerFactory, devopsClient devops.Interface, sonarqubeClient sonarqube.SonarInterface, ksClient versioned.Interface, s3Client s3.Interface, endpoint string, amInterface am.AccessManagementInterface) error {
 	ws := runtime.NewWebService(GroupVersion)
 
-	err := AddPipelineToWebService(ws, devopsClient, abc)
+	err := AddPipelineToWebService(ws, devopsClient, amInterface)
 	if err != nil {
 		return err
 	}
@@ -75,12 +75,12 @@ func AddToContainer(container *restful.Container, ksInformers externalversions.S
 	return nil
 }
 
-func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops.Interface, abc am.AccessManagementInterface) error {
+func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops.Interface, amInterface am.AccessManagementInterface) error {
 
 	projectPipelineEnable := devopsClient != nil
 
 	if projectPipelineEnable {
-		projectPipelineHandler := NewProjectPipelineHandler(devopsClient, abc)
+		projectPipelineHandler := NewProjectPipelineHandler(devopsClient, amInterface)
 
 		webservice.Route(webservice.GET("/devops/{devops}/credentials/{credential}/usage").
 			To(projectPipelineHandler.GetProjectCredentialUsage).

--- a/pkg/models/devops/devops.go
+++ b/pkg/models/devops/devops.go
@@ -487,20 +487,16 @@ func (d devopsOperator) GetNodeSteps(projectName, pipelineName, runId, nodeId st
 }
 
 func (d devopsOperator) GetPipelineRunNodes(projectName, pipelineName, runId string, req *http.Request) ([]devops.PipelineRunNodes, error) {
-
 	res, err := d.devopsClient.GetPipelineRunNodes(projectName, pipelineName, runId, convertToHttpParameters(req))
 	if err != nil {
 		klog.Error(err)
 		return nil, err
 	}
 
-	fmt.Println()
-
 	return res, err
 }
 
 func (d devopsOperator) SubmitInputStep(projectName, pipelineName, runId, nodeId, stepId string, req *http.Request) ([]byte, error) {
-
 	newBody, err := getInputReqBody(req.Body)
 	if err != nil {
 		klog.Error(err)

--- a/pkg/simple/client/devops/pipeline.go
+++ b/pkg/simple/client/devops/pipeline.go
@@ -17,9 +17,11 @@ limitations under the License.
 package devops
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 type PipelineList struct {
@@ -979,6 +981,8 @@ type NodeSteps struct {
 	StartTime          string `json:"startTime,omitempty" description:"the time of starts"`
 	State              string `json:"state,omitempty" description:"run state. e.g. SKIPPED"`
 	Type               string `json:"type,omitempty" description:"type"`
+	// Approvable indicates if this step can be approved by current user
+	Approvable bool `json:"aprovable" description:"indicate if this step can be approved by current user"`
 }
 
 // CheckScriptCompile
@@ -1075,6 +1079,11 @@ type NodesDetail struct {
 	Steps              []NodeSteps   `json:"steps,omitempty" description:"steps"`
 }
 
+const (
+	// StatePaused indicates a node or a step was paused, for example it's waiting for an iput
+	StatePaused = "PAUSED"
+)
+
 type NodesStepsIndex struct {
 	Id    int         `json:"id,omitempty" description:"id"`
 	Steps []NodeSteps `json:"steps,omitempty" description:"steps"`
@@ -1095,6 +1104,37 @@ type Input struct {
 	Submitter  interface{}   `json:"submitter,omitempty" description:"check submitter"`
 }
 
+// GetSubmitters returns the all submitters related to this input
+func (i *Input) GetSubmitters() (submitters []string) {
+	if i.Submitter == nil {
+		return
+	}
+
+	submitterArray := strings.Split(fmt.Sprintf("%v", i.Submitter), ",")
+	submitters = make([]string, len(submitterArray))
+	for i, submitter := range submitterArray {
+		submitters[i] = strings.TrimSpace(submitter)
+	}
+	return
+}
+
+// Approvable returns the result if the given identify (username or group name) can approve this input
+func (i *Input) Approvable(identify string) (ok bool) {
+	submitters := i.GetSubmitters()
+
+	// it means anyone can approve this if there's no specific one
+	if len(submitters) == 0 {
+		ok = true
+	} else {
+		for _, submitter := range submitters {
+			if submitter == identify {
+				ok = true
+			}
+		}
+	}
+	return
+}
+
 type HttpParameters struct {
 	Method   string        `json:"method,omitempty"`
 	Header   http.Header   `json:"header,omitempty"`
@@ -1105,7 +1145,6 @@ type HttpParameters struct {
 }
 
 type PipelineOperator interface {
-
 	// Pipelinne operator interface
 	GetPipeline(projectName, pipelineName string, httpParameters *HttpParameters) (*Pipeline, error)
 	ListPipelines(httpParameters *HttpParameters) (*PipelineList, error)

--- a/pkg/simple/client/devops/pipeline_test.go
+++ b/pkg/simple/client/devops/pipeline_test.go
@@ -1,0 +1,34 @@
+package devops
+
+import (
+	"gotest.tools/assert"
+	"testing"
+)
+
+func TestGetSubmitters(t *testing.T) {
+	input := &Input{}
+	assert.Equal(t, len(input.GetSubmitters()), 0,
+		"errors happen when try to get submitters without any submitters")
+
+	input.Submitter = "a , b, c,d"
+	submitters := input.GetSubmitters()
+	assert.Equal(t, len(submitters), 4, "get incorrect number of submitters")
+	assert.DeepEqual(t, submitters, []string{"a", "b", "c", "d"})
+}
+
+func TestApprovable(t *testing.T) {
+	input := &Input{}
+
+	assert.Equal(t, input.Approvable(""), true, "should allow anyone to approve it if there's no submitter given")
+	assert.Equal(t, input.Approvable("fake"), true, "should allow anyone to approve it if there's no submitter given")
+
+	input.Submitter = "fake"
+	assert.Equal(t, input.Approvable(""), false, "should not approve by nobody if there's a particular submitter")
+	assert.Equal(t, input.Approvable("rick"), false, "should not approve by who is not the specific one")
+	assert.Equal(t, input.Approvable("fake"), true, "should be approvable")
+
+	input.Submitter = "fake, good ,bad"
+	assert.Equal(t, input.Approvable("fake"), true, "should be approvable")
+	assert.Equal(t, input.Approvable("good"), true, "should be approvable")
+	assert.Equal(t, input.Approvable("bad"), true, "should be approvable")
+}

--- a/tools/cmd/doc-gen/main.go
+++ b/tools/cmd/doc-gen/main.go
@@ -119,7 +119,7 @@ func generateSwaggerJson() []byte {
 	urlruntime.Must(oauth.AddToContainer(container, nil, nil, nil, nil, nil))
 	urlruntime.Must(clusterkapisv1alpha1.AddToContainer(container, informerFactory.KubernetesSharedInformerFactory(),
 		informerFactory.KubeSphereSharedInformerFactory(), "", "", ""))
-	urlruntime.Must(devopsv1alpha2.AddToContainer(container, informerFactory.KubeSphereSharedInformerFactory(), &fakedevops.Devops{}, nil, clientsets.KubeSphere(), fakes3.NewFakeS3(), ""))
+	urlruntime.Must(devopsv1alpha2.AddToContainer(container, informerFactory.KubeSphereSharedInformerFactory(), &fakedevops.Devops{}, nil, clientsets.KubeSphere(), fakes3.NewFakeS3(), "", am.NewReadOnlyOperator(informerFactory)))
 	urlruntime.Must(devopsv1alpha3.AddToContainer(container, &fakedevops.Devops{}, clientsets.Kubernetes(), clientsets.KubeSphere(), informerFactory.KubeSphereSharedInformerFactory(), informerFactory.KubernetesSharedInformerFactory()))
 	urlruntime.Must(iamv1alpha2.AddToContainer(container, im.NewOperator(clientsets.KubeSphere(), informerFactory, nil), am.NewReadOnlyOperator(informerFactory), group.New(informerFactory, clientsets.KubeSphere(), clientsets.Kubernetes()), authoptions.NewAuthenticateOptions()))
 	urlruntime.Must(monitoringv1alpha3.AddToContainer(container, clientsets.Kubernetes(), nil, informerFactory, nil))


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Restrict the specific users who can approve a pipeline. These users might be mentioned from the pipeline, or their role is admin.

**Which issue(s) this PR fixes**:
Fixes #3006

**Special notes for reviewers**:
With this feature, the user who is not a platform admin, or didn't mention by a pipeline, is not able to approve a paused pipeline step. For security reasons, the API will return an error message if someone triggers it via a curl command or other ways. Please see the message format below:

`{"allow":"false","message":"some tips"}`

In order to don't let our users feel confused, the font-end can disable the approve (or reject) button according to the field `aprovable`. Please see the snippet of JSON data:

```
[
  "state": "PAUSED",
  "steps": [
   {
    "input": {...},
    "state": "PAUSED",
    "type": "STEP",
    "aprovable": false
   }
  ]
]
```

Considering some people are not very famillar with relevant APIs, the above JSON output comes from:

`/devops/{devops}/pipelines/{pipeline}/runs/{run}/nodesdetail` or `/devops/{devops}/pipelines/{pipeline}/branches/{branch}/runs/{run}/nodesdetail`

**Additional documentation, usage docs, etc.**:

