### PR TITLE
Fix the docker image tag always be override

### DIFF
--- a/hack/docker_build.sh
+++ b/hack/docker_build.sh
@@ -17,8 +17,15 @@ tag_for_branch() {
 }
 
 get_repo() {
-    local repo=$1
-    repo=${repo:-kubespheredev}
+    local repo=${REPO} # read from env
+    if [[ "$1" != "" ]]; then
+      repo="$1"
+    fi
+
+    # set the default value if there's no user defined
+    if [[ "${repo}" == "" ]]; then
+      repo="kubespheredev"
+    fi
     echo "$repo"
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The ENV variable `REPO` is not working. It caused by https://github.com/kubesphere/kubesphere/pull/3250/

**Which issue(s) this PR fixes**:

**Additional documentation, usage docs, etc.**:
