### PR TITLE
fix bug member cluster can not view the notification channels

### DIFF
--- a/pkg/controller/notification/notification_controller.go
+++ b/pkg/controller/notification/notification_controller.go
@@ -124,7 +124,7 @@ func (c *Controller) setEventHandlers() error {
 		}
 	}
 
-	// Watch the cluster add and delete operator.
+	// Watch the cluster add and delete operations.
 	if informer, err := c.ksCache.GetInformer(context.Background(), &v1alpha1.Cluster{}); err != nil {
 		klog.Errorf("get cluster informer error, %v", err)
 		return err
@@ -240,9 +240,8 @@ func (c *Controller) reconcile(obj interface{}) error {
 
 	name := accessor.GetName()
 
-	// If the cluster changed, add or delete, it should update the annotations of secrets
-	// which the notification controller managed, then the notification controller
-	// will receiver a event to reconcile the secret.
+	// The notification controller should update the annotations of secrets managed by itself
+	// whenever a cluster is added or deleted. This way, the controller will have a chance to override the secret.
 	if _, ok := obj.(*v1alpha1.Cluster); ok {
 		err = c.updateSecret()
 		if err != nil {
@@ -519,7 +518,7 @@ func (c *Controller) updateOverrides(obj *corev1.Secret, fedSecret *v1beta1.Fede
 	return nil
 }
 
-// Update the annotations of secrets which the notification controller managed, rigger a  reconcile.
+// Update the annotations of secrets managed by the notification controller to trigger a reconcile.
 func (c *Controller) updateSecret() error {
 
 	secretList := &corev1.SecretList{}

--- a/pkg/controller/notification/notification_controller_suite_test.go
+++ b/pkg/controller/notification/notification_controller_suite_test.go
@@ -20,18 +20,15 @@ import (
 	"path/filepath"
 	"testing"
 
-	"k8s.io/client-go/kubernetes/fake"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 
 	"kubesphere.io/kubesphere/pkg/apis"
 	"kubesphere.io/kubesphere/pkg/apis/notification/v2beta1"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 )
 
 func TestSource(t *testing.T) {
@@ -42,7 +39,6 @@ func TestSource(t *testing.T) {
 
 var testenv *envtest.Environment
 var cfg *rest.Config
-var k8sManager ctrl.Manager
 
 var _ = BeforeSuite(func(done Done) {
 
@@ -55,27 +51,8 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	err = v2beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = apis.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:             scheme.Scheme,
-		MetricsBindAddress: "0",
-	})
-	Expect(err).ToNot(HaveOccurred())
-
-	r, err := NewController(fake.NewSimpleClientset(), k8sManager.GetClient(), k8sManager.GetCache())
-	Expect(err).ToNot(HaveOccurred())
-	err = k8sManager.Add(r)
-	Expect(err).ToNot(HaveOccurred())
-
-	go func() {
-		err = k8sManager.Start(ctrl.SetupSignalHandler())
-		Expect(err).ToNot(HaveOccurred())
-	}()
+	Expect(v2beta1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(apis.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 
 	close(done)
 }, 60)


### PR DESCRIPTION
Signed-off-by: wanjunlei <wanjunlei@yunify.com>

**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:
In the multi-cluster environment, the host cluster will synchronize the secret of notification configs and receivers by `FederatedSecret`. 
The `FederatedSecret` cannot synchronize the label to the member through the `template`, the member cluster will  display the notification configuration incorrectly because of the secret in the member cluster is missing some required labels. 
So it need to use `Overrides` to synchronize the labels. The notification controller will watch cluster resources. When a member cluster is created or deleted, the notification controller will update the `FederatedSecret` Overrides

**Special notes for reviewers**:
```
/assign @zryfish 
/assign @benjaminhuo 
```

