### PR TITLE
remove trailing dollar char of namespacedResourcesFilter for monitoring api

### DIFF
--- a/pkg/kapis/monitoring/v1alpha3/helper.go
+++ b/pkg/kapis/monitoring/v1alpha3/helper.go
@@ -132,7 +132,9 @@ func parseRequestParams(req *restful.Request) reqParams {
 	r.page = req.QueryParameter("page")
 	r.limit = req.QueryParameter("limit")
 	r.metricFilter = req.QueryParameter("metrics_filter")
-	r.namespacedResourcesFilter = req.QueryParameter("namespaced_resources_filter")
+	// namespacedResourcesFilter supports only <namespace>/<pod_name>|<namespace>/<pod_name> format
+	// which is different from resources_filter or metrics_filter, so wipe off the possible $ at the end.
+	r.namespacedResourcesFilter = strings.TrimRight(req.QueryParameter("namespaced_resources_filter"), "$")
 	r.resourceFilter = req.QueryParameter("resources_filter")
 	r.workspaceName = req.PathParameter("workspace")
 	r.namespaceName = req.PathParameter("namespace")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

remove trailing dollar char of `namespacedResourcesFilter` param for monitoring api to avoid missing monitoring data of the last resource

**Which issue(s) this PR fixes**:

ref: https://github.com/kubesphere/kubesphere/issues/3777

/area monitoring
/cc @benjaminhuo 