### PR TITLE
Fix that devops admin users cannot approve a Pipeline input

### DIFF
--- a/pkg/apiserver/authorization/authorizer/interfaces.go
+++ b/pkg/apiserver/authorization/authorizer/interfaces.go
@@ -209,4 +209,6 @@ const (
 	VerbGet = "get"
 	// VerbWatch represents the verb of watching a resource
 	VerbWatch = "watch"
+	// VerbDelete represents the verb of deleting a resource
+	VerbDelete = "delete"
 )

--- a/pkg/kapis/devops/v1alpha2/devops.go
+++ b/pkg/kapis/devops/v1alpha2/devops.go
@@ -307,8 +307,9 @@ func (h *ProjectPipelineHandler) approvableCheck(nodes []clientDevOps.NodesDetai
 	if userInfo, ok = request.UserFrom(pipe.Context); ok {
 		createAuth := authorizer.AttributesRecord{
 			User:            userInfo,
-			Verb:            authorizer.VerbCreate,
+			Verb:            authorizer.VerbDelete,
 			Workspace:       pipe.Workspace,
+			DevOps:          pipe.ProjectName,
 			Resource:        "devopsprojects",
 			ResourceRequest: true,
 			ResourceScope:   request.DevOpsScope,


### PR DESCRIPTION

**What type of PR is this?**
/kind bug
/area devops

**What this PR does / why we need it**:
DevOps admin users cannot approve or reject a Pipeline input. I've fixed the wrong permission check, before this PR the only the platform admin can approve or reject a Pipeline input.

Please read the official document of Jenkins Pipeline [input](https://www.jenkins.io/doc/book/pipeline/syntax/#input) if you want to know more details about it.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3513

**Special notes for reviewers**:
None.

**Additional documentation, usage docs, etc.**:
None.

