### PR TITLE
Fix: add kubeconfig when check release status

### DIFF
--- a/pkg/simple/client/openpitrix/helmwrapper/helm_wrapper.go
+++ b/pkg/simple/client/openpitrix/helmwrapper/helm_wrapper.go
@@ -94,6 +94,12 @@ func (c *helmWrapper) IsReleaseReady(waitTime time.Duration) (bool, error) {
 	if c.Kubeconfig == "" {
 		client = kube.New(nil)
 	} else {
+		// kube.New() needs kubeconfig.
+		err := c.ensureWorkspace()
+		if err != nil {
+			return false, err
+		}
+		defer c.cleanup()
 		helmSettings := cli.New()
 		helmSettings.KubeConfig = c.kubeConfigPath()
 		client = kube.New(helmSettings.RESTClientGetter())


### PR DESCRIPTION
Signed-off-by: LiHui <andrewli@yunify.com>

**What type of PR is this?**
/kind bug
/area app-management

**What this PR does / why we need it**:
When multicluster is enabled, helm need kubeconfig to check release status.
