### PR TITLE
fix the panic caused by parsing requestinfo slice access out of bounds

### DIFF
--- a/pkg/apiserver/request/requestinfo.go
+++ b/pkg/apiserver/request/requestinfo.go
@@ -181,7 +181,7 @@ func (r *RequestInfoFactory) NewRequestInfo(req *http.Request) (*RequestInfo, er
 	requestInfo.APIVersion = currentParts[0]
 	currentParts = currentParts[1:]
 
-	if specialVerbs.Has(currentParts[0]) {
+	if len(currentParts) > 0 && specialVerbs.Has(currentParts[0]) {
 		if len(currentParts) < 2 {
 			return &requestInfo, fmt.Errorf("unable to determine kind and namespace from url: %v", req.URL)
 		}


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug


**What this PR does / why we need it**:
There is a panic problem in the parsing requestinfo


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes panic problem

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
