### PR TITLE
set fetch depth of checkout action to fetch all history and tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Check pr is properly formatted
         run: diff -u <(echo -n) <(gofmt -d ./pkg ./cmd ./tools ./test)


### PR DESCRIPTION
Signed-off-by: Jeff <jeffzhang@yunify.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently,  image built by github actions can't resolve version info correctly. That's because ttps://github.com/actions/checkout only fetch one single commit by default. Need to set the `fetch-depth` to 0 to fetch all history and tags.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
