### PR TITLE
Fix: validate repo when modify url

### DIFF
--- a/pkg/kapis/openpitrix/v1/handler.go
+++ b/pkg/kapis/openpitrix/v1/handler.go
@@ -201,8 +201,12 @@ func (h *openpitrixHandler) ModifyRepo(req *restful.Request, resp *restful.Respo
 	err = h.openpitrix.ModifyRepo(repoId, &updateRepoRequest)
 
 	if err != nil {
-		klog.Errorln(err)
-		handleOpenpitrixError(resp, err)
+		klog.Error(err)
+		if apierrors.IsNotFound(err) {
+			api.HandleNotFound(resp, nil, err)
+			return
+		}
+		api.HandleBadRequest(resp, nil, err)
 		return
 	} else {
 		klog.V(4).Info("modify repo: ", repoId)

--- a/pkg/models/openpitrix/repos.go
+++ b/pkg/models/openpitrix/repos.go
@@ -175,11 +175,10 @@ func (c *repoOperator) ModifyRepo(id string, request *ModifyRepoRequest) error {
 				return repoItemExists
 			}
 		}
-
 		repoCopy.Spec.Name = *request.Name
 	}
 
-	// modify credential
+	// modify url or credential
 	if request.URL != nil && len(*request.URL) > 0 {
 		parsedUrl, err := url.Parse(*request.URL)
 		if err != nil {
@@ -209,6 +208,13 @@ func (c *repoOperator) ModifyRepo(id string, request *ModifyRepoRequest) error {
 
 		repoCopy.Spec.Credential = *cred
 		repoCopy.Spec.Url = parsedUrl.String()
+
+		// validate repo
+		_, err = c.ValidateRepo(repoCopy.Spec.Url, &repo.Spec.Credential)
+		if err != nil {
+			klog.Errorf("validate repo failed, err: %s", err)
+			return err
+		}
 
 		// change repo name and description won't change version
 		repoCopy.Spec.Version += 1


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
User could modify url of the repo, the url may be an invalid url. So user need to check the url. 

**Which issue(s) this PR fixes**:
Fixes #3736

/assign @zheng1 