### PR TITLE
Fix cannot modify UserSpec

### DIFF
--- a/pkg/kapis/iam/v1alpha2/handler.go
+++ b/pkg/kapis/iam/v1alpha2/handler.go
@@ -544,7 +544,6 @@ func (h *iamHandler) UpdateUser(request *restful.Request, response *restful.Resp
 	var user iamv1alpha2.User
 
 	err := request.ReadEntity(&user)
-
 	if err != nil {
 		api.HandleBadRequest(response, request, err)
 		return
@@ -566,7 +565,6 @@ func (h *iamHandler) UpdateUser(request *restful.Request, response *restful.Resp
 	}
 
 	operator, ok := apirequest.UserFrom(request.Request.Context())
-
 	if globalRole != "" && ok {
 		err = h.updateGlobalRoleBinding(operator, updated, globalRole)
 		if err != nil {

--- a/pkg/models/iam/im/im.go
+++ b/pkg/models/iam/im/im.go
@@ -64,12 +64,9 @@ func (im *imOperator) UpdateUser(new *iamv1alpha2.User) (*iamv1alpha2.User, erro
 		klog.Error(err)
 		return nil, err
 	}
-	if old.Annotations == nil {
-		old.Annotations = make(map[string]string, 0)
-	}
 	// keep encrypted password
 	new.Spec.EncryptedPassword = old.Spec.EncryptedPassword
-	updated, err := im.ksClient.IamV1alpha2().Users().Update(context.Background(), old, metav1.UpdateOptions{})
+	updated, err := im.ksClient.IamV1alpha2().Users().Update(context.Background(), new, metav1.UpdateOptions{})
 	if err != nil {
 		klog.Error(err)
 		return nil, err


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The wrong object was used when using the UpdateUser method, which made the user update API unavailable and unable to modify the user's language and description.

**Which issue(s) this PR fixes**:

Fixes #3407