### PR TITLE
add parameter to allow ignore cert

### DIFF
--- a/pkg/kapis/resources/v1alpha2/handler.go
+++ b/pkg/kapis/resources/v1alpha2/handler.go
@@ -18,6 +18,10 @@ package v1alpha2
 
 import (
 	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
 	"github.com/emicklei/go-restful"
 	v1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -37,9 +41,6 @@ import (
 	"kubesphere.io/kubesphere/pkg/models/routers"
 	"kubesphere.io/kubesphere/pkg/server/errors"
 	"kubesphere.io/kubesphere/pkg/server/params"
-	"net/http"
-	"strconv"
-	"strings"
 )
 
 type resourceHandler struct {
@@ -325,8 +326,9 @@ func (r *resourceHandler) handleGetRegistryEntry(request *restful.Request, respo
 	imageName := request.QueryParameter("image")
 	namespace := request.QueryParameter("namespace")
 	secretName := request.QueryParameter("secret")
+	insecure := request.QueryParameter("insecure") == "true"
 
-	detail, err := r.registryGetter.GetEntry(namespace, secretName, imageName)
+	detail, err := r.registryGetter.GetEntry(namespace, secretName, imageName, insecure)
 	if err != nil {
 		api.HandleBadRequest(response, nil, err)
 		return

--- a/pkg/kapis/resources/v1alpha2/register.go
+++ b/pkg/kapis/resources/v1alpha2/register.go
@@ -17,8 +17,10 @@ limitations under the License.
 package v1alpha2
 
 import (
+	"net/http"
+
 	"github.com/emicklei/go-restful"
-	"github.com/emicklei/go-restful-openapi"
+	restfulspec "github.com/emicklei/go-restful-openapi"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,7 +35,6 @@ import (
 	registriesmodel "kubesphere.io/kubesphere/pkg/models/registries"
 	"kubesphere.io/kubesphere/pkg/server/errors"
 	"kubesphere.io/kubesphere/pkg/server/params"
-	"net/http"
 )
 
 const (
@@ -145,6 +146,9 @@ func AddToContainer(c *restful.Container, k8sClient kubernetes.Interface, factor
 		Param(webservice.QueryParameter("secret", "secret name").
 			Required(false).
 			DataFormat("secret=%s")).
+		Param(webservice.QueryParameter("insecure", "whether verify cert if using https repo").
+			Required(false).
+			DataFormat("insecure=%s")).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.RegistryTag}).
 		Doc("Retrieve the blob from the registry identified").
 		Writes(registriesmodel.ImageDetails{}).

--- a/pkg/models/registries/manifest_test.go
+++ b/pkg/models/registries/manifest_test.go
@@ -23,7 +23,7 @@ import (
 func TestDigestFromDockerHub(t *testing.T) {
 
 	testImage := Image{Domain: "docker.io", Path: "library/alpine", Tag: "latest"}
-	r, err := CreateRegistryClient("", "", "docker.io", true)
+	r, err := CreateRegistryClient("", "", "docker.io", true, false)
 	if err != nil {
 		t.Fatalf("Could not get client: %s", err)
 	}

--- a/pkg/models/registries/registry_client_test.go
+++ b/pkg/models/registries/registry_client_test.go
@@ -41,7 +41,7 @@ func TestCreateRegistryClient(t *testing.T) {
 	}
 
 	for _, testImage := range testImages {
-		reg, err := CreateRegistryClient(testImage.Username, testImage.Password, testImage.Domain, testImage.UseSSL)
+		reg, err := CreateRegistryClient(testImage.Username, testImage.Password, testImage.Domain, testImage.UseSSL, false)
 		if err != nil {
 			t.Fatalf("Get err %s", err)
 		}
@@ -57,7 +57,7 @@ func TestCreateRegistryClient(t *testing.T) {
 	}
 
 	testImage := Image{Domain: DockerHub, Path: "library/alpine", Tag: "latest"}
-	r, err := CreateRegistryClient("", "", DockerHub, true)
+	r, err := CreateRegistryClient("", "", DockerHub, true, false)
 	if err != nil {
 		t.Fatalf("Could not get client: %s", err)
 	}

--- a/pkg/models/registries/token_test.go
+++ b/pkg/models/registries/token_test.go
@@ -48,7 +48,7 @@ func (asm authServiceMock) equalTo(v *authService) bool {
 
 func TestToken(t *testing.T) {
 	testImage := Image{Domain: "docker.io", Path: "library/alpine", Tag: "latest"}
-	r, err := CreateRegistryClient("", "", "docker.io", true)
+	r, err := CreateRegistryClient("", "", "docker.io", true, false)
 	if err != nil {
 		t.Fatalf("Could not get registry client: %s", err)
 	}


### PR DESCRIPTION
Signed-off-by: shaowenchen <mail@chenshaowen.com>

**What type of PR is this?**

 /kind bug

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubesphere/kubesphere/issues/3308

**Additional documentation, usage docs, etc.**:

add parameter `ignorecert=true` to query image blob.

e.g. /kapis/resources.kubesphere.io/v1alpha2/registry/blob?namespace=harbor&image=harbor.dev.oa.com%2Fnginx%2Funit%3Alatest&secret=harbor&ignorecert=true
