### PR TITLE
fix duplicate args error

### DIFF
--- a/pkg/models/routers/routers.go
+++ b/pkg/models/routers/routers.go
@@ -19,6 +19,9 @@ package routers
 import (
 	"fmt"
 	"io/ioutil"
+	"sort"
+	"strings"
+
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -29,8 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog"
-	"sort"
-	"strings"
+	"kubesphere.io/kubesphere/pkg/utils/sliceutil"
 )
 
 // choose router node ip by labels, currently select master node
@@ -318,13 +320,13 @@ func (c *routerOperator) createOrUpdateRouterWorkload(namespace string, publishS
 			deployment.Spec.Template.Labels["project"] = namespace
 
 			// Add configmap
-			deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--configmap=$(POD_NAMESPACE)/"+deployment.Name+configMapSuffix)
+			deployment.Spec.Template.Spec.Containers[0].Args = sliceutil.AppendArg(deployment.Spec.Template.Spec.Containers[0].Args, "--configmap=$(POD_NAMESPACE)/"+deployment.Name+configMapSuffix)
 
 			// Isolate namespace
-			deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--watch-namespace="+namespace)
+			deployment.Spec.Template.Spec.Containers[0].Args = sliceutil.AppendArg(deployment.Spec.Template.Spec.Containers[0].Args, "--watch-namespace="+namespace)
 
 			// Choose self as master
-			deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--election-id="+deployment.Name)
+			deployment.Spec.Template.Spec.Containers[0].Args = sliceutil.AppendArg(deployment.Spec.Template.Spec.Containers[0].Args, "--election-id="+deployment.Name)
 
 		}
 	} else {
@@ -340,7 +342,7 @@ func (c *routerOperator) createOrUpdateRouterWorkload(namespace string, publishS
 						strings.HasPrefix("--report-node-internal-ip-address", argument) {
 						continue
 					}
-					args = append(args, deployment.Spec.Template.Spec.Containers[i].Args[j])
+					args = sliceutil.AppendArg(args, deployment.Spec.Template.Spec.Containers[i].Args[j])
 				}
 				deployment.Spec.Template.Spec.Containers[i].Args = args
 			}
@@ -357,9 +359,9 @@ func (c *routerOperator) createOrUpdateRouterWorkload(namespace string, publishS
 	}
 
 	if publishService {
-		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--publish-service="+ingressControllerNamespace+"/"+ingressControllerPrefix+namespace)
+		deployment.Spec.Template.Spec.Containers[0].Args = sliceutil.AppendArg(deployment.Spec.Template.Spec.Containers[0].Args, "--publish-service="+ingressControllerNamespace+"/"+ingressControllerPrefix+namespace)
 	} else {
-		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--report-node-internal-ip-address")
+		deployment.Spec.Template.Spec.Containers[0].Args = sliceutil.AppendArg(deployment.Spec.Template.Spec.Containers[0].Args, "--report-node-internal-ip-address")
 	}
 
 	if createDeployment {

--- a/pkg/utils/sliceutil/sliceutil_test.go
+++ b/pkg/utils/sliceutil/sliceutil_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 KubeSphere Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sliceutil
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAppendArg(t *testing.T) {
+	var tests = []struct {
+		args     []string
+		arg      string
+		expected []string
+	}{
+		{
+			args:     []string{"--arg1=val1", "--arg2=val2", "--arg3=val3"},
+			arg:      "--arg4=val4",
+			expected: []string{"--arg1=val1", "--arg2=val2", "--arg3=val3", "--arg4=val4"},
+		},
+		{
+			args:     []string{"--arg1=val1", "--arg2=val2", "--arg3=val3"},
+			arg:      "  --arg2=val2 ",
+			expected: []string{"--arg1=val1", "--arg2=val2", "--arg3=val3"},
+		},
+		{
+			args:     []string{"  --arg1 = val1", " --arg2=val2 ", " --arg3"},
+			arg:      "  --arg2=val2 ",
+			expected: []string{"  --arg1 = val1", " --arg2=val2 ", " --arg3"},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			result := AppendArg(test.args, test.arg)
+			if diff := cmp.Diff(result, test.expected); diff != "" {
+				t.Fatalf("%T differ (-got, +want): %s", test.expected, diff)
+			}
+		})
+	}
+}

--- a/pkg/utils/sliceutil/sliceutils.go
+++ b/pkg/utils/sliceutil/sliceutils.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package sliceutil
 
+import (
+	"strings"
+)
+
 func RemoveString(slice []string, remove func(item string) bool) []string {
 	for i := 0; i < len(slice); i++ {
 		if remove(slice[i]) {
@@ -33,4 +37,15 @@ func HasString(slice []string, str string) bool {
 		}
 	}
 	return false
+}
+
+func AppendArg(args []string, arg string) []string {
+	n := strings.TrimSpace(strings.Split(arg, "=")[0])
+	for _, v := range args {
+		if strings.TrimSpace(strings.Split(v, "=")[0]) == n {
+			return args
+		}
+	}
+
+	return append(args, arg)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
append nginx-ingress-controller container's args without duplicated 

**Which issue(s) this PR fixes**:
edit project gateway configuration and save it several times would cause nginx-ingress-controller container's args duplicated 

      - args:
        - /nginx-ingress-controller
        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
        - --annotations-prefix=nginx.ingress.kubernetes.io
        - --force-namespace-isolation
        - --update-status
        - --update-status-on-shutdown
        - --configmap=$(POD_NAMESPACE)/kubesphere-router-paas-nginx
        - --watch-namespace=paas
        - --election-id=kubesphere-router-paas
        - --configmap=$(POD_NAMESPACE)/kubesphere-router-paas-nginx
        - --watch-namespace=paas
        - --election-id=kubesphere-router-paas
        - --publish-service=kubesphere-controls-system/kubesphere-router-paas
        - --publish-service=kubesphere-controls-system/kubesphere-router-paas
        - --publish-service=kubesphere-controls-system/kubesphere-router-paas
        - --publish-service=kubesphere-controls-system/kubesphere-router-paas
        - --publish-service=kubesphere-controls-system/kubesphere-router-paas

Fixes #

**Special notes for reviewers**:
```
```
