### PR TITLE
add RawExtension type annotation

### DIFF
--- a/config/crds/iam.kubesphere.io_rolebases.yaml
+++ b/config/crds/iam.kubesphere.io_rolebases.yaml
@@ -32,6 +32,8 @@ spec:
             type: object
           role:
             type: object
+            x-kubernetes-embedded-resource: true
+            x-kubernetes-preserve-unknown-fields: true
         required:
         - role
         type: object

--- a/config/crds/tenant.kubesphere.io_workspacetemplates.yaml
+++ b/config/crds/tenant.kubesphere.io_workspacetemplates.yaml
@@ -47,6 +47,7 @@ spec:
                             type: string
                           value:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         required:
                         - path
                         type: object

--- a/staging/src/kubesphere.io/api/iam/v1alpha2/types.go
+++ b/staging/src/kubesphere.io/api/iam/v1alpha2/types.go
@@ -283,7 +283,8 @@ type WorkspaceRoleBindingList struct {
 type RoleBase struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:EmbeddedResource
 	Role runtime.RawExtension `json:"role"`
 }
 

--- a/staging/src/kubesphere.io/api/types/v1beta1/types.go
+++ b/staging/src/kubesphere.io/api/types/v1beta1/types.go
@@ -44,8 +44,9 @@ type GenericPlacement struct {
 }
 
 type ClusterOverride struct {
-	Op    string               `json:"op,omitempty"`
-	Path  string               `json:"path"`
+	Op   string `json:"op,omitempty"`
+	Path string `json:"path"`
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Value runtime.RawExtension `json:"value,omitempty"`
 }
 


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`Role` Filed in `RoleBas`e type was missing when upgrading CustomResourceDefinition from apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1.
According to the [Kubernetes doc ](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#rawextension), we need to set the below properties:

```yaml
type: object
properties:
  foo:
    x-kubernetes-embedded-resource: true
    x-kubernetes-preserve-unknown-fields: true
```


**Which issue(s) this PR fixes**:

Fixes #3766 3794

/cc @zryfish @wansir 