### PR TITLE
fix bug can not search auditing logs with nil namespace

### DIFF
--- a/pkg/simple/client/auditing/elasticsearch/elasticsearch.go
+++ b/pkg/simple/client/auditing/elasticsearch/elasticsearch.go
@@ -114,14 +114,14 @@ func parseToQueryPart(f *auditing.Filter) *query.Query {
 	bi := query.NewBool().WithMinimumShouldMatch(mini)
 	for k, v := range f.ObjectRefNamespaceMap {
 		bi.AppendShould(query.NewBool().
-			AppendFilter(query.NewMatchPhrase("ObjectRef.Namespace", k)).
+			AppendFilter(query.NewMatchPhrase("ObjectRef.Namespace.keyword", k)).
 			AppendFilter(query.NewRange("RequestReceivedTimestamp").
 				WithGTE(v)))
 	}
 
 	for k, v := range f.WorkspaceMap {
 		bi.AppendShould(query.NewBool().
-			AppendFilter(query.NewMatchPhrase("Workspace", k)).
+			AppendFilter(query.NewMatchPhrase("Workspace.keyword", k)).
 			AppendFilter(query.NewRange("RequestReceivedTimestamp").
 				WithGTE(v)))
 	}
@@ -159,10 +159,10 @@ func parseToQueryPart(f *auditing.Filter) *query.Query {
 	b.AppendFilter(bi)
 
 	b.AppendFilter(query.NewBool().
-		AppendMultiShould(query.NewMultiMatchPhrase("Verb", f.Verbs)).
+		AppendMultiShould(query.NewMultiMatchPhrase("Verb.keyword", f.Verbs)).
 		WithMinimumShouldMatch(mini))
 	b.AppendFilter(query.NewBool().
-		AppendMultiShould(query.NewMultiMatchPhrase("Level", f.Levels)).
+		AppendMultiShould(query.NewMultiMatchPhrase("Level.keyword", f.Levels)).
 		WithMinimumShouldMatch(mini))
 
 	bi = query.NewBool().WithMinimumShouldMatch(mini)
@@ -197,7 +197,7 @@ func parseToQueryPart(f *auditing.Filter) *query.Query {
 		AppendShould(query.NewTerms("ResponseStatus.code", f.ResponseCodes)).
 		WithMinimumShouldMatch(mini))
 	b.AppendFilter(query.NewBool().
-		AppendMultiShould(query.NewMultiMatchPhrase("ResponseStatus.status", f.ResponseStatus)).
+		AppendMultiShould(query.NewMultiMatchPhrase("ResponseStatus.status.keyword", f.ResponseStatus)).
 		WithMinimumShouldMatch(mini))
 
 	r := query.NewRange("RequestReceivedTimestamp")

--- a/pkg/simple/client/auditing/elasticsearch/elasticsearch_test.go
+++ b/pkg/simple/client/auditing/elasticsearch/elasticsearch_test.go
@@ -154,7 +154,7 @@ func TestParseToQueryPart(t *testing.T) {
                                     "filter":[
                                         {
                                             "match_phrase":{
-                                                "ObjectRef.Namespace":"kubesphere-system"
+                                                "ObjectRef.Namespace.keyword":"kubesphere-system"
                                             }
                                         },
                                         {
@@ -172,7 +172,7 @@ func TestParseToQueryPart(t *testing.T) {
                                     "filter":[
                                         {
                                             "match_phrase":{
-                                                "Workspace":"system-workspace"
+                                                "Workspace.keyword":"system-workspace"
                                             }
                                         },
                                         {
@@ -218,7 +218,7 @@ func TestParseToQueryPart(t *testing.T) {
                         "should":[
                             {
                                 "match_phrase":{
-                                    "Verb":"create"
+                                    "Verb.keyword":"create"
                                 }
                             }
                         ],
@@ -230,7 +230,7 @@ func TestParseToQueryPart(t *testing.T) {
                         "should":[
                             {
                                 "match_phrase":{
-                                    "Level":"Metadata"
+                                    "Level.keyword":"Metadata"
                                 }
                             }
                         ],
@@ -328,7 +328,7 @@ func TestParseToQueryPart(t *testing.T) {
                         "should":[
                             {
                                 "match_phrase":{
-                                    "ResponseStatus.status":"Failure"
+                                    "ResponseStatus.status.keyword":"Failure"
                                 }
                             }
                         ],

--- a/pkg/simple/client/es/response.go
+++ b/pkg/simple/client/es/response.go
@@ -6,9 +6,9 @@ import (
 )
 
 type Response struct {
-	ScrollId      string `json:"_scroll_id,omitempty"`
-	Hits          `json:"hits,omitempty"`
-	*Aggregations `json:"aggregations,omitempty"`
+	ScrollId     string `json:"_scroll_id,omitempty"`
+	Hits         `json:"hits,omitempty"`
+	Aggregations `json:"aggregations,omitempty"`
 }
 
 type Hits struct {
@@ -22,8 +22,8 @@ type Hit struct {
 }
 
 type Aggregations struct {
-	*CardinalityAggregation   `json:"cardinality_aggregation,omitempty"`
-	*DateHistogramAggregation `json:"date_histogram_aggregation,omitempty"`
+	CardinalityAggregation   `json:"cardinality_aggregation,omitempty"`
+	DateHistogramAggregation `json:"date_histogram_aggregation,omitempty"`
 }
 
 type CardinalityAggregation struct {

--- a/pkg/simple/client/events/elasticsearch/elasticsearch.go
+++ b/pkg/simple/client/events/elasticsearch/elasticsearch.go
@@ -74,9 +74,6 @@ func (c *client) CountOverTime(filter *events.Filter, interval string) (*events.
 	if err != nil {
 		return nil, err
 	}
-	if resp == nil || resp.Aggregations.DateHistogramAggregation == nil {
-		return &events.Histogram{}, nil
-	}
 
 	histo := events.Histogram{Total: c.c.GetTotalHitCount(resp.Total)}
 	for _, bucket := range resp.Buckets {
@@ -97,9 +94,6 @@ func (c *client) StatisticsOnResources(filter *events.Filter) (*events.Statistic
 	resp, err := c.c.Search(b, filter.StartTime, filter.EndTime, false)
 	if err != nil {
 		return nil, err
-	}
-	if resp == nil || resp.Aggregations.CardinalityAggregation == nil {
-		return &events.Statistics{}, nil
 	}
 
 	return &events.Statistics{


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@yunify.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:
fix bug can not search auditing logs with nil namespace



**Special notes for reviewers**:
```
/assign @zryfish 
/assign @benjaminhuo 
```

