### PR TITLE
Cascading deletion of children groups

### DIFF
--- a/pkg/kapis/iam/v1alpha2/register.go
+++ b/pkg/kapis/iam/v1alpha2/register.go
@@ -576,7 +576,7 @@ func AddToContainer(container *restful.Container, im im.IdentityManagementInterf
 		Returns(http.StatusOK, api.StatusOK, []v1.RoleBinding{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.NamespaceRoleTag}))
 
-	ws.Route(ws.DELETE("/namespace/{namespace}/rolebindings/{rolebinding}").
+	ws.Route(ws.DELETE("/namespaces/{namespace}/rolebindings/{rolebinding}").
 		To(handler.DeleteRoleBinding).
 		Param(ws.PathParameter("workspace", "workspace name")).
 		Param(ws.PathParameter("namespace", "groupbinding name")).

--- a/pkg/models/iam/am/am.go
+++ b/pkg/models/iam/am/am.go
@@ -1050,9 +1050,9 @@ func (am *amOperator) CreateWorkspaceRoleBinding(workspace string, roleBinding *
 	}
 
 	if roleBinding.Subjects[0].Kind == rbacv1.GroupKind {
-		roleBinding.Labels[iamv1alpha2.GroupReferenceLabel] = roleBinding.RoleRef.Name
+		roleBinding.Labels[iamv1alpha2.GroupReferenceLabel] = roleBinding.Subjects[0].Name
 	} else if roleBinding.Subjects[0].Kind == rbacv1.UserKind {
-		roleBinding.Labels[iamv1alpha2.UserReferenceLabel] = roleBinding.RoleRef.Name
+		roleBinding.Labels[iamv1alpha2.UserReferenceLabel] = roleBinding.Subjects[0].Name
 	}
 
 	roleBinding.Labels[tenantv1alpha1.WorkspaceLabel] = workspace


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Hierarchical groups are supported when creating groups. But when the parent is deleted, the child groups should be deleted too. So we added an OwnerReferences when creating child groups, cascading deletion will be handled by Kubernetes controller.
