### PR TITLE
change kubesphere-monitoring-federated to system namespace

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -128,7 +128,7 @@ const (
 
 	NotificationTag             = "Notification"
 	NotificationSecretNamespace = "kubesphere-monitoring-federated"
-	NotificationManagedLabel    = "notification/managed"
+	NotificationManagedLabel    = "notification.kubesphere.io/managed"
 )
 
 var (

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -128,6 +128,7 @@ const (
 
 	NotificationTag             = "Notification"
 	NotificationSecretNamespace = "kubesphere-monitoring-federated"
+	NotificationManagedLabel    = "notification/managed"
 )
 
 var (

--- a/pkg/controller/notification/notification_controller_test.go
+++ b/pkg/controller/notification/notification_controller_test.go
@@ -47,6 +47,9 @@ var (
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
 				Namespace: constants.NotificationSecretNamespace,
+				Labels: map[string]string{
+					constants.NotificationManagedLabel: "true",
+				},
 			},
 		}
 

--- a/pkg/models/notification/notification_test.go
+++ b/pkg/models/notification/notification_test.go
@@ -111,7 +111,7 @@ func TestOperator_Create(t *testing.T) {
 					Name:      "test",
 					Namespace: constants.NotificationSecretNamespace,
 					Labels: map[string]string{
-						"type": "global",
+						constants.NotificationManagedLabel: "true",
 					},
 				},
 			},
@@ -119,7 +119,7 @@ func TestOperator_Create(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 					Labels: map[string]string{
-						"type": "global",
+						constants.NotificationManagedLabel: "true",
 					},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@yunify.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
 /kind feature

**What this PR does / why we need it**:
With this pr, the federatednamespace `kubesphere-monitoring-federated` will not create by `ks-apiserver`, it will be created by `ks-installer` after the multicluster enabled.


**Special notes for reviewers**:
```
/assign @benjaminhuo 
/assign @zryfish 
```
