### PR TITLE
fix bug get goroutine for audit timeout

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -281,7 +281,7 @@ func (s *APIServer) buildHandlerChain(stopCh <-chan struct{}) {
 
 	if s.Config.AuditingOptions.Enable {
 		handler = filters.WithAuditing(handler,
-			audit.NewAuditing(s.InformerFactory, s.Config.AuditingOptions.WebhookUrl, stopCh))
+			audit.NewAuditing(s.InformerFactory, s.Config.AuditingOptions, stopCh))
 	}
 
 	var authorizers authorizer.Authorizer

--- a/pkg/apiserver/auditing/types.go
+++ b/pkg/apiserver/auditing/types.go
@@ -229,7 +229,7 @@ func (a *auditing) cacheEvent(e auditv1alpha1.Event) {
 	case a.cache <- &e:
 		return
 	case <-time.After(CacheTimeout):
-		klog.Errorf("cache audit event %s timeout", e.AuditID)
+		klog.V(8).Infof("cache audit event %s timeout", e.AuditID)
 		break
 	}
 }

--- a/pkg/apiserver/auditing/types.go
+++ b/pkg/apiserver/auditing/types.go
@@ -36,6 +36,7 @@ import (
 	"kubesphere.io/kubesphere/pkg/informers"
 	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3"
 	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3/devops"
+	options "kubesphere.io/kubesphere/pkg/simple/client/auditing/elasticsearch"
 	"kubesphere.io/kubesphere/pkg/utils/iputil"
 	"net"
 	"net/http"
@@ -46,8 +47,6 @@ const (
 	DefaultWebhook       = "kube-auditing-webhook"
 	DefaultCacheCapacity = 10000
 	CacheTimeout         = time.Second
-	SendTimeout          = time.Second * 3
-	ChannelCapacity      = 10
 )
 
 type Auditing interface {
@@ -60,19 +59,19 @@ type Auditing interface {
 type auditing struct {
 	webhookLister v1alpha1.WebhookLister
 	devopsGetter  v1alpha3.Interface
-	cache         chan *auditv1alpha1.EventList
+	cache         chan *auditv1alpha1.Event
 	backend       *Backend
 }
 
-func NewAuditing(informers informers.InformerFactory, url string, stopCh <-chan struct{}) Auditing {
+func NewAuditing(informers informers.InformerFactory, opts *options.Options, stopCh <-chan struct{}) Auditing {
 
 	a := &auditing{
 		webhookLister: informers.KubeSphereSharedInformerFactory().Auditing().V1alpha1().Webhooks().Lister(),
 		devopsGetter:  devops.New(informers.KubeSphereSharedInformerFactory()),
-		cache:         make(chan *auditv1alpha1.EventList, DefaultCacheCapacity),
+		cache:         make(chan *auditv1alpha1.Event, DefaultCacheCapacity),
 	}
 
-	a.backend = NewBackend(url, ChannelCapacity, a.cache, SendTimeout, stopCh)
+	a.backend = NewBackend(opts, a.cache, stopCh)
 	return a
 }
 
@@ -226,10 +225,8 @@ func (a *auditing) LogResponseObject(e *auditv1alpha1.Event, resp *ResponseCaptu
 
 func (a *auditing) cacheEvent(e auditv1alpha1.Event) {
 
-	eventList := &auditv1alpha1.EventList{}
-	eventList.Items = append(eventList.Items, e)
 	select {
-	case a.cache <- eventList:
+	case a.cache <- &e:
 		return
 	case <-time.After(CacheTimeout):
 		klog.Errorf("cache audit event %s timeout", e.AuditID)

--- a/pkg/simple/client/auditing/elasticsearch/options.go
+++ b/pkg/simple/client/auditing/elasticsearch/options.go
@@ -25,15 +25,15 @@ import (
 type Options struct {
 	Enable     bool   `json:"enable" yaml:"enable"`
 	WebhookUrl string `json:"webhookUrl" yaml:"webhookUrl"`
-	// The number of goroutines which send auditing events to webhook.
-	GoroutinesNum int `json:"goroutinesNum" yaml:"goroutinesNum"`
-	// The max size of the auditing event in a batch.
-	MaxBatchSize int `json:"batchSize" yaml:"batchSize"`
-	// MaxBatchWait indicates the maximum interval between two batches.
-	MaxBatchWait time.Duration `json:"batchTimeout" yaml:"batchTimeout"`
-	Host         string        `json:"host" yaml:"host"`
-	IndexPrefix  string        `json:"indexPrefix,omitempty" yaml:"indexPrefix"`
-	Version      string        `json:"version" yaml:"version"`
+	// The maximum concurrent senders which send auditing events to the auditing webhook.
+	EventSendersNum int `json:"eventSendersNum" yaml:"eventSendersNum"`
+	// The batch size of auditing events.
+	EventBatchSize int `json:"eventBatchSize" yaml:"eventBatchSize"`
+	// The batch interval of auditing events.
+	EventBatchInterval time.Duration `json:"eventBatchInterval" yaml:"eventBatchInterval"`
+	Host               string        `json:"host" yaml:"host"`
+	IndexPrefix        string        `json:"indexPrefix,omitempty" yaml:"indexPrefix"`
+	Version            string        `json:"version" yaml:"version"`
 }
 
 func NewElasticSearchOptions() *Options {
@@ -59,12 +59,12 @@ func (s *Options) AddFlags(fs *pflag.FlagSet, c *Options) {
 	fs.BoolVar(&s.Enable, "auditing-enabled", c.Enable, "Enable auditing component or not. ")
 
 	fs.StringVar(&s.WebhookUrl, "auditing-webhook-url", c.WebhookUrl, "Auditing wehook url")
-	fs.IntVar(&s.GoroutinesNum, "auditing-goroutines-num", c.GoroutinesNum,
-		"The number of goroutines which send auditing events to webhook.")
-	fs.IntVar(&s.MaxBatchSize, "auditing-batch-max-size", c.MaxBatchSize,
-		"The max size of the auditing event in a batch.")
-	fs.DurationVar(&s.MaxBatchWait, "auditing-batch-max-wait", c.MaxBatchWait,
-		"MaxBatchWait indicates the maximum interval between two batches.")
+	fs.IntVar(&s.EventSendersNum, "auditing-event-senders-num", c.EventSendersNum,
+		"The maximum concurrent senders which send auditing events to the auditing webhook.")
+	fs.IntVar(&s.EventBatchSize, "auditing-event-batch-size", c.EventBatchSize,
+		"The batch size of auditing events.")
+	fs.DurationVar(&s.EventBatchInterval, "auditing-event-batch-interval", c.EventBatchInterval,
+		"The batch interval of auditing events.")
 	fs.StringVar(&s.Host, "auditing-elasticsearch-host", c.Host, ""+
 		"Elasticsearch service host. KubeSphere is using elastic as auditing store, "+
 		"if this filed left blank, KubeSphere will use kubernetes builtin event API instead, and"+

--- a/pkg/simple/client/auditing/elasticsearch/options.go
+++ b/pkg/simple/client/auditing/elasticsearch/options.go
@@ -19,14 +19,21 @@ package elasticsearch
 import (
 	"github.com/spf13/pflag"
 	"kubesphere.io/kubesphere/pkg/utils/reflectutils"
+	"time"
 )
 
 type Options struct {
-	Enable      bool   `json:"enable" yaml:"enable"`
-	WebhookUrl  string `json:"webhookUrl" yaml:"webhookUrl"`
-	Host        string `json:"host" yaml:"host"`
-	IndexPrefix string `json:"indexPrefix,omitempty" yaml:"indexPrefix"`
-	Version     string `json:"version" yaml:"version"`
+	Enable     bool   `json:"enable" yaml:"enable"`
+	WebhookUrl string `json:"webhookUrl" yaml:"webhookUrl"`
+	// The number of goroutines which send auditing events to webhook.
+	GoroutinesNum int `json:"goroutinesNum" yaml:"goroutinesNum"`
+	// The max size of the auditing event in a batch.
+	MaxBatchSize int `json:"batchSize" yaml:"batchSize"`
+	// MaxBatchWait indicates the maximum interval between two batches.
+	MaxBatchWait time.Duration `json:"batchTimeout" yaml:"batchTimeout"`
+	Host         string        `json:"host" yaml:"host"`
+	IndexPrefix  string        `json:"indexPrefix,omitempty" yaml:"indexPrefix"`
+	Version      string        `json:"version" yaml:"version"`
 }
 
 func NewElasticSearchOptions() *Options {
@@ -52,7 +59,12 @@ func (s *Options) AddFlags(fs *pflag.FlagSet, c *Options) {
 	fs.BoolVar(&s.Enable, "auditing-enabled", c.Enable, "Enable auditing component or not. ")
 
 	fs.StringVar(&s.WebhookUrl, "auditing-webhook-url", c.WebhookUrl, "Auditing wehook url")
-
+	fs.IntVar(&s.GoroutinesNum, "auditing-goroutines-num", c.GoroutinesNum,
+		"The number of goroutines which send auditing events to webhook.")
+	fs.IntVar(&s.MaxBatchSize, "auditing-batch-max-size", c.MaxBatchSize,
+		"The max size of the auditing event in a batch.")
+	fs.DurationVar(&s.MaxBatchWait, "auditing-batch-max-wait", c.MaxBatchWait,
+		"MaxBatchWait indicates the maximum interval between two batches.")
 	fs.StringVar(&s.Host, "auditing-elasticsearch-host", c.Host, ""+
 		"Elasticsearch service host. KubeSphere is using elastic as auditing store, "+
 		"if this filed left blank, KubeSphere will use kubernetes builtin event API instead, and"+


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@yunify.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Now the limit of goroutines that send audit events to webhook is small and can not be customized,  if there are so many requests, this will cause an error that `get goroutine for audit timeout`, the audit event will sending failed. 
This pr will increase the default limit of goroutines from 10 to 100, and allow the user to customize it with an argument named `auditing-goroutines-num`.
In addition, the audit events will be aggregated and sent to increase the efficiency of sending. Users can customize the size of events in one batch with the argument `auditing-batch-max-size`, and the interval of two batches with the argument `auditing-batch-max-wait`.

