### PR TITLE
Fix the wrong XML parse of Pipeline choice parameter

### DIFF
--- a/pkg/simple/client/devops/jenkins/pipeline_internal.go
+++ b/pkg/simple/client/devops/jenkins/pipeline_internal.go
@@ -170,11 +170,9 @@ func appendParametersToEtree(properties *etree.Element, parameters []devopsv1alp
 				case "choice":
 					choices := paramDefine.CreateElement("choices")
 					choices.CreateAttr("class", "java.util.Arrays$ArrayList")
-					a := choices.CreateElement("a")
-					a.CreateAttr("class", "string-array")
 					choiceValues := strings.Split(parameter.DefaultValue, "\n")
 					for _, choiceValue := range choiceValues {
-						a.CreateElement("string").SetText(choiceValue)
+						choices.CreateElement("string").SetText(choiceValue)
 					}
 				case "file":
 					break
@@ -232,7 +230,7 @@ func getParametersfromEtree(properties *etree.Element) []devopsv1alpha3.Paramete
 					Description: param.SelectElement("description").Text(),
 					Type:        ParameterTypeMap["hudson.model.ChoiceParameterDefinition"],
 				}
-				choices := param.SelectElement("choices").SelectElement("a").SelectElements("string")
+				choices := param.SelectElement("choices").SelectElements("string")
 				for _, choice := range choices {
 					choiceParameter.DefaultValue += fmt.Sprintf("%s\n", choice.Text())
 				}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/area devops

**What this PR does / why we need it**:
The `ks-controller-manager` keeps panic due to the Pipeline parse errors.

**Which issue(s) this PR fixes**:
Fixes #3290

**Special notes for reviewers**:
In order to make this review progress be easier, you can see the following XML structure of Jenkins Pipeline Choice parameters:

```
        <hudson.model.ChoiceParameterDefinition>
          <name>action</name>
          <description>Please let us know if you want to install or uninstall</description>
          <choices>
            <string>install</string>
            <string>uninstall</string>
          </choices>
        </hudson.model.ChoiceParameterDefinition>
        <hudson.model.ChoiceParameterDefinition>
          <name>test</name>
          <description>Pleatestl</description>
          <choices/>
        </hudson.model.ChoiceParameterDefinition>
      </parameterDefinitions>
```

**Additional documentation, usage docs, etc.**:

/cc @kubesphere/sig-devops 