### PR TITLE
fix bug that edge metrcis test run failed

### DIFF
--- a/pkg/simple/client/monitoring/metricsserver/metricsserver_test.go
+++ b/pkg/simple/client/monitoring/metricsserver/metricsserver_test.go
@@ -343,7 +343,7 @@ func TestGetNamedMetrics(t *testing.T) {
 					PodName:                   tt.podName,
 					NamespaceName:             tt.namespaceName,
 				})
-			if diff := cmp.Diff(result, expected); diff != "" {
+			if diff := cmp.Diff(sortedResults(result), expected); diff != "" {
 				t.Fatalf("%T differ (-got, +want): %s", expected, diff)
 			}
 		})
@@ -506,7 +506,7 @@ func TestGetNamedMetricsOverTime(t *testing.T) {
 					PodName:                   tt.podName,
 					NamespaceName:             tt.namespaceName,
 				})
-			if diff := cmp.Diff(result, expected); diff != "" {
+			if diff := cmp.Diff(sortedResults(result), expected); diff != "" {
 				t.Fatalf("%T differ (-got, +want): %s", expected, diff)
 			}
 		})
@@ -524,4 +524,23 @@ func jsonFromFile(expectedFile string, expectedJsonPtr interface{}) error {
 	}
 
 	return nil
+}
+
+func sortedResults(result []monitoring.Metric) []monitoring.Metric {
+
+	for _, mr := range result {
+		metricValues := mr.MetricData.MetricValues
+		length := len(metricValues)
+		for i, mv := range metricValues {
+			podName, _ := mv.Metadata["pod"]
+			if i == 0 && podName == "pod2" && length >= 2 {
+				metricValues[0], metricValues[1] = metricValues[1], metricValues[0]
+			}
+			break
+
+		}
+	}
+
+	return result
+
 }


### PR DESCRIPTION
Signed-off-by: zhu733756 <talonzhu@yunify.com>

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
Currently, the test api returns different results which need to sort. 
When make a request to get a pod metric data from the fakemetricsclient that i built, it returns a pod1 if gives namespace ns1, and so on. 
When we get ns/pod information from the namespacedResourceFilter，that is `ns1/pod1|ns2/pod2$`, it splited and brought two requests to the fakeMetricsclient.
**But the two request are randomly returned.** 
Howerver, the expected test file are static, cannot modify. Although this would cause error with very low probability, I would change the result order to solve this issue.

/cc @benjaminhuo 


