### PR TITLE
remove http1.1 support code

### DIFF
--- a/pkg/apiserver/dispatch/dispatch.go
+++ b/pkg/apiserver/dispatch/dispatch.go
@@ -18,24 +18,25 @@ package dispatch
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/httpstream"
-	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/proxy"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
+
 	clusterv1alpha1 "kubesphere.io/kubesphere/pkg/apis/cluster/v1alpha1"
 	"kubesphere.io/kubesphere/pkg/apiserver/request"
 	clusterinformer "kubesphere.io/kubesphere/pkg/client/informers/externalversions/cluster/v1alpha1"
 	clusterlister "kubesphere.io/kubesphere/pkg/client/listers/cluster/v1alpha1"
-	"net/http"
-	"net/url"
-	"strings"
-	"sync"
 )
 
 const proxyURLFormat = "/api/v1/namespaces/kubesphere-system/services/:ks-apiserver:/proxy%s"
@@ -198,21 +199,6 @@ func (c *clusterDispatch) getInnerCluster(name string) *innerCluster {
 	return nil
 }
 
-// copy from https://github.com/kubernetes/apimachinery/blob/master/pkg/util/proxy/dial.go
-func supportsHTTP11(nextProtos []string) bool {
-	if len(nextProtos) == 0 {
-		return true
-	}
-
-	for _, proto := range nextProtos {
-		if proto == "http/1.1" {
-			return true
-		}
-	}
-
-	return false
-}
-
 func (c *clusterDispatch) updateInnerClusters(obj interface{}) {
 	cluster := obj.(*clusterv1alpha1.Cluster)
 
@@ -245,14 +231,6 @@ func (c *clusterDispatch) updateInnerClusters(obj interface{}) {
 	if err != nil {
 		klog.Errorf("Create transport failed, %v", err)
 		return
-	}
-
-	tlsConfig, err := net.TLSClientConfig(transport)
-	if err == nil {
-		// since http2 doesn't support websocket, we need to disable http2 when using websocket
-		if supportsHTTP11(tlsConfig.NextProtos) {
-			tlsConfig.NextProtos = []string{"http/1.1"}
-		}
 	}
 
 	c.mutex.Lock()

--- a/pkg/apiserver/filters/kubeapiserver.go
+++ b/pkg/apiserver/filters/kubeapiserver.go
@@ -17,15 +17,16 @@ limitations under the License.
 package filters
 
 import (
-	"k8s.io/apimachinery/pkg/util/net"
+	"net/http"
+	"net/url"
+
 	"k8s.io/apimachinery/pkg/util/proxy"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
+
 	"kubesphere.io/kubesphere/pkg/apiserver/request"
 	"kubesphere.io/kubesphere/pkg/server/errors"
-	"net/http"
-	"net/url"
 )
 
 // WithKubeAPIServer proxy request to kubernetes service if requests path starts with /api
@@ -35,16 +36,6 @@ func WithKubeAPIServer(handler http.Handler, config *rest.Config, failed proxy.E
 	if err != nil {
 		klog.Errorf("Unable to create transport from rest.Config: %v", err)
 		return handler
-	}
-
-	tlsConfig, err := net.TLSClientConfig(defaultTransport)
-	if err != nil {
-		klog.V(5).Infof("Unable to unwrap transport %T to get at TLS config: %v", defaultTransport, err)
-	}
-
-	// since http2 doesn't support websocket, we need to disable http2 when using websocket
-	if supportsHTTP11(tlsConfig.NextProtos) {
-		tlsConfig.NextProtos = []string{"http/1.1"}
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -70,19 +61,4 @@ func WithKubeAPIServer(handler http.Handler, config *rest.Config, failed proxy.E
 
 		handler.ServeHTTP(w, req)
 	})
-}
-
-// copy from https://github.com/kubernetes/apimachinery/blob/master/pkg/util/proxy/dial.go
-func supportsHTTP11(nextProtos []string) bool {
-	if len(nextProtos) == 0 {
-		return true
-	}
-
-	for _, proto := range nextProtos {
-		if proto == "http/1.1" {
-			return true
-		}
-	}
-
-	return false
 }


### PR DESCRIPTION
Signed-off-by: yuswift <yuswiftli@yunify.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We've updated the dependencies and don't need to copy the `supportsHTTP11()` function  from `https://github.com/kubernetes/apimachinery/blob/master/pkg/util/proxy/dial.go` manaully.