### PR TITLE
Don't exit while synchronizing calico ippool

### DIFF
--- a/pkg/controller/network/ippool/ippool_controller.go
+++ b/pkg/controller/network/ippool/ippool_controller.go
@@ -339,12 +339,14 @@ func (c *IPPoolController) processIPPoolItem() bool {
 	if err == nil {
 		c.ippoolQueue.Forget(key)
 		return true
-	} else if delay != nil {
-		c.ippoolQueue.AddAfter(key, *delay)
 	}
 
+	if delay != nil {
+		c.ippoolQueue.AddAfter(key, *delay)
+	} else {
+		c.ippoolQueue.AddRateLimited(key)
+	}
 	utilruntime.HandleError(fmt.Errorf("error processing ippool %v (will retry): %v", key, err))
-	c.ippoolQueue.AddRateLimited(key)
 	return true
 }
 

--- a/pkg/simple/client/network/ippool/calico/provider.go
+++ b/pkg/simple/client/network/ippool/calico/provider.go
@@ -695,9 +695,16 @@ func NewProvider(podInformer informercorev1.PodInformer, ksclient kubesphereclie
 	})
 	p.block = blockI
 
-	if err := p.syncIPPools(); err != nil {
-		klog.Fatalf("failed to sync calico ippool to kubesphere ippool, err=%v", err)
-	}
+	go func() {
+		for {
+			if err := p.syncIPPools(); err != nil {
+				klog.Infof("failed to sync calico ippool to kubesphere ippool, err=%v", err)
+				time.Sleep(3 * time.Second)
+				continue
+			}
+			break
+		}
+	}()
 
 	return p
 }


### PR DESCRIPTION
Signed-off-by: Duan Jiong <djduanjiong@gmail.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Don't exit while synchronizing calico ippool. Because the ippool update will call the webhook, but the webhook is not ready during the controller startup phase

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
