### PR TITLE
fixed: check the cluster has initialized

### DIFF
--- a/pkg/controller/cluster/cluster_controller.go
+++ b/pkg/controller/cluster/cluster_controller.go
@@ -538,7 +538,10 @@ func (c *clusterController) syncCluster(key string) error {
 			LastUpdateTime:     metav1.Now(),
 			LastTransitionTime: metav1.Now(),
 		}
-		c.updateClusterCondition(cluster, initializedCondition)
+
+		if !isConditionTrue(cluster, clusterv1alpha1.ClusterInitialized) {
+			c.updateClusterCondition(cluster, initializedCondition)
+		}
 
 		if !reflect.DeepEqual(oldCluster, cluster) {
 			cluster, err = c.clusterClient.Update(cluster)
@@ -546,7 +549,6 @@ func (c *clusterController) syncCluster(key string) error {
 				klog.Errorf("Error updating cluster %s, error %s", cluster.Name, err)
 				return err
 			}
-			return nil
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Previously, always check whether the cluster has been initialized, but the updateClusterCondition function always removes the old condition and then adds the new condition, resulting in always returning after updating the initialized condition. So the edge cluster cannot join to the host cluster

This commit check the cluster has initialized, if initialized will not updated condition

**Which issue(s) this PR fixes**:
Fixes #3198

**Special notes for reviewers**:
```
@yuswift  @zryfish 
```

**Additional documentation, usage docs, etc.**:
```docs

```
