### PR TITLE
Let ks-apiserver optionally support authentication enabled and es without authentication enabled;

### DIFF
--- a/pkg/simple/client/auditing/elasticsearch/elasticsearch.go
+++ b/pkg/simple/client/auditing/elasticsearch/elasticsearch.go
@@ -101,7 +101,7 @@ func NewClient(options *auditing.Options) (auditing.Client, error) {
 	c := &client{}
 
 	var err error
-	c.c, err = es.NewClient(options.Host, options.IndexPrefix, options.Version)
+	c.c, err = es.NewClient(options.Host, options.BasicAuth, options.Username, options.Password, options.IndexPrefix, options.Version)
 	return c, err
 }
 

--- a/pkg/simple/client/auditing/options.go
+++ b/pkg/simple/client/auditing/options.go
@@ -34,6 +34,9 @@ type Options struct {
 	// The batch interval of auditing events.
 	EventBatchInterval time.Duration `json:"eventBatchInterval" yaml:"eventBatchInterval"`
 	Host               string        `json:"host" yaml:"host"`
+	BasicAuth          bool          `json:"basicAuth" yaml:"basicAuth"`
+	Username           string        `json:"username" yaml:"username"`
+	Password           string        `json:"password" yaml:"password"`
 	IndexPrefix        string        `json:"indexPrefix,omitempty" yaml:"indexPrefix"`
 	Version            string        `json:"version" yaml:"version"`
 }
