### PR TITLE
Fix the error caused by the wrong filter parse

### DIFF
--- a/pkg/kapis/devops/v1alpha2/devops_test.go
+++ b/pkg/kapis/devops/v1alpha2/devops_test.go
@@ -1,0 +1,61 @@
+package v1alpha2
+
+import (
+	"strings"
+	"testing"
+
+	"kubesphere.io/kubesphere/pkg/apis/devops/v1alpha3"
+	"kubesphere.io/kubesphere/pkg/models/devops"
+)
+
+func TestParseNameFilterFromQuery(t *testing.T) {
+	table := []struct {
+		query           string
+		pipeline        *v1alpha3.Pipeline
+		expectFilter    devops.PipelineFilter
+		expectNamespace string
+		message         string
+	}{{
+		query:           "type:pipeline;organization:jenkins;pipeline:serverjkq4c/*",
+		pipeline:        &v1alpha3.Pipeline{},
+		expectFilter:    nil,
+		expectNamespace: "serverjkq4c",
+		message:         "query all pipelines with filter *",
+	}, {
+		query:    "type:pipeline;organization:jenkins;pipeline:cccc/*abc*",
+		pipeline: &v1alpha3.Pipeline{},
+		expectFilter: func(pipeline *v1alpha3.Pipeline) bool {
+			return strings.Contains(pipeline.Name, "abc")
+		},
+		expectNamespace: "cccc",
+		message:         "query all pipelines with filter abc",
+	}, {
+		query:           "type:pipeline;organization:jenkins;pipeline:pai-serverjkq4c/*",
+		pipeline:        &v1alpha3.Pipeline{},
+		expectFilter:    nil,
+		expectNamespace: "pai-serverjkq4c",
+		message:         "query all pipelines with filter *",
+	}, {
+		query:           "type:pipeline;organization:jenkins;pipeline:defdef",
+		pipeline:        &v1alpha3.Pipeline{},
+		expectFilter:    nil,
+		expectNamespace: "defdef",
+		message:         "query all pipelines with filter *",
+	}}
+
+	for i, item := range table {
+		filter, ns := parseNameFilterFromQuery(item.query)
+		if item.expectFilter == nil {
+			if filter != nil {
+				t.Fatalf("invalid filter, index: %d, message: %s", i, item.message)
+			}
+		} else {
+			if filter == nil || filter(item.pipeline) != item.expectFilter(item.pipeline) {
+				t.Fatalf("invalid filter, index: %d, message: %s", i, item.message)
+			}
+		}
+		if ns != item.expectNamespace {
+			t.Fatalf("invalid namespace, index: %d, message: %s", i, item.message)
+		}
+	}
+}

--- a/pkg/models/devops/devops.go
+++ b/pkg/models/devops/devops.go
@@ -53,6 +53,9 @@ const (
 	channelMaxCapacity = 100
 )
 
+type PipelineFilter func(pipeline *v1alpha3.Pipeline) bool
+type PipelineSorter func([]*v1alpha3.Pipeline, int, int) bool
+
 type DevopsOperator interface {
 	CreateDevOpsProject(workspace string, project *v1alpha3.DevOpsProject) (*v1alpha3.DevOpsProject, error)
 	GetDevOpsProject(workspace string, projectName string) (*v1alpha3.DevOpsProject, error)
@@ -64,7 +67,7 @@ type DevopsOperator interface {
 	GetPipelineObj(projectName string, pipelineName string) (*v1alpha3.Pipeline, error)
 	DeletePipelineObj(projectName string, pipelineName string) error
 	UpdatePipelineObj(projectName string, pipeline *v1alpha3.Pipeline) (*v1alpha3.Pipeline, error)
-	ListPipelineObj(projectName string, filterFunc func(*v1alpha3.Pipeline) bool, sortFunc func([]*v1alpha3.Pipeline, int, int) bool, limit, offset int) (api.ListResult, error)
+	ListPipelineObj(projectName string, filterFunc PipelineFilter, sortFunc PipelineSorter, limit, offset int) (api.ListResult, error)
 
 	CreateCredentialObj(projectName string, s *v1.Secret) (*v1.Secret, error)
 	GetCredentialObj(projectName string, secretName string) (*v1.Secret, error)
@@ -268,8 +271,8 @@ func (d devopsOperator) UpdatePipelineObj(projectName string, pipeline *v1alpha3
 	return d.ksclient.DevopsV1alpha3().Pipelines(ns).Update(context.Background(), pipeline, metav1.UpdateOptions{})
 }
 
-func (d devopsOperator) ListPipelineObj(projectName string, filterFunc func(pipeline *v1alpha3.Pipeline) bool,
-	sortFunc func([]*v1alpha3.Pipeline, int, int) bool, limit, offset int) (api.ListResult, error) {
+func (d devopsOperator) ListPipelineObj(projectName string, filterFunc PipelineFilter,
+	sortFunc PipelineSorter, limit, offset int) (api.ListResult, error) {
 	projectObj, err := d.ksInformers.Devops().V1alpha3().DevOpsProjects().Lister().Get(projectName)
 	if err != nil {
 		return api.ListResult{}, err


### PR DESCRIPTION

**What type of PR is this?**
/kind bug
/area devops

**What this PR does / why we need it**:
A wrong pipeline filter parse caused the erorr.

I'd like to say thanks to @daniel-hutao. He help us to find this issue.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3765

**Special notes for reviewers**:
The error caused by misuse between `TrimLeft` and `TrimPrefix`.

**Additional documentation, usage docs, etc.**:
None.

