### PR TITLE
feature: add user email to built-in ldap

### DIFF
--- a/pkg/simple/client/ldap/ldap.go
+++ b/pkg/simple/client/ldap/ldap.go
@@ -254,6 +254,10 @@ func (l *ldapInterfaceImpl) Create(user *iamv1alpha2.User) error {
 				Type: ldapAttributeUserPassword,
 				Vals: []string{user.Spec.EncryptedPassword},
 			},
+			{
+				Type: ldapAttributeMail,
+				Vals: []string{user.Spec.Email},
+			},
 		},
 	}
 


### PR DESCRIPTION
add user email to built-in ldap

What type of PR is this?
/kind feature

What this PR does / why we need it:
By adding user email to built-in ldap which can support some components(e.g gitlab,harbor) to adopt the built-in ldap to authenticating user when no external ldap component.