### PR TITLE
Fix: filter app by app_id

### DIFF
--- a/pkg/kapis/openpitrix/v1/handler.go
+++ b/pkg/kapis/openpitrix/v1/handler.go
@@ -406,10 +406,6 @@ func (h *openpitrixHandler) ListApps(req *restful.Request, resp *restful.Respons
 		conditions.Match[openpitrix.WorkspaceLabel] = req.PathParameter("workspace")
 	}
 
-	if conditions.Match[openpitrix.WorkspaceLabel] == "" {
-		conditions.Match[openpitrix.WorkspaceLabel] = req.QueryParameter("workspace")
-	}
-
 	result, err := h.openpitrix.ListApps(conditions, orderBy, reverse, limit, offset)
 
 	if err != nil {

--- a/pkg/models/openpitrix/utils.go
+++ b/pkg/models/openpitrix/utils.go
@@ -673,11 +673,28 @@ func filterApps(apps []*v1alpha1.HelmApplication, conditions *params.Conditions)
 		return apps
 	}
 
+	// filter app by param app_id
+	appIdMap := make(map[string]string)
+	if len(conditions.Match[AppId]) > 0 {
+		ids := strings.Split(conditions.Match[AppId], "|")
+		for _, id := range ids {
+			if len(id) > 0 {
+				appIdMap[id] = ""
+			}
+		}
+	}
+
 	curr := 0
 	for i := 0; i < len(apps); i++ {
 		if conditions.Match[Keyword] != "" {
 			fv := filterAppByName(apps[i], conditions.Match[Keyword])
 			if !fv {
+				continue
+			}
+		}
+
+		if len(appIdMap) > 0 {
+			if _, exists := appIdMap[apps[i].Name]; !exists {
 				continue
 			}
 		}


### PR DESCRIPTION
Signed-off-by: LiHui <andrewli@yunify.com>

**What type of PR is this?**


/kind bug
/area app-management


**What this PR does / why we need it**:
ks-console need filer app by app_id, ks-apiserver should handle this paramter.
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3719

/assign @zheng1 
