### PR TITLE
Fix: handle invalid semver

### DIFF
--- a/pkg/controller/openpitrix/helmapplication/helm_application_controller.go
+++ b/pkg/controller/openpitrix/helmapplication/helm_application_controller.go
@@ -52,7 +52,7 @@ const (
 )
 
 func (r *ReconcileHelmApplication) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	klog.V(4).Info("sync helm application")
+	klog.V(4).Infof("sync helm application: %s ", request.String())
 
 	rootCtx := context.Background()
 	app := &v1alpha1.HelmApplication{}

--- a/pkg/models/openpitrix/utils.go
+++ b/pkg/models/openpitrix/utils.go
@@ -32,7 +32,6 @@ import (
 	"kubesphere.io/kubesphere/pkg/utils/stringutils"
 	"path"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 )
@@ -320,10 +319,16 @@ func convertApp(app *v1alpha1.HelmApplication, versions []*v1alpha1.HelmApplicat
 	} else {
 		out.CategorySet = AppCategorySet{}
 	}
-	if versions != nil && len(versions) > 0 {
-		sort.Sort(AppVersions(versions))
-		out.LatestAppVersion = convertAppVersion(versions[len(versions)-1])
-	} else {
+
+	for _, version := range versions {
+		if app.Status.LatestVersion == version.GetVersionName() {
+			// find the latest version, and convert its format
+			out.LatestAppVersion = convertAppVersion(version)
+			break
+		}
+	}
+
+	if out.LatestAppVersion == nil {
 		out.LatestAppVersion = &AppVersion{}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/area app-management


**Which issue(s) this PR fixes**:
Handle ks-controller-manager crash when  semantic version is invalid.

Fixes #3552 #3551





