### PR TITLE
Add a GitHub action for building nightly images

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -1,0 +1,66 @@
+name: NightlyBuild
+
+on:
+  schedule:
+    # This is a UTC time
+    - cron: "0 16 * * *"
+  # Keep it only for test purpose, comment it once everything is ok
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Downloading go dependencies
+        run: go mod vendor
+
+      - name: Install kubebuilder
+        run: bash hack/install_kubebuilder.sh
+
+      - name: Build
+        run: make all
+
+      - name: Make OpenAPI Spec
+        run: make openapi
+
+      - name: Build and push docker images
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          bash hack/docker_build.sh master
+
+          if [[ $? == 0 ]]; then
+            tag=nightly-$(date '+%Y%m%d')
+
+            docker tag kubespheredev/ks-apiserver kubespheredev/ks-apiserver:${tag}
+            docker tag kubespheredev/ks-controller-manager kubespheredev/ks-controller-manager:${tag}
+
+            docker push kubespheredev/ks-apiserver:${tag}
+            docker push kubespheredev/ks-controller-manager:${tag}
+          else
+            exit -1
+          fi
+
+      - name: slack
+        uses: 8398a7/action-slack@v3
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+        if: always()


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Many users of KubeSphere want to try something new in the next release, or we have already fixed a bunch of bugs in the previous version. It's sad if all users need to wait for a long time to get it. So as many projects did, we can offer a nightly build distribution. We hope that anyone can install a fresh one.

For the community, we can get feedback much more fast than before.

For the users who like to try something new. They can tell us the specific version of KubeSphere. We can track down issues easily. For example, for the users who are using `KubeSphere nightly-2020-12-12`. They can give the exact version instead of `the master branch`.

**Which issue(s) this PR fixes**:
None.

**Special notes for reviewers**:
Test unit testing is not very unstable. The build might be failed due to unstable testing. So I'm wondering if we can just skip the testing during the nightly build. There're two reasons:
* Testing already done every time with PR and every time in the master branch. So technically we do not skip the testing.
* If we cannot guarantee all components images exist. Then users will feel very confused about the missing parts.

See also https://github.com/kubesphere/console/pull/1386

**Additional documentation, usage docs, etc.**:
