### PR TITLE
feat: optional cascade delete resources when deleting workspace

### DIFF
--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -192,11 +192,12 @@ func (r *Reconciler) bindWorkspace(ctx context.Context, logger logr.Logger, name
 }
 
 func (r *Reconciler) unbindWorkspace(ctx context.Context, logger logr.Logger, namespace *corev1.Namespace) error {
-	if k8sutil.IsControlledBy(namespace.OwnerReferences, tenantv1alpha1.ResourceKindWorkspace, "") || len(namespace.Labels) > 0 {
+	_, hasWorkspaceLabel := namespace.Labels[tenantv1alpha1.WorkspaceLabel]
+	if hasWorkspaceLabel || k8sutil.IsControlledBy(namespace.OwnerReferences, tenantv1alpha1.ResourceKindWorkspace, "") {
 		ns := namespace.DeepCopy()
 
 		wsName := k8sutil.GetWorkspaceOwnerName(ns.OwnerReferences)
-		if _, ok := namespace.Labels[tenantv1alpha1.WorkspaceLabel]; ok {
+		if hasWorkspaceLabel {
 			wsName = namespace.Labels[tenantv1alpha1.WorkspaceLabel]
 		}
 

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -170,6 +170,10 @@ func (r *Reconciler) bindWorkspace(ctx context.Context, logger logr.Logger, name
 		// skip if workspace not found
 		return client.IgnoreNotFound(err)
 	}
+	// workspace has been deleted
+	if !workspace.ObjectMeta.DeletionTimestamp.IsZero() {
+		return r.unbindWorkspace(ctx, logger, namespace)
+	}
 	// owner reference not match workspace label
 	if !metav1.IsControlledBy(namespace, workspace) {
 		namespace := namespace.DeepCopy()
@@ -188,11 +192,18 @@ func (r *Reconciler) bindWorkspace(ctx context.Context, logger logr.Logger, name
 }
 
 func (r *Reconciler) unbindWorkspace(ctx context.Context, logger logr.Logger, namespace *corev1.Namespace) error {
-	if k8sutil.IsControlledBy(namespace.OwnerReferences, tenantv1alpha1.ResourceKindWorkspace, "") {
-		namespace := namespace.DeepCopy()
-		namespace.OwnerReferences = k8sutil.RemoveWorkspaceOwnerReference(namespace.OwnerReferences)
-		logger.V(4).Info("remove owner reference", "workspace", namespace.Labels[constants.WorkspaceLabelKey])
-		if err := r.Update(ctx, namespace); err != nil {
+	if k8sutil.IsControlledBy(namespace.OwnerReferences, tenantv1alpha1.ResourceKindWorkspace, "") || len(namespace.Labels) > 0 {
+		ns := namespace.DeepCopy()
+
+		wsName := k8sutil.GetWorkspaceOwnerName(ns.OwnerReferences)
+		if _, ok := namespace.Labels[tenantv1alpha1.WorkspaceLabel]; ok {
+			wsName = namespace.Labels[tenantv1alpha1.WorkspaceLabel]
+		}
+
+		delete(ns.Labels, constants.WorkspaceLabelKey)
+		ns.OwnerReferences = k8sutil.RemoveWorkspaceOwnerReference(ns.OwnerReferences)
+		logger.V(4).Info("remove owner reference and label", "namespace", ns.Name, "workspace", wsName)
+		if err := r.Update(ctx, ns); err != nil {
 			logger.Error(err, "update owner reference failed")
 			return err
 		}

--- a/pkg/controller/workspacetemplate/workspacetemplate_controller.go
+++ b/pkg/controller/workspacetemplate/workspacetemplate_controller.go
@@ -125,10 +125,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 			// remove our finalizer from the list and update it.
 			workspaceTemplate.ObjectMeta.Finalizers = sliceutil.RemoveString(workspaceTemplate.ObjectMeta.Finalizers, func(item string) bool {
-				return item == workspaceTemplateFinalizer
-			})
-			workspaceTemplate.ObjectMeta.Finalizers = sliceutil.RemoveString(workspaceTemplate.ObjectMeta.Finalizers, func(item string) bool {
-				return item == orphanFinalizer
+				return item == workspaceTemplateFinalizer || item == orphanFinalizer
 			})
 
 			logger.V(4).Info("update workspace template")

--- a/pkg/controller/workspacetemplate/workspacetemplate_controller.go
+++ b/pkg/controller/workspacetemplate/workspacetemplate_controller.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,8 +47,11 @@ import (
 )
 
 const (
-	controllerName             = "workspacetemplate-controller"
-	workspaceTemplateFinalizer = "finalizers.workspacetemplate.kubesphere.io"
+	controllerName                  = "workspacetemplate-controller"
+	workspaceTemplateFinalizer      = "finalizers.workspacetemplate.kubesphere.io"
+	orphanFinalizer                 = "orphan.finalizers.kubesphere.io"
+	orphanDeleteOptionAnnotationKey = "kubefed.io/deleteoption"
+	orphanDeleteOptionAnnotation    = "{\"propagationPolicy\":\"Orphan\"}"
 )
 
 // Reconciler reconciles a WorkspaceRoleBinding object
@@ -105,16 +107,30 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 	} else {
 		// The object is being deleted
-		if sliceutil.HasString(workspaceTemplate.ObjectMeta.Finalizers, workspaceTemplateFinalizer) {
+		if sliceutil.HasString(workspaceTemplate.ObjectMeta.Finalizers, workspaceTemplateFinalizer) ||
+			sliceutil.HasString(workspaceTemplate.ObjectMeta.Finalizers, orphanFinalizer) {
 			if err := r.deleteOpenPitrixResourcesInWorkspace(rootCtx, workspaceTemplate.Name); err != nil {
 				logger.Error(err, "delete resource in workspace template failed")
 				return ctrl.Result{}, err
+			}
+
+			if err := r.deleteWorkspace(rootCtx, workspaceTemplate); err != nil {
+				if errors.IsNotFound(err) {
+					logger.V(4).Info("workspace not found", "workspacerole", workspaceTemplate.Name)
+				} else {
+					logger.Error(err, "failed delete workspaces")
+					return ctrl.Result{}, nil
+				}
 			}
 
 			// remove our finalizer from the list and update it.
 			workspaceTemplate.ObjectMeta.Finalizers = sliceutil.RemoveString(workspaceTemplate.ObjectMeta.Finalizers, func(item string) bool {
 				return item == workspaceTemplateFinalizer
 			})
+			workspaceTemplate.ObjectMeta.Finalizers = sliceutil.RemoveString(workspaceTemplate.ObjectMeta.Finalizers, func(item string) bool {
+				return item == orphanFinalizer
+			})
+
 			logger.V(4).Info("update workspace template")
 			if err := r.Update(rootCtx, workspaceTemplate); err != nil {
 				logger.Error(err, "update workspace template failed")
@@ -224,9 +240,6 @@ func newFederatedWorkspace(template *tenantv1alpha2.WorkspaceTemplate) (*typesv1
 		},
 		Spec: template.Spec,
 	}
-	if err := controllerutil.SetControllerReference(template, federatedWorkspace, scheme.Scheme); err != nil {
-		return nil, err
-	}
 	return federatedWorkspace, nil
 }
 
@@ -238,10 +251,49 @@ func newWorkspace(template *tenantv1alpha2.WorkspaceTemplate) (*tenantv1alpha1.W
 		},
 		Spec: template.Spec.Template.Spec,
 	}
-	if err := controllerutil.SetControllerReference(template, workspace, scheme.Scheme); err != nil {
-		return nil, err
-	}
+
 	return workspace, nil
+}
+
+func (r *Reconciler) deleteWorkspace(ctx context.Context, template *tenantv1alpha2.WorkspaceTemplate) error {
+	if r.MultiClusterEnabled {
+		federatedWorkspace := &typesv1beta1.FederatedWorkspace{}
+		if err := r.Client.Get(ctx, types.NamespacedName{Name: template.Name}, federatedWorkspace); err != nil {
+			return err
+		}
+		// Workspace will be deleted with Orphan Option when it has a orphan finalizer.
+		// Reousrces that owned by the Workspace will not be deleted.
+		if sliceutil.HasString(template.ObjectMeta.Finalizers, orphanFinalizer) {
+			if federatedWorkspace.Annotations == nil {
+				federatedWorkspace.Annotations = make(map[string]string, 1)
+			}
+			federatedWorkspace.Annotations[orphanDeleteOptionAnnotationKey] = orphanDeleteOptionAnnotation
+			if err := r.Update(ctx, federatedWorkspace); err != nil {
+				return err
+			}
+		}
+		if err := r.Delete(ctx, federatedWorkspace); err != nil {
+			return err
+		}
+	}
+
+	opt := &client.DeleteOptions{}
+	// Dependents won't be deleted when it's has a orphanFinalizer
+	if sliceutil.HasString(template.ObjectMeta.Finalizers, orphanFinalizer) {
+		orphan := metav1.DeletePropagationOrphan
+		opt = &client.DeleteOptions{PropagationPolicy: &orphan}
+	}
+
+	ws := &tenantv1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: template.Name,
+		},
+	}
+	if err := r.Delete(ctx, ws, opt); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (r *Reconciler) ensureNotControlledByKubefed(ctx context.Context, logger logr.Logger, workspaceTemplate *tenantv1alpha2.WorkspaceTemplate) error {

--- a/pkg/controller/workspacetemplate/workspacetemplate_controller.go
+++ b/pkg/controller/workspacetemplate/workspacetemplate_controller.go
@@ -172,6 +172,7 @@ func (r *Reconciler) singleClusterSync(ctx context.Context, logger logr.Logger, 
 					logger.Error(err, "create workspace failed")
 					return err
 				}
+				return nil
 			}
 		}
 		logger.Error(err, "get workspace failed")
@@ -207,6 +208,7 @@ func (r *Reconciler) multiClusterSync(ctx context.Context, logger logr.Logger, w
 					logger.Error(err, "create federated workspace failed")
 					return err
 				}
+				return nil
 			}
 		}
 		logger.Error(err, "get federated workspace failed")

--- a/pkg/controller/workspacetemplate/workspacetemplate_controller_suite_test.go
+++ b/pkg/controller/workspacetemplate/workspacetemplate_controller_suite_test.go
@@ -17,34 +17,20 @@ limitations under the License.
 package workspacetemplate
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
-	"time"
 
-	"github.com/onsi/gomega/gexec"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/klogr"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"kubesphere.io/kubesphere/pkg/apis"
 	helmappscheme "kubesphere.io/kubesphere/pkg/apis/application/v1alpha1"
+	typesv1beta1 "kubesphere.io/kubesphere/pkg/apis/types/v1beta1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 )
-
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
-var k8sClient client.Client
-var k8sManager ctrl.Manager
-var testEnv *envtest.Environment
 
 func TestWorkspaceTemplateController(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -56,51 +42,13 @@ func TestWorkspaceTemplateController(t *testing.T) {
 var _ = BeforeSuite(func(done Done) {
 	logf.SetLogger(klogr.New())
 
-	By("bootstrapping test environment")
-	t := true
-	if os.Getenv("TEST_USE_EXISTING_CLUSTER") == "true" {
-		testEnv = &envtest.Environment{
-			UseExistingCluster: &t,
-		}
-	} else {
-		testEnv = &envtest.Environment{
-			CRDDirectoryPaths:        []string{filepath.Join("..", "..", "..", "config", "crds")},
-			AttachControlPlaneOutput: false,
-		}
-	}
-
-	cfg, err := testEnv.Start()
-	Expect(err).ToNot(HaveOccurred())
-	Expect(cfg).ToNot(BeNil())
-
+	err := helmappscheme.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 	err = apis.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:             scheme.Scheme,
-		MetricsBindAddress: "0",
-	})
-	Expect(err).ToNot(HaveOccurred())
-
-	utilruntime.Must(helmappscheme.AddToScheme(k8sManager.GetScheme()))
-
-	err = (&Reconciler{}).SetupWithManager(k8sManager)
-	Expect(err).ToNot(HaveOccurred())
-
-	go func() {
-		err = k8sManager.Start(ctrl.SetupSignalHandler())
-		Expect(err).ToNot(HaveOccurred())
-	}()
-
-	k8sClient = k8sManager.GetClient()
-	Expect(k8sClient).ToNot(BeNil())
+	err = typesv1beta1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 
 	close(done)
 }, 60)
-
-var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	gexec.KillAndWait(5 * time.Second)
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
-})

--- a/pkg/kapis/tenant/v1alpha2/handler.go
+++ b/pkg/kapis/tenant/v1alpha2/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/emicklei/go-restful"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
@@ -219,7 +220,14 @@ func (h *tenantHandler) CreateWorkspace(request *restful.Request, response *rest
 func (h *tenantHandler) DeleteWorkspace(request *restful.Request, response *restful.Response) {
 	workspace := request.PathParameter("workspace")
 
-	err := h.tenant.DeleteWorkspace(workspace)
+	opts := metav1.DeleteOptions{}
+
+	err := request.ReadEntity(&opts)
+	if err != nil {
+		opts = *metav1.NewDeleteOptions(0)
+	}
+
+	err = h.tenant.DeleteWorkspace(workspace, opts)
 
 	if err != nil {
 		klog.Error(err)

--- a/pkg/utils/k8sutil/k8sutil.go
+++ b/pkg/utils/k8sutil/k8sutil.go
@@ -44,3 +44,14 @@ func RemoveWorkspaceOwnerReference(ownerReferences []metav1.OwnerReference) []me
 	}
 	return tmp
 }
+
+// GetWorkspaceOwnerName return workspace kind owner name
+func GetWorkspaceOwnerName(ownerReferences []metav1.OwnerReference) string {
+	for _, owner := range ownerReferences {
+		if owner.Kind == tenantv1alpha1.ResourceKindWorkspace ||
+			owner.Kind == tenantv1alpha2.ResourceKindWorkspaceTemplate {
+			return owner.Name
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add DeleteOptions flags support for workspace deletion API. So user can choose whether to cascade delete related resources when deleting workspace, avoid accidental deletion of related resources.

This feature depends on Kubefed 0.7.0

**Which issue(s) this PR fixes**:
Fixes #3192

