### PR TITLE
fix case-insensitive keyword query and consistent state for alerting

### DIFF
--- a/pkg/api/alerting/v2alpha1/types.go
+++ b/pkg/api/alerting/v2alpha1/types.go
@@ -192,7 +192,7 @@ func (q *AlertingRuleQueryParams) Filter(rules []*GettableAlertingRule) []*Getta
 }
 
 func (q *AlertingRuleQueryParams) matches(rule *GettableAlertingRule) bool {
-	if q.NameContainFilter != "" && !containsI(rule.Name, q.NameContainFilter) {
+	if q.NameContainFilter != "" && !containsCaseInsensitive(rule.Name, q.NameContainFilter) {
 		return false
 	}
 	if q.State != "" && q.State != rule.State {
@@ -210,7 +210,7 @@ func (q *AlertingRuleQueryParams) matches(rule *GettableAlertingRule) bool {
 		}
 	}
 	for k, v := range q.LabelContainFilters {
-		if fv, ok := rule.Labels[k]; !ok || !containsI(fv, v) {
+		if fv, ok := rule.Labels[k]; !ok || !containsCaseInsensitive(fv, v) {
 			return false
 		}
 	}
@@ -340,7 +340,7 @@ func (q *AlertQueryParams) matches(alert *Alert) bool {
 		}
 	}
 	for k, v := range q.LabelContainFilters {
-		if fv, ok := alert.Labels[k]; !ok || !containsI(fv, v) {
+		if fv, ok := alert.Labels[k]; !ok || !containsCaseInsensitive(fv, v) {
 			return false
 		}
 	}
@@ -527,8 +527,8 @@ func NewBulkItemErrorServerResponse(ruleName string, err error) *BulkItemRespons
 	}
 }
 
-// containsI reports whether substr is case-insensitive within s.
-func containsI(s, substr string) bool {
+// containsCaseInsensitive reports whether substr is case-insensitive within s.
+func containsCaseInsensitive(s, substr string) bool {
 	return strings.Contains(
 		strings.ToLower(s),
 		strings.ToLower(substr))

--- a/pkg/api/alerting/v2alpha1/types.go
+++ b/pkg/api/alerting/v2alpha1/types.go
@@ -192,7 +192,7 @@ func (q *AlertingRuleQueryParams) Filter(rules []*GettableAlertingRule) []*Getta
 }
 
 func (q *AlertingRuleQueryParams) matches(rule *GettableAlertingRule) bool {
-	if q.NameContainFilter != "" && !strings.Contains(rule.Name, q.NameContainFilter) {
+	if q.NameContainFilter != "" && !containsI(rule.Name, q.NameContainFilter) {
 		return false
 	}
 	if q.State != "" && q.State != rule.State {
@@ -210,7 +210,7 @@ func (q *AlertingRuleQueryParams) matches(rule *GettableAlertingRule) bool {
 		}
 	}
 	for k, v := range q.LabelContainFilters {
-		if fv, ok := rule.Labels[k]; !ok || !strings.Contains(fv, v) {
+		if fv, ok := rule.Labels[k]; !ok || !containsI(fv, v) {
 			return false
 		}
 	}
@@ -340,7 +340,7 @@ func (q *AlertQueryParams) matches(alert *Alert) bool {
 		}
 	}
 	for k, v := range q.LabelContainFilters {
-		if fv, ok := alert.Labels[k]; !ok || !strings.Contains(fv, v) {
+		if fv, ok := alert.Labels[k]; !ok || !containsI(fv, v) {
 			return false
 		}
 	}
@@ -525,4 +525,11 @@ func NewBulkItemErrorServerResponse(ruleName string, err error) *BulkItemRespons
 		ErrorType: ErrServer,
 		Error:     err,
 	}
+}
+
+// containsI reports whether substr is case-insensitive within s.
+func containsI(s, substr string) bool {
+	return strings.Contains(
+		strings.ToLower(s),
+		strings.ToLower(substr))
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

let keyword query case-insensitive for alerting 
let consistent for listing and geting rules


**Which issue(s) this PR fixes**:

commit https://github.com/kubesphere/kubesphere/pull/3674/commits/68b0b8f4ba3614623d27f0f83881727c88fdf279 fixes https://github.com/kubesphere/kubesphere/issues/3648
commit https://github.com/kubesphere/kubesphere/pull/3674/commits/66c0e0dad1475d1cc52a34af124a681f7d880ce5 fixes consistent state for listing and geting rules

/cc @benjaminhuo 