### PR TITLE
feature: add annotations to pipelines for getting syncstatus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bin/
 
 # Vscode files
 .vscode/
+__debug_bin
 
 # OSX trash
 .DS_Store

--- a/pkg/kapis/devops/v1alpha2/devops.go
+++ b/pkg/kapis/devops/v1alpha2/devops.go
@@ -112,7 +112,8 @@ func (h *ProjectPipelineHandler) ListPipelines(req *restful.Request, resp *restf
 		} else {
 			pipelineMap[pipeline.Name] = i
 			pipelineList.Items[i] = clientDevOps.Pipeline{
-				Name: pipeline.Name,
+				Name:        pipeline.Name,
+				Annotations: pipeline.Annotations,
 			}
 		}
 	}

--- a/pkg/simple/client/devops/pipeline.go
+++ b/pkg/simple/client/devops/pipeline.go
@@ -31,8 +31,9 @@ type PipelineList struct {
 
 // GetPipeline & SearchPipelines
 type Pipeline struct {
-	Class string `json:"_class,omitempty" description:"It’s a fully qualified name and is an identifier of the producer of this resource's capability." `
-	Links struct {
+	Annotations map[string]string `json:"annotations,omitempty" description:"Add annotations from crd" `
+	Class       string            `json:"_class,omitempty" description:"It’s a fully qualified name and is an identifier of the producer of this resource's capability." `
+	Links       struct {
 		Self struct {
 			Class string `json:"_class,omitempty"`
 			Href  string `json:"href,omitempty"`


### PR DESCRIPTION
Signed-off-by: shaowenchen <mail@chenshaowen.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

https://github.com/kubesphere/kubesphere/issues/3007

The console web needs the sync data saved in the annotations while displaying the list of pipelines.

/cc @kubesphere/sig-devops 
