### PR TITLE
Add Bitbucket organization field "key"

### DIFF
--- a/pkg/simple/client/devops/pipeline.go
+++ b/pkg/simple/client/devops/pipeline.go
@@ -203,6 +203,7 @@ type SCMOrg struct {
 		} `json:"self,omitempty" description:"scm org self info"`
 	} `json:"_links,omitempty" description:"references the reachable path to this resource"`
 	Avatar                      string `json:"avatar,omitempty" description:"the url of organization avatar"`
+	Key                         string `json:"key,omitempty" description:"the key of a Bitbucket organization"`
 	JenkinsOrganizationPipeline bool   `json:"jenkinsOrganizationPipeline,omitempty" description:"weather or not already have jenkins pipeline."`
 	Name                        string `json:"name,omitempty" description:"organization name"`
 }


### PR DESCRIPTION

**What type of PR is this?**
/kind bug
/area devops

**What this PR does / why we need it**:
According to the comments which comes from [Bitbucket Branch Source Jenkins Plugin](https://github.com/jenkinsci/bitbucket-branch-source-plugin/blob/master/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/help-repoOwner.html), we need `key` instead of `name` when creating a Bitbucket multi-branch Pipeline.
```
Specify the name of the Bitbucket Team or Bitbucket User Account.

It could be a Bitbucket Project also, if using Bitbucket Server. In this case (Bitbucket Server):

Use the project key, not the project name.
If using a user account instead of a project, add a "~" character before the username, i.e. "~joe".
```

**Which issue(s) this PR fixes**:
None.

**Special notes for reviewers**:
None.

**Additional documentation, usage docs, etc.**:
None.

