### PR TITLE
Fix the BitBucket endpoint URL redundant checking

### DIFF
--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -542,7 +542,7 @@ func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops
 		webservice.Route(webservice.POST("/scms/{scm}/servers").
 			To(projectPipelineHandler.CreateSCMServers).
 			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsScmTag}).
-			Doc("Create scm server in the jenkins.").
+			Doc("Create scm server if it does not exist in the Jenkins.").
 			Param(webservice.PathParameter("scm", "The ID of the source configuration management (SCM).")).
 			Reads(devops.CreateScmServerReq{}).
 			Returns(http.StatusOK, RespOK, devops.SCMServer{}).

--- a/pkg/models/devops/devops.go
+++ b/pkg/models/devops/devops.go
@@ -43,6 +43,7 @@ import (
 	"kubesphere.io/kubesphere/pkg/simple/client/devops"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 )
 
@@ -826,6 +827,7 @@ func (d devopsOperator) GetOrgRepo(scmId, organizationId string, req *http.Reque
 	return res, err
 }
 
+// CreateSCMServers creates a Bitbucket server config item in Jenkins configuration if there's no same API address exist
 func (d devopsOperator) CreateSCMServers(scmId string, req *http.Request) (*devops.SCMServer, error) {
 
 	requestBody, err := ioutil.ReadAll(req.Body)
@@ -846,8 +848,9 @@ func (d devopsOperator) CreateSCMServers(scmId string, req *http.Request) (*devo
 		return nil, err
 	}
 
+	createReq.ApiURL = strings.TrimSuffix(createReq.ApiURL, "/")
 	for _, server := range servers {
-		if server.ApiURL == createReq.ApiURL {
+		if strings.TrimSuffix(server.ApiURL, "/") == createReq.ApiURL {
 			return &server, nil
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/area devops

**What this PR does / why we need it**:
Users cannot create a Bitbucket mutli-branch Pipeline if the address has a suffix `/`, and the Jenkins side does not have. But users don't understand the details.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3530

**Special notes for reviewers**:

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
