### PR TITLE
Query workspacerolebindings by rolename

### DIFF
--- a/pkg/models/resources/v1alpha3/workspacerolebinding/workspacerolebindings.go
+++ b/pkg/models/resources/v1alpha3/workspacerolebinding/workspacerolebindings.go
@@ -27,6 +27,8 @@ import (
 	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3"
 )
 
+const RoleName = "rolename"
+
 type workspacerolebindingsGetter struct {
 	sharedInformers informers.SharedInformerFactory
 }
@@ -76,6 +78,10 @@ func (d *workspacerolebindingsGetter) filter(object runtime.Object, filter query
 	if !ok {
 		return false
 	}
-
-	return v1alpha3.DefaultObjectMetaFilter(role.ObjectMeta, filter)
+	switch filter.Field {
+	case RoleName:
+		return role.RoleRef.Name == string(filter.Value)
+	default:
+		return v1alpha3.DefaultObjectMetaFilter(role.ObjectMeta, filter)
+	}
 }


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Add WorkspaceRoleBindings query by rolename, So the frontend can check if a role was bind to a user or group.

**Which issue(s) this PR fixes**:

Fixes # kubesphere/console#1876

/cc @wansir 
