### PR TITLE
When the ip4 addres is nil, it should try the next.

### DIFF
--- a/pkg/utils/idutils/id_utils.go
+++ b/pkg/utils/idutils/id_utils.go
@@ -114,6 +114,9 @@ func IPv4() (net.IP, error) {
 		}
 
 		ip := ipnet.IP.To4()
+		if ip == nil {
+			continue
+		}
 		return ip, nil
 
 	}


### PR DESCRIPTION
Signed-off-by: lee <s_xun_s@163.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

In a complex network environment, there may be a problem of not obtaining IP.
When the obtained IP is nil, I think it should continue to try. Otherwise, it may be fail to start because the obtained ip(ipv4) is empty.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:

Here is the error message:

```
API server listening at: [::]:62292
debugserver-@(#)PROGRAM:LLDB  PROJECT:lldb-1200.0.44
 for x86_64.
Got a connection, launched process /private/var/folders/bs/h4yt6_l14_d5k6wbd0q434pm0000gn/T/___go_build_apiserver_go (pid = 5129).
panic: runtime error: index out of range [2] with length 0

goroutine 1 [running]:
kubesphere.io/kubesphere/pkg/utils/idutils.lower16BitIP(0x0, 0x0, 0x0)
        /Users/lee/go/src/kubesphere/pkg/utils/idutils/id_utils.go:92 +0x159
github.com/sony/sonyflake.NewSonyflake(0x0, 0x0, 0x0, 0x4f59ae8, 0x0, 0x0)
        /Users/lee/go/pkg/mod/github.com/sony/sonyflake@v0.0.0-20181109022403-6d5bd6181009/sonyflake.go:75 +0x233
kubesphere.io/kubesphere/pkg/utils/idutils.init.0()
        /Users/lee/go/src/kubesphere/pkg/utils/idutils/id_utils.go:36 +0xd9
Exiting.

Debugger finished with exit code 0

```

**Additional documentation, usage docs, etc.**:

The network environment is following: 

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
	options=1203<RXCSUM,TXCSUM,TXSTATUS,SW_TIMESTAMP>
	inet 127.0.0.1 netmask 0xff000000
	inet6 ::1 prefixlen 128
	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
	nd6 options=201<PERFORMNUD,DAD>
gif0: flags=8010<POINTOPOINT,MULTICAST> mtu 1280
stf0: flags=0<> mtu 1280
XHC1: flags=0<> mtu 0
XHC0: flags=0<> mtu 0
XHC20: flags=0<> mtu 0
VHC128: flags=0<> mtu 0
en5: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
	ether ac:de:48:00:11:22
	inet6 fe80::aede:48ff:fe00:1122%en5 prefixlen 64 scopeid 0x8
	nd6 options=201<PERFORMNUD,DAD>
	media: autoselect (100baseTX <full-duplex>)
	status: active
ap1: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 1500
	options=400<CHANNEL_IO>
	ether 3a:f9:d3:de:a8:7c
	nd6 options=201<PERFORMNUD,DAD>
	media: autoselect
	status: inactive
en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
	options=400<CHANNEL_IO>
	ether 38:f9:d3:de:a8:7c
	inet6 fe80::43e:86e:fdb7:9894%en0 prefixlen 64 secured scopeid 0xa
	inet 1.1.12.33 netmask 0xffffff00 broadcast 1.1.12.255
	nd6 options=201<PERFORMNUD,DAD>
	media: autoselect
	status: active
en3: flags=8963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
	options=460<TSO4,TSO6,CHANNEL_IO>
	ether 82:25:2b:e8:5c:05
	media: autoselect <full-duplex>
	status: inactive
en4: flags=8963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
	options=460<TSO4,TSO6,CHANNEL_IO>
	ether 82:25:2b:e8:5c:04
	media: autoselect <full-duplex>
	status: inactive
en1: flags=8963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
	options=460<TSO4,TSO6,CHANNEL_IO>
	ether 82:25:2b:e8:5c:01
	media: autoselect <full-duplex>
	status: inactive
en2: flags=8963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
	options=460<TSO4,TSO6,CHANNEL_IO>
	ether 82:25:2b:e8:5c:00
	media: autoselect <full-duplex>
	status: inactive
awdl0: flags=8943<UP,BROADCAST,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
	options=400<CHANNEL_IO>
	ether f2:68:0e:aa:e1:c7
	inet6 fe80::f068:eff:feaa:e1c7%awdl0 prefixlen 64 scopeid 0xf
	nd6 options=201<PERFORMNUD,DAD>
	media: autoselect
	status: active
llw0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
	options=400<CHANNEL_IO>
	ether f2:68:0e:aa:e1:c7
	inet6 fe80::f068:eff:feaa:e1c7%llw0 prefixlen 64 scopeid 0x10
	nd6 options=201<PERFORMNUD,DAD>
	media: autoselect
	status: active
bridge0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
	options=63<RXCSUM,TXCSUM,TSO4,TSO6>
	ether 82:25:2b:e8:5c:01
	Configuration:
		id 0:0:0:0:0:0 priority 0 hellotime 0 fwddelay 0
		maxage 0 holdcnt 0 proto stp maxaddr 100 timeout 1200
		root id 0:0:0:0:0:0 priority 0 ifcost 0 port 0
		ipfilter disabled flags 0x0
	member: en1 flags=3<LEARNING,DISCOVER>
	        ifmaxaddr 0 port 13 priority 0 path cost 0
	member: en2 flags=3<LEARNING,DISCOVER>
	        ifmaxaddr 0 port 14 priority 0 path cost 0
	member: en3 flags=3<LEARNING,DISCOVER>
	        ifmaxaddr 0 port 11 priority 0 path cost 0
	member: en4 flags=3<LEARNING,DISCOVER>
	        ifmaxaddr 0 port 12 priority 0 path cost 0
	nd6 options=201<PERFORMNUD,DAD>
	media: <unknown type>
	status: inactive
utun0: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1380
	inet6 fe80::36de:1be6:5ad2:8a3a%utun0 prefixlen 64 scopeid 0x12
	nd6 options=201<PERFORMNUD,DAD>
utun1: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 2000
	inet6 fe80::7ce8:a382:8807:7dd3%utun1 prefixlen 64 scopeid 0x13
	nd6 options=201<PERFORMNUD,DAD>
```
In this Environment,  the  `1.1.12.33` is the ipv4 which I expect. However, because the  status of the `en5` is active, and it's not `Loopback Address`, so the program will try to get the `ipv4` of `en5`. But the `ipv4` does not exist. Eventually, the `ipv4` is `nil`,the   program can not work correctly.