### PR TITLE
Fix fields missing when convert Jenkinsfile to JSON

### DIFF
--- a/pkg/kapis/devops/v1alpha2/register.go
+++ b/pkg/kapis/devops/v1alpha2/register.go
@@ -614,6 +614,13 @@ func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops
 			Writes(devops.ResJenkinsfile{}))
 
 		// match /pipeline-model-converter/toJson
+		/*
+		 * Considering the following reasons, we use a generic data struct here.
+		 * - A fixed go struct might need to change again once Jenkins has new features.
+		 * - No refer requirement for the specific data struct
+		 * Please read the official document if you want to know more details
+		 * https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/fc8d22192d7d3a17badc3b8af7191a84bb7fd4ca/EXTENDING.md#conversion-to-json-representation-from-jenkinsfile
+		 */
 		webservice.Route(webservice.POST("/tojson").
 			To(projectPipelineHandler.ToJson).
 			Metadata(restfulspec.KeyOpenAPITags, []string{constants.DevOpsJenkinsfileTag}).
@@ -621,8 +628,8 @@ func AddPipelineToWebService(webservice *restful.WebService, devopsClient devops
 			Produces("application/json", "charset=utf-8").
 			Doc("Convert jenkinsfile to json format. Usually the frontend uses json to show or edit pipeline").
 			Reads(devops.ReqJenkinsfile{}).
-			Returns(http.StatusOK, RespOK, devops.ResJson{}).
-			Writes(devops.ResJson{}))
+			Returns(http.StatusOK, RespOK, map[string]interface{}{}).
+			Writes(map[string]interface{}{}))
 	}
 	return nil
 }

