### PR TITLE
upgrade kubefed client to v0.6.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,8 +34,7 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-ldap/ldap v3.0.3+incompatible
-	github.com/go-logr/logr v0.1.0
-	github.com/go-logr/zapr v0.1.1 // indirect
+	github.com/go-logr/logr v0.3.0
 	github.com/go-openapi/loads v0.19.5
 	github.com/go-openapi/spec v0.19.7
 	github.com/go-openapi/strfmt v0.19.5
@@ -55,8 +54,8 @@ require (
 	github.com/kubernetes-csi/external-snapshotter/client/v3 v3.0.0
 	github.com/kubesphere/sonargo v0.0.2
 	github.com/mitchellh/mapstructure v1.2.2
-	github.com/onsi/ginkgo v1.14.0
-	github.com/onsi/gomega v1.10.1
+	github.com/onsi/ginkgo v1.14.2
+	github.com/onsi/gomega v1.10.3
 	github.com/open-policy-agent/opa v0.18.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
@@ -66,12 +65,12 @@ require (
 	github.com/prometheus-community/prom-label-proxy v0.2.0
 	github.com/prometheus-operator/prometheus-operator v0.42.2-0.20200928114327-fbd01683839a
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.42.1
-	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_golang v1.8.0
 	github.com/prometheus/common v0.11.1
 	github.com/prometheus/prometheus v1.8.2-0.20200907175821-8219b442c864
 	github.com/sony/sonyflake v0.0.0-20181109022403-6d5bd6181009
 	github.com/speps/go-hashids v2.0.0+incompatible
-	github.com/spf13/cobra v1.0.0
+	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.6.1
@@ -92,26 +91,26 @@ require (
 	istio.io/api v0.0.0-20201113182140-d4b7e3fc2b44
 	istio.io/client-go v0.0.0-20201113183938-0734e976e785
 	istio.io/gogo-genproto v0.0.0-20201113182723-5b8563d8a012 // indirect
-	k8s.io/api v0.19.0
-	k8s.io/apiextensions-apiserver v0.18.6
-	k8s.io/apimachinery v0.19.0
-	k8s.io/apiserver v0.18.6
+	k8s.io/api v0.19.3
+	k8s.io/apiextensions-apiserver v0.19.3
+	k8s.io/apimachinery v0.19.3
+	k8s.io/apiserver v0.19.3
 	k8s.io/cli-runtime v0.18.6
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/code-generator v0.19.0
-	k8s.io/component-base v0.18.6
+	k8s.io/component-base v0.19.3
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.0.0
-	k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6
-	k8s.io/kubectl v0.18.6
+	k8s.io/kube-openapi v0.0.0-20200923155610-8b5066479488
+	k8s.io/kubectl v0.19.3
 	k8s.io/metrics v0.18.6
-	k8s.io/utils v0.0.0-20200603063816-c1c6865ac451
+	k8s.io/utils v0.0.0-20201005171033-6301aaf42dc7
 	kubesphere.io/client-go v0.0.0
 	kubesphere.io/monitoring-dashboard v0.1.2
 	sigs.k8s.io/application v0.8.4-0.20201016185654-c8e2959e57a0
 	sigs.k8s.io/controller-runtime v0.6.4
 	sigs.k8s.io/controller-tools v0.4.0
-	sigs.k8s.io/kubefed v0.7.0
+	sigs.k8s.io/kubefed v0.6.1
 	sigs.k8s.io/kustomize v2.0.3+incompatible
 	sigs.k8s.io/yaml v1.2.0
 )
@@ -742,7 +741,7 @@ replace (
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.6.4
 	sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.4.0
 	sigs.k8s.io/kind => sigs.k8s.io/kind v0.8.1
-	sigs.k8s.io/kubefed => sigs.k8s.io/kubefed v0.4.0
+	sigs.k8s.io/kubefed => sigs.k8s.io/kubefed v0.6.1
 	sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
 	sigs.k8s.io/structured-merge-diff/v3 => sigs.k8s.io/structured-merge-diff/v3 v3.0.0
 	sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -875,8 +875,8 @@ sigs.k8s.io/controller-runtime v0.6.4/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJU
 sigs.k8s.io/controller-tools v0.4.0 h1:9zIdrc6q9RKke8+DnVPVBVZ+cfF9L0TwM01cxNnklYo=
 sigs.k8s.io/controller-tools v0.4.0/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/kind v0.8.1/go.mod h1:oNKTxUVPYkV9lWzY6CVMNluVq8cBsyq+UgPJdvA3uu4=
-sigs.k8s.io/kubefed v0.4.0 h1:eNZ5SpblUBQEzPHs8XtAjEwmkbs498IhrGvqzdynHOY=
-sigs.k8s.io/kubefed v0.4.0/go.mod h1:YBq2sF7Usjfh1xmop6E7k+5USBYfhB5IMLitCoOnOkM=
+sigs.k8s.io/kubefed v0.6.1 h1:5NqfXCYPG1UC7H2KCs8tX77XN1ohHv+VegkZ69UWvF0=
+sigs.k8s.io/kubefed v0.6.1/go.mod h1:dP40OsC2z1m2uzkk8YiTMdaO/Y8/2zvAAWfGuYnJTKU=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0 h1:dOmIZBMfhcHS09XZkMyUgkq5trg3/jRyJYFZUiaOp8E=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -190,7 +190,7 @@ github.com/go-kit/kit/log/level
 github.com/go-ldap/ldap
 # github.com/go-logfmt/logfmt v0.5.0 => github.com/go-logfmt/logfmt v0.5.0
 github.com/go-logfmt/logfmt
-# github.com/go-logr/logr v0.1.0 => github.com/go-logr/logr v0.1.0
+# github.com/go-logr/logr v0.3.0 => github.com/go-logr/logr v0.1.0
 github.com/go-logr/logr
 # github.com/go-openapi/analysis v0.19.10 => github.com/go-openapi/analysis v0.19.10
 github.com/go-openapi/analysis
@@ -376,7 +376,7 @@ github.com/nxadm/tail/watch
 github.com/nxadm/tail/winfile
 # github.com/oklog/ulid v1.3.1 => github.com/oklog/ulid v1.3.1
 github.com/oklog/ulid
-# github.com/onsi/ginkgo v1.14.0 => github.com/onsi/ginkgo v1.14.0
+# github.com/onsi/ginkgo v1.14.2 => github.com/onsi/ginkgo v1.14.0
 github.com/onsi/ginkgo
 github.com/onsi/ginkgo/config
 github.com/onsi/ginkgo/internal/codelocation
@@ -396,7 +396,7 @@ github.com/onsi/ginkgo/reporters/stenographer
 github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
 github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty
 github.com/onsi/ginkgo/types
-# github.com/onsi/gomega v1.10.1 => github.com/onsi/gomega v1.10.1
+# github.com/onsi/gomega v1.10.3 => github.com/onsi/gomega v1.10.1
 github.com/onsi/gomega
 github.com/onsi/gomega/format
 github.com/onsi/gomega/gbytes
@@ -516,7 +516,7 @@ github.com/prometheus/alertmanager/api/v2/client/receiver
 github.com/prometheus/alertmanager/api/v2/client/silence
 github.com/prometheus/alertmanager/api/v2/models
 github.com/prometheus/alertmanager/pkg/labels
-# github.com/prometheus/client_golang v1.7.1 => github.com/prometheus/client_golang v1.7.1
+# github.com/prometheus/client_golang v1.8.0 => github.com/prometheus/client_golang v1.7.1
 github.com/prometheus/client_golang/api
 github.com/prometheus/client_golang/api/prometheus/v1
 github.com/prometheus/client_golang/prometheus
@@ -580,7 +580,7 @@ github.com/spf13/afero
 github.com/spf13/afero/mem
 # github.com/spf13/cast v1.3.0 => github.com/spf13/cast v1.3.0
 github.com/spf13/cast
-# github.com/spf13/cobra v1.0.0 => github.com/spf13/cobra v0.0.5
+# github.com/spf13/cobra v1.1.1 => github.com/spf13/cobra v0.0.5
 github.com/spf13/cobra
 # github.com/spf13/jwalterweatherman v1.0.0 => github.com/spf13/jwalterweatherman v1.0.0
 github.com/spf13/jwalterweatherman
@@ -649,7 +649,7 @@ go.uber.org/atomic
 go.uber.org/multierr
 # go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee => go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee
 go.uber.org/tools/update-license
-# go.uber.org/zap v1.13.0 => go.uber.org/zap v1.13.0
+# go.uber.org/zap v1.16.0 => go.uber.org/zap v1.13.0
 go.uber.org/zap
 go.uber.org/zap/buffer
 go.uber.org/zap/internal/bufferpool
@@ -714,7 +714,7 @@ golang.org/x/sys/unix
 golang.org/x/sys/windows
 golang.org/x/sys/windows/registry
 golang.org/x/sys/windows/svc/eventlog
-# golang.org/x/text v0.3.3 => golang.org/x/text v0.3.0
+# golang.org/x/text v0.3.4 => golang.org/x/text v0.3.0
 golang.org/x/text/encoding
 golang.org/x/text/encoding/charmap
 golang.org/x/text/encoding/htmlindex
@@ -1015,7 +1015,7 @@ istio.io/client-go/pkg/listers/security/v1beta1
 # istio.io/gogo-genproto v0.0.0-20201113182723-5b8563d8a012 => istio.io/gogo-genproto v0.0.0-20201113182723-5b8563d8a012
 istio.io/gogo-genproto/googleapis/google/api
 istio.io/gogo-genproto/googleapis/google/rpc
-# k8s.io/api v0.19.0 => k8s.io/api v0.18.6
+# k8s.io/api v0.19.3 => k8s.io/api v0.18.6
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
@@ -1059,7 +1059,7 @@ k8s.io/api/settings/v1alpha1
 k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
-# k8s.io/apiextensions-apiserver v0.18.6 => k8s.io/apiextensions-apiserver v0.18.6
+# k8s.io/apiextensions-apiserver v0.19.3 => k8s.io/apiextensions-apiserver v0.18.6
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
@@ -1077,7 +1077,7 @@ k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensio
 k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/internalinterfaces
 k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1
-# k8s.io/apimachinery v0.19.0 => k8s.io/apimachinery v0.18.6
+# k8s.io/apimachinery v0.19.3 => k8s.io/apimachinery v0.18.6
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -1137,7 +1137,7 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
-# k8s.io/apiserver v0.18.6 => k8s.io/apiserver v0.18.6
+# k8s.io/apiserver v0.19.3 => k8s.io/apiserver v0.18.6
 k8s.io/apiserver/pkg/admission
 k8s.io/apiserver/pkg/admission/configuration
 k8s.io/apiserver/pkg/admission/initializer
@@ -1516,7 +1516,7 @@ k8s.io/code-generator/cmd/lister-gen/args
 k8s.io/code-generator/cmd/lister-gen/generators
 k8s.io/code-generator/pkg/namer
 k8s.io/code-generator/pkg/util
-# k8s.io/component-base v0.18.6 => k8s.io/component-base v0.18.6
+# k8s.io/component-base v0.19.3 => k8s.io/component-base v0.18.6
 k8s.io/component-base/cli/flag
 k8s.io/component-base/featuregate
 k8s.io/component-base/logs
@@ -1537,7 +1537,7 @@ k8s.io/klog
 k8s.io/klog/klogr
 # k8s.io/klog/v2 v2.0.0 => k8s.io/klog/v2 v2.0.0
 k8s.io/klog/v2
-# k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6
+# k8s.io/kube-openapi v0.0.0-20200923155610-8b5066479488 => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6
 k8s.io/kube-openapi/cmd/openapi-gen
 k8s.io/kube-openapi/cmd/openapi-gen/args
 k8s.io/kube-openapi/pkg/builder
@@ -1550,7 +1550,7 @@ k8s.io/kube-openapi/pkg/util
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/util/proto/validation
 k8s.io/kube-openapi/pkg/util/sets
-# k8s.io/kubectl v0.18.6 => k8s.io/kubectl v0.18.6
+# k8s.io/kubectl v0.19.3 => k8s.io/kubectl v0.18.6
 k8s.io/kubectl/pkg/cmd/util
 k8s.io/kubectl/pkg/scheme
 k8s.io/kubectl/pkg/util/interrupt
@@ -1571,7 +1571,7 @@ k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1
 k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake
 k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1
 k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake
-# k8s.io/utils v0.0.0-20200603063816-c1c6865ac451 => k8s.io/utils v0.0.0-20200603063816-c1c6865ac451
+# k8s.io/utils v0.0.0-20201005171033-6301aaf42dc7 => k8s.io/utils v0.0.0-20200603063816-c1c6865ac451
 k8s.io/utils/buffer
 k8s.io/utils/exec
 k8s.io/utils/integer
@@ -1653,7 +1653,7 @@ sigs.k8s.io/controller-tools/pkg/schemapatcher
 sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml
 sigs.k8s.io/controller-tools/pkg/version
 sigs.k8s.io/controller-tools/pkg/webhook
-# sigs.k8s.io/kubefed v0.4.0 => sigs.k8s.io/kubefed v0.4.0
+# sigs.k8s.io/kubefed v0.6.1 => sigs.k8s.io/kubefed v0.6.1
 sigs.k8s.io/kubefed/pkg/apis
 sigs.k8s.io/kubefed/pkg/apis/core/common
 sigs.k8s.io/kubefed/pkg/apis/core/v1alpha1

--- a/vendor/sigs.k8s.io/kubefed/pkg/apis/core/v1beta1/federatedtypeconfig_types.go
+++ b/vendor/sigs.k8s.io/kubefed/pkg/apis/core/v1beta1/federatedtypeconfig_types.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/kubefed/pkg/apis/core/common"
@@ -66,7 +66,7 @@ type APIResource struct {
 	// suffixing an 's'.
 	PluralName string `json:"pluralName"`
 	// Scope of the resource.
-	Scope apiextv1b1.ResourceScope `json:"scope"`
+	Scope apiextv1.ResourceScope `json:"scope"`
 }
 
 // PropagationMode defines the state of propagation to member clusters.
@@ -207,18 +207,20 @@ func (f *FederatedTypeConfig) GetFederatedType() metav1.APIResource {
 	return apiResourceToMeta(f.Spec.FederatedType, f.GetFederatedNamespaced())
 }
 
+// TODO (hectorj2f): It should get deprecated once we move to the new status approach
+// because the type is the same as the target type.
 func (f *FederatedTypeConfig) GetStatusType() *metav1.APIResource {
 	if f.Spec.StatusType == nil {
 		return nil
 	}
+	// Return the original target type
 	metaAPIResource := apiResourceToMeta(*f.Spec.StatusType, f.Spec.StatusType.Namespaced())
 	return &metaAPIResource
 }
 
 func (f *FederatedTypeConfig) GetStatusEnabled() bool {
 	return f.Spec.StatusCollection != nil &&
-		*f.Spec.StatusCollection == StatusCollectionEnabled &&
-		f.Name == "services"
+		*f.Spec.StatusCollection == StatusCollectionEnabled
 }
 
 // TODO(font): This method should be removed from the interface i.e. remove
@@ -243,7 +245,7 @@ func (f *FederatedTypeConfig) IsNamespace() bool {
 }
 
 func (a *APIResource) Namespaced() bool {
-	return a.Scope == apiextv1b1.NamespaceScoped
+	return a.Scope == apiextv1.NamespaceScoped
 }
 
 func apiResourceToMeta(apiResource APIResource, namespaced bool) metav1.APIResource {

--- a/vendor/sigs.k8s.io/kubefed/pkg/apis/core/v1beta1/kubefedconfig_types.go
+++ b/vendor/sigs.k8s.io/kubefed/pkg/apis/core/v1beta1/kubefedconfig_types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,7 +26,7 @@ type KubeFedConfigSpec struct {
 	// The scope of the KubeFed control plane should be either
 	// `Namespaced` or `Cluster`. `Namespaced` indicates that the
 	// KubeFed namespace will be the only target of the control plane.
-	Scope apiextv1b1.ResourceScope `json:"scope"`
+	Scope apiextv1.ResourceScope `json:"scope"`
 	// +optional
 	ControllerDuration *DurationConfig `json:"controllerDuration,omitempty"`
 	// +optional

--- a/vendor/sigs.k8s.io/kubefed/pkg/apis/scheduling/v1alpha1/replicaschedulingpreference_types.go
+++ b/vendor/sigs.k8s.io/kubefed/pkg/apis/scheduling/v1alpha1/replicaschedulingpreference_types.go
@@ -22,7 +22,7 @@ import (
 
 // ReplicaSchedulingPreferenceSpec defines the desired state of ReplicaSchedulingPreference
 type ReplicaSchedulingPreferenceSpec struct {
-	//TODO (@irfanurrehman); upgrade this to label selector only if need be.
+	// TODO (@irfanurrehman); upgrade this to label selector only if need be.
 	// The idea of this API is to have a a set of preferences which can
 	// be used for a target FederatedDeployment or FederatedReplicaset.
 	// Although the set of preferences in question can be applied to multiple
@@ -75,7 +75,7 @@ type ReplicaSchedulingPreferenceStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=replicaschedulingpreferences
+// +kubebuilder:resource:path=replicaschedulingpreferences,shortName=rsp
 
 type ReplicaSchedulingPreference struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/vendor/sigs.k8s.io/kubefed/pkg/controller/util/controllerconfig.go
+++ b/vendor/sigs.k8s.io/kubefed/pkg/controller/util/controllerconfig.go
@@ -68,11 +68,12 @@ type ClusterHealthCheckConfig struct {
 // controllers.
 type ControllerConfig struct {
 	KubeFedNamespaces
-	KubeConfig              *restclient.Config
-	ClusterAvailableDelay   time.Duration
-	ClusterUnavailableDelay time.Duration
-	MinimizeLatency         bool
-	SkipAdoptingResources   bool
+	KubeConfig                  *restclient.Config
+	ClusterAvailableDelay       time.Duration
+	ClusterUnavailableDelay     time.Duration
+	MinimizeLatency             bool
+	SkipAdoptingResources       bool
+	RawResourceStatusCollection bool
 }
 
 func (c *ControllerConfig) LimitedScope() bool {

--- a/vendor/sigs.k8s.io/kubefed/pkg/controller/util/meta.go
+++ b/vendor/sigs.k8s.io/kubefed/pkg/controller/util/meta.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 )
 
 // Copies cluster-independent, user provided data from the given ObjectMeta struct. If in
@@ -114,7 +113,7 @@ func ObjectMetaAndSpecEquivalent(a, b runtime.Object) bool {
 	return ObjectMetaEquivalent(objectMetaA, objectMetaB) && reflect.DeepEqual(specA, specB)
 }
 
-func MetaAccessor(obj pkgruntime.Object) metav1.Object {
+func MetaAccessor(obj runtime.Object) metav1.Object {
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		// This should always succeed if obj is not nil.  Also,

--- a/vendor/sigs.k8s.io/kubefed/pkg/controller/util/overrides.go
+++ b/vendor/sigs.k8s.io/kubefed/pkg/controller/util/overrides.go
@@ -19,7 +19,7 @@ package util
 import (
 	"encoding/json"
 
-	"github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/pkg/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -159,8 +159,8 @@ func UnstructuredToInterface(rawObj *unstructured.Unstructured, obj interface{})
 	return json.Unmarshal(content, obj)
 }
 
-// ApplyJsonPatch applies the override on to the given unstructured object.
-func ApplyJsonPatch(obj *unstructured.Unstructured, overrides ClusterOverrides) error {
+// ApplyJSONPatch applies the override on to the given unstructured object.
+func ApplyJSONPatch(obj *unstructured.Unstructured, overrides ClusterOverrides) error {
 	// TODO: Do the defaulting of "op" field to "replace" in API defaulting
 	for i, overrideItem := range overrides {
 		if overrideItem.Op == "" {
@@ -177,12 +177,12 @@ func ApplyJsonPatch(obj *unstructured.Unstructured, overrides ClusterOverrides) 
 		return err
 	}
 
-	ObjectJSONBytes, err := obj.MarshalJSON()
+	objectJSONBytes, err := obj.MarshalJSON()
 	if err != nil {
 		return err
 	}
 
-	patchedObjectJSONBytes, err := patch.Apply(ObjectJSONBytes)
+	patchedObjectJSONBytes, err := patch.Apply(objectJSONBytes)
 	if err != nil {
 		return err
 	}

--- a/vendor/sigs.k8s.io/kubefed/pkg/controller/util/worker.go
+++ b/vendor/sigs.k8s.io/kubefed/pkg/controller/util/worker.go
@@ -137,7 +137,7 @@ func (w *asyncWorker) deliver(qualifiedName QualifiedName, delay time.Duration, 
 	key := qualifiedName.String()
 	if failed {
 		w.backoff.Next(key, time.Now())
-		delay = delay + w.backoff.Get(key)
+		delay += w.backoff.Get(key)
 	} else {
 		w.backoff.Reset(key)
 	}

--- a/vendor/sigs.k8s.io/kubefed/pkg/kubefedctl/options/options.go
+++ b/vendor/sigs.k8s.io/kubefed/pkg/kubefedctl/options/options.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 
-	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -101,7 +101,7 @@ func (o *CommonJoinOptions) SetName(args []string) error {
 	return nil
 }
 
-func GetScopeFromKubeFedConfig(hostConfig *rest.Config, namespace string) (apiextv1b1.ResourceScope, error) {
+func GetScopeFromKubeFedConfig(hostConfig *rest.Config, namespace string) (apiextv1.ResourceScope, error) {
 	client, err := genericclient.New(hostConfig)
 	if err != nil {
 		err = errors.Wrap(err, "Failed to get kubefed clientset")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
Kubefed v0.7.0 relies on k8s v1.20 dependencies, which are not supported by KubeSphere. We need to upgrade kubefed to v0.6.1 to avoid such conflict.
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3593 

https://github.com/kubesphere/kubesphere/pull/3658 did not upgrade kubefed to v0.7.0 with correct stages(hack/pin-dependency.sh sigs.k8s.io/kubefed v0.7.0 && hack/update-vendor.sh). In this pr, I executed `hack/pin-dependency.sh sigs.k8s.io/kubefed v0.6.1 && hack/update-vendor.sh`
