### PR TITLE
config data desensitization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/kubernetes-csi/external-snapshotter/v2 v2.1.0
 	github.com/kubesphere/sonargo v0.0.2
 	github.com/lib/pq v1.2.0 // indirect
+	github.com/mitchellh/mapstructure v1.2.2
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
 	github.com/open-policy-agent/opa v0.18.0

--- a/pkg/apiserver/authentication/oauth/oauth_options.go
+++ b/pkg/apiserver/authentication/oauth/oauth_options.go
@@ -17,9 +17,11 @@ limitations under the License.
 package oauth
 
 import (
+	"encoding/json"
 	"errors"
 	"kubesphere.io/kubesphere/pkg/utils/sliceutil"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -74,7 +76,56 @@ type Options struct {
 	AccessTokenInactivityTimeout time.Duration `json:"accessTokenInactivityTimeout" yaml:"accessTokenInactivityTimeout"`
 }
 
+// the type of key must be string
 type DynamicOptions map[string]interface{}
+
+func (o DynamicOptions) MarshalJSON() ([]byte, error) {
+	data, err := json.Marshal(desensitize(o))
+	return data, err
+}
+
+var (
+	sensitiveKeys = [...]string{"password", "secret"}
+)
+
+// isSensitiveData returns whether the input string contains sensitive information
+func isSensitiveData(key string) bool {
+	for _, v := range sensitiveKeys {
+		if strings.Contains(strings.ToLower(key), v) {
+			return true
+		}
+	}
+	return false
+}
+
+// desensitize returns the desensitized data
+func desensitize(data map[string]interface{}) map[string]interface{} {
+	output := make(map[string]interface{})
+	for k, v := range data {
+		if isSensitiveData(k) {
+			continue
+		}
+		switch v.(type) {
+		case map[interface{}]interface{}:
+			output[k] = desensitize(convert(v.(map[interface{}]interface{})))
+		default:
+			output[k] = v
+		}
+	}
+	return output
+}
+
+// convert returns formatted data
+func convert(m map[interface{}]interface{}) map[string]interface{} {
+	output := make(map[string]interface{})
+	for k, v := range m {
+		switch k.(type) {
+		case string:
+			output[k.(string)] = v
+		}
+	}
+	return output
+}
 
 type IdentityProviderOptions struct {
 	// The provider name.

--- a/pkg/kapis/config/v1alpha2/register.go
+++ b/pkg/kapis/config/v1alpha2/register.go
@@ -18,11 +18,7 @@ package v1alpha2
 
 import (
 	"github.com/emicklei/go-restful"
-	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/klog"
-	"kubesphere.io/kubesphere/pkg/api"
-	"kubesphere.io/kubesphere/pkg/apiserver/authentication/oauth"
 	kubesphereconfig "kubesphere.io/kubesphere/pkg/apiserver/config"
 	"kubesphere.io/kubesphere/pkg/apiserver/runtime"
 )
@@ -39,20 +35,7 @@ func AddToContainer(c *restful.Container, config *kubesphereconfig.Config) error
 	webservice.Route(webservice.GET("/configs/oauth").
 		Doc("Information about the authorization server are published.").
 		To(func(request *restful.Request, response *restful.Response) {
-			// workaround for this issue https://github.com/go-yaml/yaml/issues/139
-			// fixed in gopkg.in/yaml.v3
-			yamlData, err := yaml.Marshal(config.AuthenticationOptions.OAuthOptions)
-			if err != nil {
-				klog.Error(err)
-				api.HandleInternalError(response, request, err)
-			}
-			var options oauth.Options
-			err = yaml.Unmarshal(yamlData, &options)
-			if err != nil {
-				klog.Error(err)
-				api.HandleInternalError(response, request, err)
-			}
-			response.WriteEntity(options)
+			response.WriteEntity(config.AuthenticationOptions.OAuthOptions)
 		}))
 
 	webservice.Route(webservice.GET("/configs/configz").


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

API `/config.kubesphere.io/v1alpha2/configs` can be accessed anonymously,  the returned data needs to be desensitized. 