--- a/pkg/models/devops/devops.go
+++ b/pkg/models/devops/devops.go
@@ -115,7 +115,7 @@ type DevopsOperator interface {
 	CheckCron(projectName string, req *http.Request) (*devops.CheckCronRes, error)
 
 	ToJenkinsfile(req *http.Request) (*devops.ResJenkinsfile, error)
-	ToJson(req *http.Request) (*devops.ResJson, error)
+	ToJson(req *http.Request) (map[string]interface{}, error)
 }
 
 type devopsOperator struct {
@@ -932,7 +932,7 @@ func (d devopsOperator) ToJenkinsfile(req *http.Request) (*devops.ResJenkinsfile
 	return res, err
 }
 
-func (d devopsOperator) ToJson(req *http.Request) (*devops.ResJson, error) {
+func (d devopsOperator) ToJson(req *http.Request) (map[string]interface{}, error) {
 
 	res, err := d.devopsClient.ToJson(convertToHttpParameters(req))
 	if err != nil {

--- a/pkg/simple/client/devops/fake/fakedevops.go
+++ b/pkg/simple/client/devops/fake/fakedevops.go
@@ -297,7 +297,7 @@ func (d *Devops) CheckCron(projectName string, httpParameters *devops.HttpParame
 func (d *Devops) ToJenkinsfile(httpParameters *devops.HttpParameters) (*devops.ResJenkinsfile, error) {
 	return nil, nil
 }
-func (d *Devops) ToJson(httpParameters *devops.HttpParameters) (*devops.ResJson, error) {
+func (d *Devops) ToJson(httpParameters *devops.HttpParameters) (map[string]interface{}, error) {
 	return nil, nil
 }
 

--- a/pkg/simple/client/devops/jenkins/jenkins.go
+++ b/pkg/simple/client/devops/jenkins/jenkins.go
@@ -872,7 +872,7 @@ func (j *Jenkins) ToJenkinsfile(httpParameters *devops.HttpParameters) (*devops.
 	return res, err
 }
 
-func (j *Jenkins) ToJson(httpParameters *devops.HttpParameters) (*devops.ResJson, error) {
+func (j *Jenkins) ToJson(httpParameters *devops.HttpParameters) (map[string]interface{}, error) {
 	PipelineOjb := &Pipeline{
 		HttpParameters: httpParameters,
 		Jenkins:        j,

--- a/pkg/simple/client/devops/jenkins/pipeline.go
+++ b/pkg/simple/client/devops/jenkins/pipeline.go
@@ -856,19 +856,10 @@ func (p *Pipeline) ToJenkinsfile() (*devops.ResJenkinsfile, error) {
 	return &jenkinsfile, err
 }
 
-func (p *Pipeline) ToJson() (*devops.ResJson, error) {
-	res, err := p.Jenkins.SendPureRequest(p.Path, p.HttpParameters)
-	if err != nil {
-		klog.Error(err)
-		return nil, err
+func (p *Pipeline) ToJson() (result map[string]interface{}, err error) {
+	var data []byte
+	if data, err = p.Jenkins.SendPureRequest(p.Path, p.HttpParameters); err == nil {
+		err = json.Unmarshal(data, &result)
 	}
-
-	var toJson devops.ResJson
-	err = json.Unmarshal(res, &toJson)
-	if err != nil {
-		klog.Error(err)
-		return nil, err
-	}
-
-	return &toJson, err
+	return
 }

--- a/pkg/simple/client/devops/pipeline.go
+++ b/pkg/simple/client/devops/pipeline.go
@@ -1025,40 +1025,6 @@ type ReqJenkinsfile struct {
 	Jenkinsfile string `json:"jenkinsfile,omitempty" description:"jenkinsfile"`
 }
 
-type ResJson struct {
-	Status string `json:"status,omitempty" description:"status e.g. ok"`
-	Data   struct {
-		Result string `json:"result,omitempty" description:"result e.g. success"`
-		JSON   struct {
-			Pipeline struct {
-				Stages []interface{} `json:"stages,omitempty" description:"stages"`
-				Agent  struct {
-					Type      string `json:"type,omitempty" description:"type"`
-					Arguments []struct {
-						Key   string `json:"key,omitempty" description:"key"`
-						Value struct {
-							IsLiteral bool   `json:"isLiteral,omitempty" description:"is literal or not"`
-							Value     string `json:"value,omitempty" description:"value"`
-						} `json:"value,omitempty"`
-					} `json:"arguments,omitempty"`
-				} `json:"agent,omitempty"`
-				Parameters struct {
-					Parameters []struct {
-						Name      string `json:"name,omitempty" description:"name"`
-						Arguments []struct {
-							Key   string `json:"key,omitempty" description:"key"`
-							Value struct {
-								IsLiteral bool        `json:"isLiteral,omitempty" description:"is literal or not"`
-								Value     interface{} `json:"value,omitempty" description:"value"`
-							} `json:"value,omitempty"`
-						} `json:"arguments,omitempty"`
-					} `json:"parameters,omitempty"`
-				} `json:"parameters,omitempty"`
-			} `json:"pipeline,omitempty"`
-		} `json:"json,omitempty"`
-	} `json:"data,omitempty"`
-}
-
 type NodesDetail struct {
 	Class string `json:"_class,omitempty" description:"It’s a fully qualified name and is an identifier of the producer of this resource's capability."`
 	Links struct {
@@ -1202,5 +1168,5 @@ type PipelineOperator interface {
 	CheckScriptCompile(projectName, pipelineName string, httpParameters *HttpParameters) (*CheckScript, error)
 	CheckCron(projectName string, httpParameters *HttpParameters) (*CheckCronRes, error)
 	ToJenkinsfile(httpParameters *HttpParameters) (*ResJenkinsfile, error)
-	ToJson(httpParameters *HttpParameters) (*ResJson, error)
+	ToJson(httpParameters *HttpParameters) (map[string]interface{}, error)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/area devops

**What this PR does / why we need it**:
Some fields was missing due to the struct does not have all the fields which comes from Jenkins. Such as, the fields `environment` missed.

I changed the struct to a generic data. There're two reasons here:
* A fixed go struct might need to change again once Jenkins has new features
* No other references with the struct, so it's ok that we removed it

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubesphere/console#1575

**Special notes for reviewers**:

**Additional documentation, usage docs, etc.**:

