### PR TITLE
Reduce the size of the binary and image size by upx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,11 @@ jobs:
         run: bash hack/install_kubebuilder.sh
 
       - name: Build
-        run: make all
+        run: |
+          export PATH=$PATH:${PWD}/upx-3.96-amd64_linux
+          curl -L https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz | tar xJ
+          upx -V
+          make all
 
       - name: Make OpenAPI Spec
         run: make openapi

--- a/hack/gobuild.sh
+++ b/hack/gobuild.sh
@@ -43,7 +43,7 @@ LDFLAGS=$(kube::version::ldflags)
 
 # forgoing -i (incremental build) because it will be deprecated by tool chain.
 time GOOS=${BUILD_GOOS} CGO_ENABLED=0 GOARCH=${BUILD_GOARCH} ${GOBINARY} build \
-        -ldflags="${LDFLAGS}" \
+        -ldflags="${LDFLAGS} -w -s" \
         -o ${OUT} \
         ${BUILDPATH}
 

--- a/hack/gobuild.sh
+++ b/hack/gobuild.sh
@@ -46,3 +46,9 @@ time GOOS=${BUILD_GOOS} CGO_ENABLED=0 GOARCH=${BUILD_GOARCH} ${GOBINARY} build \
         -ldflags="${LDFLAGS}" \
         -o ${OUT} \
         ${BUILDPATH}
+
+# upx is a tool which can reduce the binary size dramatically
+if upx -V &> /dev/null
+then
+  upx ${OUT}
+fi


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
[upx](https://github.com/upx/upx) is a tool that can reduce the binary size dramatically.

You can see the reduce ratio below:
```
        File size         Ratio      Format      Name
   --------------------   ------   -----------   -----------
 108234000 ->  41676816   38.51%   macho/amd64   ks-apiserver 


         File size         Ratio      Format      Name
   --------------------   ------   -----------   -----------
  72386928 ->  28536848   39.42%   macho/amd64   controller-manager
```

Before we using upx, the docker images size is:
```
surenpi/ks-controller-manager   reduce-binary-size                               262ebb9fa9d4       78.5MB
surenpi/ks-apiserver            reduce-binary-size                               90f4774c0370       114MB
```

After we using upx, the docker images size is:
```
surenpi/ks-controller-manager   reduce-binary-size                               dc649966e3ec       34.7MB
surenpi/ks-apiserver            reduce-binary-size                               3b866f1b8f44       47.8MB
```

**Which issue(s) this PR fixes**:
None.

**Special notes for reviewers**:

**Additional documentation, usage docs, etc.**:

Want to get started on your own computer? It's very easy to install for macOS users. For other users, you can download it from the [release page](https://github.com/upx/upx/releases).

```
brew install upx
```