### PR TITLE
Add namespacedResourcesFilter field back in reqParams struct.

### DIFF
--- a/pkg/kapis/monitoring/v1alpha3/helper.go
+++ b/pkg/kapis/monitoring/v1alpha3/helper.go
@@ -60,35 +60,36 @@ const (
 )
 
 type reqParams struct {
-	metering         bool
-	operation        string
-	time             string
-	start            string
-	end              string
-	step             string
-	target           string
-	order            string
-	page             string
-	limit            string
-	metricFilter     string
-	resourceFilter   string
-	nodeName         string
-	workspaceName    string
-	namespaceName    string
-	workloadKind     string
-	workloadName     string
-	podName          string
-	containerName    string
-	pvcName          string
-	storageClassName string
-	componentType    string
-	expression       string
-	metric           string
-	applications     string
-	openpitrixs      string
-	cluster          string
-	services         string
-	pvcFilter        string
+	metering                  bool
+	operation                 string
+	time                      string
+	start                     string
+	end                       string
+	step                      string
+	target                    string
+	order                     string
+	page                      string
+	limit                     string
+	metricFilter              string
+	namespacedResourcesFilter string
+	resourceFilter            string
+	nodeName                  string
+	workspaceName             string
+	namespaceName             string
+	workloadKind              string
+	workloadName              string
+	podName                   string
+	containerName             string
+	pvcName                   string
+	storageClassName          string
+	componentType             string
+	expression                string
+	metric                    string
+	applications              string
+	openpitrixs               string
+	cluster                   string
+	services                  string
+	pvcFilter                 string
 }
 
 type queryOptions struct {
@@ -130,6 +131,7 @@ func parseRequestParams(req *restful.Request) reqParams {
 	r.page = req.QueryParameter("page")
 	r.limit = req.QueryParameter("limit")
 	r.metricFilter = req.QueryParameter("metrics_filter")
+	r.namespacedResourcesFilter = req.QueryParameter("namespaced_resources_filter")
 	r.resourceFilter = req.QueryParameter("resources_filter")
 	r.workspaceName = req.PathParameter("workspace")
 	r.namespaceName = req.PathParameter("namespace")
@@ -285,12 +287,13 @@ func (h handler) makeQueryOptions(r reqParams, lvl monitoring.Level) (q queryOpt
 	case monitoring.LevelPod:
 		q.identifier = model.IdentifierPod
 		q.option = monitoring.PodOption{
-			ResourceFilter: r.resourceFilter,
-			NodeName:       r.nodeName,
-			NamespaceName:  r.namespaceName,
-			WorkloadKind:   r.workloadKind,
-			WorkloadName:   r.workloadName,
-			PodName:        r.podName,
+			NamespacedResourcesFilter: r.namespacedResourcesFilter,
+			ResourceFilter:            r.resourceFilter,
+			NodeName:                  r.nodeName,
+			NamespaceName:             r.namespaceName,
+			WorkloadKind:              r.workloadKind,
+			WorkloadName:              r.workloadName,
+			PodName:                   r.podName,
 		}
 		q.namedMetrics = model.PodMetrics
 

--- a/pkg/kapis/monitoring/v1alpha3/helper_test.go
+++ b/pkg/kapis/monitoring/v1alpha3/helper_test.go
@@ -291,6 +291,33 @@ func TestParseRequestParams(t *testing.T) {
 			lvl:         monitoring.LevelOpenpitrix,
 			expectedErr: true,
 		},
+		{
+			params: reqParams{
+				time:                      "1585880000",
+				namespacedResourcesFilter: "test1|test2",
+			},
+			lvl: monitoring.LevelPod,
+			expected: queryOptions{
+				metricFilter: ".*",
+				identifier:   "pod",
+				time:         time.Unix(1585880000, 0),
+				namedMetrics: []string{
+					"pod_cpu_usage",
+					"pod_memory_usage",
+					"pod_memory_usage_wo_cache",
+					"pod_net_bytes_transmitted",
+					"pod_net_bytes_received",
+					"meter_pod_cpu_usage",
+					"meter_pod_memory_usage_wo_cache",
+					"meter_pod_net_bytes_transmitted",
+					"meter_pod_net_bytes_received",
+					"meter_pod_pvc_bytes_total",
+				},
+				Operation: OperationQuery,
+				option:    monitoring.PodOption{NamespacedResourcesFilter: "test1|test2", ResourceFilter: ".*"},
+			},
+			expectedErr: false,
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Signed-off-by: Rao Yunkun <yunkunrao@yunify.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Latest metering code remove namespacedResourcesFilter field back in reqParams struct incorrectly. This PR add this filed back.

Fixes: #3697 