@@ -61,6 +64,21 @@ func (s *Options) AddFlags(fs *pflag.FlagSet, c *Options) {
 	fs.BoolVar(&s.Enable, "auditing-enabled", c.Enable, "Enable auditing component or not. ")
 
 	fs.StringVar(&s.WebhookUrl, "auditing-webhook-url", c.WebhookUrl, "Auditing wehook url")
+
+	fs.BoolVar(&s.BasicAuth, "auditing-elasticsearch-basicAuth", c.BasicAuth, ""+
+		"Elasticsearch auditing service basic auth enabled. KubeSphere is using elastic as auditing store, "+
+		"if it is set to true, KubeSphere will connect to ElasticSearch using provided username and password by "+
+		"auditing-elasticsearch-username and auditing-elasticsearch-username. Otherwise, KubeSphere will "+
+		"anonymously access the Elasticsearch.")
+
+	fs.StringVar(&s.Username, "auditing-elasticsearch-username", c.Username, ""+
+		"ElasticSearch authentication username, only needed when auditing-elasticsearch-basicAuth is"+
+		"set to true. ")
+
+	fs.StringVar(&s.Password, "auditing-elasticsearch-password", c.Password, ""+
+		"ElasticSearch authentication password, only needed when auditing-elasticsearch-basicAuth is"+
+		"set to true. ")
+
 	fs.IntVar(&s.EventSendersNum, "auditing-event-senders-num", c.EventSendersNum,
 		"The maximum concurrent senders which send auditing events to the auditing webhook.")
 	fs.IntVar(&s.EventBatchSize, "auditing-event-batch-size", c.EventBatchSize,

--- a/pkg/simple/client/es/client.go
+++ b/pkg/simple/client/es/client.go
@@ -41,29 +41,35 @@ const (
 
 // Elasticsearch client
 type Client struct {
-	host    string
-	version string
-	index   string
+	host      string
+	basicAuth bool
+	username  string
+	password  string
+	version   string
+	index     string
 
 	c   versions.Client
 	mux sync.Mutex
 }
 
-func NewClient(host, indexPrefix, version string) (*Client, error) {
+func NewClient(host string, basicAuth bool, username, password, indexPrefix, version string) (*Client, error) {
 	var err error
 	es := &Client{
-		host:    host,
-		version: version,
-		index:   indexPrefix,
+		host:      host,
+		basicAuth: basicAuth,
+		username:  username,
+		password:  password,
+		version:   version,
+		index:     indexPrefix,
 	}
 
 	switch es.version {
 	case ElasticV5:
-		es.c, err = v5.New(es.host, es.index)
+		es.c, err = v5.New(es.host, es.basicAuth, es.username, es.password, es.index)
 	case ElasticV6:
-		es.c, err = v6.New(es.host, es.index)
+		es.c, err = v6.New(es.host, es.basicAuth, es.username, es.password, es.index)
 	case ElasticV7:
-		es.c, err = v7.New(es.host, es.index)
+		es.c, err = v7.New(es.host, es.basicAuth, es.username, es.password, es.index)
 	case "":
 		es.c = nil
 	default:
@@ -89,7 +95,7 @@ func (c *Client) loadClient() error {
 
 	// Detect Elasticsearch server version using Info API.
 	// Info API is backward compatible across v5, v6 and v7.
-	esv6, err := v6.New(c.host, "")
+	esv6, err := v6.New(c.host, c.basicAuth, c.username, c.password, c.index)
 	if err != nil {
 		return err
 	}
@@ -126,11 +132,11 @@ func (c *Client) loadClient() error {
 	v := strings.Split(number, ".")[0]
 	switch v {
 	case ElasticV5:
-		vc, err = v5.New(c.host, c.index)
+		vc, err = v5.New(c.host, c.basicAuth, c.username, c.password, c.index)
 	case ElasticV6:
-		vc, err = v6.New(c.host, c.index)
+		vc, err = v6.New(c.host, c.basicAuth, c.username, c.password, c.index)
 	case ElasticV7:
-		vc, err = v7.New(c.host, c.index)
+		vc, err = v7.New(c.host, c.basicAuth, c.username, c.password, c.index)
 	default:
 		err = fmt.Errorf("unsupported elasticsearch version %s", version)
 	}

--- a/pkg/simple/client/es/client_test.go
+++ b/pkg/simple/client/es/client_test.go
@@ -90,7 +90,7 @@ func TestClient_Search(t *testing.T) {
 			srv := mockElasticsearchService("/ks-logstash*/_search", test.fakeResp, test.fakeCode)
 			defer srv.Close()
 
-			c, err := NewClient(srv.URL, "ks-logstash", test.fakeVersion)
+			c, err := NewClient(srv.URL, false, "", "", "ks-logstash", test.fakeVersion)
 			if err != nil {
 				t.Fatalf("create client error, %s", err)
 			}

--- a/pkg/simple/client/es/versions/v5/v5.go
+++ b/pkg/simple/client/es/versions/v5/v5.go
@@ -33,9 +33,19 @@ type Elastic struct {
 	index  string
 }
 
-func New(address string, index string) (*Elastic, error) {
-	client, err := elasticsearch.NewClient(elasticsearch.Config{
+func New(address string, basicAuth bool, username, password, index string) (*Elastic, error) {
+	var client *elasticsearch.Client
+	var err error
+
+	if !basicAuth {
+		username = ""
+		password = ""
+	}
+
+	client, err = elasticsearch.NewClient(elasticsearch.Config{
 		Addresses: []string{address},
+		Username:  username,
+		Password:  password,
 	})
 
 	return &Elastic{client: client, index: index}, err

--- a/pkg/simple/client/es/versions/v6/v6.go
+++ b/pkg/simple/client/es/versions/v6/v6.go
@@ -33,9 +33,19 @@ type Elastic struct {
 	index  string
 }
 
-func New(address string, index string) (*Elastic, error) {
-	client, err := elasticsearch.NewClient(elasticsearch.Config{
+func New(address string, basicAuth bool, username, password, index string) (*Elastic, error) {
+	var client *elasticsearch.Client
+	var err error
+
+	if !basicAuth {
+		username = ""
+		password = ""
+	}
+
+	client, err = elasticsearch.NewClient(elasticsearch.Config{
 		Addresses: []string{address},
+		Username:  username,
+		Password:  password,
 	})
 
 	return &Elastic{Client: client, index: index}, err

--- a/pkg/simple/client/es/versions/v7/v7.go
+++ b/pkg/simple/client/es/versions/v7/v7.go
@@ -33,9 +33,19 @@ type Elastic struct {
 	index  string
 }
 
-func New(address string, index string) (*Elastic, error) {
-	client, err := elasticsearch.NewClient(elasticsearch.Config{
+func New(address string, basicAuth bool, username, password, index string) (*Elastic, error) {
+	var client *elasticsearch.Client
+	var err error
+
+	if !basicAuth {
+		username = ""
+		password = ""
+	}
+
+	client, err = elasticsearch.NewClient(elasticsearch.Config{
 		Addresses: []string{address},
+		Username:  username,
+		Password:  password,
 	})
 
 	return &Elastic{client: client, index: index}, err

--- a/pkg/simple/client/events/elasticsearch/elasticsearch.go
+++ b/pkg/simple/client/events/elasticsearch/elasticsearch.go
@@ -32,7 +32,7 @@ func NewClient(options *events.Options) (events.Client, error) {
 	c := &client{}
 
 	var err error
-	c.c, err = es.NewClient(options.Host, options.IndexPrefix, options.Version)
+	c.c, err = es.NewClient(options.Host, options.BasicAuth, options.Username, options.Password, options.IndexPrefix, options.Version)
 	return c, err
 }
 

--- a/pkg/simple/client/events/options.go
+++ b/pkg/simple/client/events/options.go
@@ -24,6 +24,9 @@ import (
 
 type Options struct {
 	Host        string `json:"host" yaml:"host"`
+	BasicAuth   bool   `json:"basicAuth" yaml:"basicAuth"`
+	Username    string `json:"username" yaml:"username"`
+	Password    string `json:"password" yaml:"password"`
 	IndexPrefix string `json:"indexPrefix,omitempty" yaml:"indexPrefix"`
 	Version     string `json:"version" yaml:"version"`
 }
@@ -53,6 +56,20 @@ func (s *Options) AddFlags(fs *pflag.FlagSet, c *Options) {
 		"Elasticsearch service host. KubeSphere is using elastic as event store, "+
 		"if this filed left blank, KubeSphere will use kubernetes builtin event API instead, and"+
 		" the following elastic search options will be ignored.")
+
+	fs.BoolVar(&s.BasicAuth, "events-elasticsearch-basicAuth", c.BasicAuth, ""+
+		"Elasticsearch events service basic auth enabled. KubeSphere is using elastic as events store, "+
+		"if it is set to true, KubeSphere will connect to ElasticSearch using provided username and password by "+
+		"events-elasticsearch-username and events-elasticsearch-username. Otherwise, KubeSphere will "+
+		"anonymously access the Elasticsearch.")
+
+	fs.StringVar(&s.Username, "events-elasticsearch-username", c.Username, ""+
+		"ElasticSearch authentication username, only needed when events-elasticsearch-basicAuth is"+
+		"set to true. ")
+
+	fs.StringVar(&s.Password, "events-elasticsearch-password", c.Password, ""+
+		"ElasticSearch authentication password, only needed when events-elasticsearch-basicAuth is"+
+		"set to true. ")
 
 	fs.StringVar(&s.IndexPrefix, "events-index-prefix", c.IndexPrefix, ""+
 		"Index name prefix. KubeSphere will retrieve events against indices matching the prefix.")

--- a/pkg/simple/client/logging/elasticsearch/elasticsearch.go
+++ b/pkg/simple/client/logging/elasticsearch/elasticsearch.go
@@ -59,7 +59,7 @@ func NewClient(options *logging.Options) (logging.Client, error) {
 	c := &client{}
 
 	var err error
-	c.c, err = es.NewClient(options.Host, options.IndexPrefix, options.Version)
+	c.c, err = es.NewClient(options.Host, options.BasicAuth, options.Username, options.Password, options.IndexPrefix, options.Version)
 	return c, err
 }
 

--- a/pkg/simple/client/logging/options.go
+++ b/pkg/simple/client/logging/options.go
@@ -24,6 +24,9 @@ import (
 
 type Options struct {
 	Host        string `json:"host" yaml:"host"`
+	BasicAuth   bool   `json:"basicAuth" yaml:"basicAuth"`
+	Username    string `json:"username" yaml:"username"`
+	Password    string `json:"password" yaml:"password"`
 	IndexPrefix string `json:"indexPrefix,omitempty" yaml:"indexPrefix"`
 	Version     string `json:"version" yaml:"version"`
 }
@@ -52,6 +55,20 @@ func (s *Options) AddFlags(fs *pflag.FlagSet, c *Options) {
 		"Elasticsearch logging service host. KubeSphere is using elastic as log store, "+
 		"if this filed left blank, KubeSphere will use kubernetes builtin log API instead, and"+
 		" the following elastic search options will be ignored.")
+
+	fs.BoolVar(&s.BasicAuth, "logging-elasticsearch-basicAuth", c.BasicAuth, ""+
+		"Elasticsearch logging service basic auth enabled. KubeSphere is using elastic as logging store, "+
+		"if it is set to true, KubeSphere will connect to ElasticSearch using provided username and password by "+
+		"logging-elasticsearch-username and logging-elasticsearch-username. Otherwise, KubeSphere will "+
+		"anonymously access the Elasticsearch.")
+
+	fs.StringVar(&s.Username, "logging-elasticsearch-username", c.Username, ""+
+		"ElasticSearch authentication username, only needed when logging-elasticsearch-basicAuth is"+
+		"set to true. ")
+
+	fs.StringVar(&s.Password, "logging-elasticsearch-password", c.Password, ""+
+		"ElasticSearch authentication password, only needed when logging-elasticsearch-basicAuth is"+
+		"set to true. ")
 
 	fs.StringVar(&s.IndexPrefix, "logging-index-prefix", c.IndexPrefix, ""+
 		"Index name prefix. KubeSphere will retrieve logs against indices matching the prefix.")


### PR DESCRIPTION
Let components such as ks-apiserver optionally support authentication enabled and es without authentication enabled;

Signed-off-by: Daniel Hu <farmer.hutao@outlook.com>

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

https://github.com/kubesphere/kubesphere/issues/3457

Let components such as ks-apiserver optionally support authentication enabled and es without authentication enabled;


Also ref: 
kubesphere/ks-installer#1361
kubesphere/ks-installer#1362