### PR TITLE
fix servicemesh traffic governance

### DIFF
--- a/config/crds/servicemesh.kubesphere.io_servicepolicies.yaml
+++ b/config/crds/servicemesh.kubesphere.io_servicepolicies.yaml
@@ -69,933 +69,1131 @@ spec:
                     description: Metadata of the virtual services created from this template
                     type: object
                   spec:
-                    description: Spec indicates the behavior of a destination rule.
+                    description: 'Configuration affecting load balancing, outlier detection,
+                      etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
                     properties:
-                      export_to:
-                        description: "A list of namespaces to which this destination rule is exported. The resolution of a destination rule to apply to a service occurs in the context of a hierarchy of namespaces. Exporting a destination rule allows it to be included in the resolution hierarchy for services in other namespaces. This feature provides a mechanism for service owners and mesh administrators to control the visibility of destination rules across namespace boundaries. \n If no namespaces are specified then the destination rule is exported to all namespaces by default. \n The value \".\" is reserved and defines an export to the same namespace that the destination rule is declared in. Similarly, the value \"*\" is reserved and defines an export to all namespaces. \n NOTE: in the current release, the `exportTo` value is restricted to \".\" or \"*\" (i.e., the current namespace or all namespaces)."
+                      exportTo:
+                        description: A list of namespaces to which this destination rule is
+                          exported.
                         items:
+                          format: string
                           type: string
                         type: array
                       host:
-                        description: "The name of a service from the service registry. Service names are looked up from the platform's service registry (e.g., Kubernetes services, Consul services, etc.) and from the hosts declared by [ServiceEntries](https://istio.io/docs/reference/config/networking/service-entry/#ServiceEntry). Rules defined for services that do not exist in the service registry will be ignored. \n *Note for Kubernetes users*: When short names are used (e.g. \"reviews\" instead of \"reviews.default.svc.cluster.local\"), Istio will interpret the short name based on the namespace of the rule, not the service. A rule in the \"default\" namespace containing a host \"reviews\" will be interpreted as \"reviews.default.svc.cluster.local\", irrespective of the actual namespace associated with the reviews service. _To avoid potential misconfigurations, it is recommended to always use fully qualified domain names over short names._ \n Note that the host field applies to both HTTP and TCP services."
+                        description: The name of a service from the service registry.
+                        format: string
                         type: string
                       subsets:
-                        description: One or more named sets that represent individual versions of a service. Traffic policies can be overridden at subset level.
                         items:
-                          description: "A subset of endpoints of a service. Subsets can be used for scenarios like A/B testing, or routing to a specific version of a service. Refer to [VirtualService](https://istio.io/docs/reference/config/networking/virtual-service/#VirtualService) documentation for examples of using subsets in these scenarios. In addition, traffic policies defined at the service-level can be overridden at a subset-level. The following rule uses a round robin load balancing policy for all traffic going to a subset named testversion that is composed of endpoints (e.g., pods) with labels (version:v3). \n {{<tabset category-name=\"example\">}} {{<tab name=\"v1alpha3\" category-value=\"v1alpha3\">}} ```yaml apiVersion: networking.istio.io/v1alpha3 kind: DestinationRule metadata:   name: bookinfo-ratings spec:   host: ratings.prod.svc.cluster.local   trafficPolicy:     loadBalancer:       simple: LEAST_CONN   subsets:   - name: testversion     labels:       version: v3     trafficPolicy:       loadBalancer:         simple: ROUND_ROBIN ``` {{</tab>}} \n {{<tab name=\"v1beta1\" category-value=\"v1beta1\">}} ```yaml apiVersion: networking.istio.io/v1beta1 kind: DestinationRule metadata:   name: bookinfo-ratings spec:   host: ratings.prod.svc.cluster.local   trafficPolicy:     loadBalancer:       simple: LEAST_CONN   subsets:   - name: testversion     labels:       version: v3     trafficPolicy:       loadBalancer:         simple: ROUND_ROBIN ``` {{</tab>}} {{</tabset>}} \n **Note:** Policies specified for subsets will not take effect until a route rule explicitly sends traffic to this subset. \n One or more labels are typically required to identify the subset destination, however, when the corresponding DestinationRule represents a host that supports multiple SNI hosts (e.g., an egress gateway), a subset without labels may be meaningful. In this case a traffic policy with [ClientTLSSettings](#ClientTLSSettings) can be used to identify a specific SNI host corresponding to the named subset."
                           properties:
                             labels:
                               additionalProperties:
+                                format: string
                                 type: string
-                              description: Labels apply a filter over the endpoints of a service in the service registry. See route rules for examples of usage.
                               type: object
                             name:
-                              description: Name of the subset. The service name and the subset name can be used for traffic splitting in a route rule.
+                              description: Name of the subset.
+                              format: string
                               type: string
-                            traffic_policy:
-                              description: Traffic policies that apply to this subset. Subsets inherit the traffic policies specified at the DestinationRule level. Settings specified at the subset level will override the corresponding settings specified at the DestinationRule level.
+                            trafficPolicy:
+                              description: Traffic policies that apply to this subset.
                               properties:
-                                connection_pool:
-                                  description: Settings controlling the volume of connections to an upstream service
+                                connectionPool:
                                   properties:
                                     http:
                                       description: HTTP connection pool settings.
                                       properties:
-                                        h2_upgrade_policy:
-                                          description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+                                        h2UpgradePolicy:
+                                          description: Specify if http1.1 connection should
+                                            be upgraded to http2 for the associated destination.
+                                          enum:
+                                            - DEFAULT
+                                            - DO_NOT_UPGRADE
+                                            - UPGRADE
+                                          type: string
+                                        http1MaxPendingRequests:
+                                          description: Maximum number of pending HTTP requests
+                                            to a destination.
                                           format: int32
                                           type: integer
-                                        http1_max_pending_requests:
-                                          description: Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+                                        http2MaxRequests:
+                                          description: Maximum number of requests to a backend.
                                           format: int32
                                           type: integer
-                                        http2_max_requests:
-                                          description: Maximum number of requests to a backend. Default 2^32-1.
+                                        idleTimeout:
+                                          description: The idle timeout for upstream connection
+                                            pool connections.
+                                          type: string
+                                        maxRequestsPerConnection:
+                                          description: Maximum number of requests per connection
+                                            to a backend.
                                           format: int32
                                           type: integer
-                                        idle_timeout:
-                                          description: The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. If not set, the default is 1 hour. When the idle timeout is reached the connection will be closed. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.
-                                          properties:
-                                            nanos:
-                                              description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                              format: int32
-                                              type: integer
-                                            seconds:
-                                              description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                              format: int64
-                                              type: integer
-                                          type: object
-                                        max_requests_per_connection:
-                                          description: Maximum number of requests per connection to a backend. Setting this parameter to 1 disables keep alive. Default 0, meaning "unlimited", up to 2^29.
+                                        maxRetries:
                                           format: int32
                                           type: integer
-                                        max_retries:
-                                          description: Maximum number of retries that can be outstanding to all hosts in a cluster at a given time. Defaults to 2^32-1.
-                                          format: int32
-                                          type: integer
+                                        useClientProtocol:
+                                          description: If set to true, client protocol will
+                                            be preserved while initiating connection to backend.
+                                          type: boolean
                                       type: object
                                     tcp:
-                                      description: Settings common to both HTTP and TCP upstream connections.
+                                      description: Settings common to both HTTP and TCP upstream
+                                        connections.
                                       properties:
-                                        connect_timeout:
-                                          description: 'TCP connection timeout. format: 1h/1m/1s/1ms. MUST BE >=1ms. Default is 10s.'
-                                          properties:
-                                            nanos:
-                                              description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                              format: int32
-                                              type: integer
-                                            seconds:
-                                              description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                              format: int64
-                                              type: integer
-                                          type: object
-                                        max_connections:
-                                          description: Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.
+                                        connectTimeout:
+                                          description: TCP connection timeout.
+                                          type: string
+                                        maxConnections:
+                                          description: Maximum number of HTTP1 /TCP connections
+                                            to a destination host.
                                           format: int32
                                           type: integer
-                                        tcp_keepalive:
-                                          description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+                                        tcpKeepalive:
+                                          description: If set then set SO_KEEPALIVE on the
+                                            socket to enable TCP Keepalives.
                                           properties:
                                             interval:
-                                              description: The time duration between keep-alive probes. Default is to use the OS level configuration (unless overridden, Linux defaults to 75s.)
-                                              properties:
-                                                nanos:
-                                                  description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                                  format: int32
-                                                  type: integer
-                                                seconds:
-                                                  description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                                  format: int64
-                                                  type: integer
-                                              type: object
+                                              description: The time duration between keep-alive
+                                                probes.
+                                              type: string
                                             probes:
-                                              description: Maximum number of keepalive probes to send without response before deciding the connection is dead. Default is to use the OS level configuration (unless overridden, Linux defaults to 9.)
-                                              format: int32
                                               type: integer
                                             time:
-                                              description: The time duration a connection needs to be idle before keep-alive probes start being sent. Default is to use the OS level configuration (unless overridden, Linux defaults to 7200s (ie 2 hours.)
-                                              properties:
-                                                nanos:
-                                                  description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                                  format: int32
-                                                  type: integer
-                                                seconds:
-                                                  description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                                  format: int64
-                                                  type: integer
-                                              type: object
+                                              type: string
                                           type: object
                                       type: object
                                   type: object
-                                load_balancer:
+                                loadBalancer:
                                   description: Settings controlling the load balancer algorithms.
+                                  oneOf:
+                                    - not:
+                                        anyOf:
+                                          - required:
+                                              - simple
+                                          - properties:
+                                              consistentHash:
+                                                oneOf:
+                                                  - not:
+                                                      anyOf:
+                                                        - required:
+                                                            - httpHeaderName
+                                                        - required:
+                                                            - httpCookie
+                                                        - required:
+                                                            - useSourceIp
+                                                        - required:
+                                                            - httpQueryParameterName
+                                                  - required:
+                                                      - httpHeaderName
+                                                  - required:
+                                                      - httpCookie
+                                                  - required:
+                                                      - useSourceIp
+                                                  - required:
+                                                      - httpQueryParameterName
+                                            required:
+                                              - consistentHash
+                                    - required:
+                                        - simple
+                                    - properties:
+                                        consistentHash:
+                                          oneOf:
+                                            - not:
+                                                anyOf:
+                                                  - required:
+                                                      - httpHeaderName
+                                                  - required:
+                                                      - httpCookie
+                                                  - required:
+                                                      - useSourceIp
+                                                  - required:
+                                                      - httpQueryParameterName
+                                            - required:
+                                                - httpHeaderName
+                                            - required:
+                                                - httpCookie
+                                            - required:
+                                                - useSourceIp
+                                            - required:
+                                                - httpQueryParameterName
+                                      required:
+                                        - consistentHash
                                   properties:
-                                    locality_lb_setting:
-                                      description: Locality load balancer settings, this will override mesh wide settings in entirety, meaning no merging would be performed between this object and the object one in MeshConfig
+                                    consistentHash:
+                                      properties:
+                                        httpCookie:
+                                          description: Hash based on HTTP cookie.
+                                          properties:
+                                            name:
+                                              description: Name of the cookie.
+                                              format: string
+                                              type: string
+                                            path:
+                                              description: Path to set for the cookie.
+                                              format: string
+                                              type: string
+                                            ttl:
+                                              description: Lifetime of the cookie.
+                                              type: string
+                                          type: object
+                                        httpHeaderName:
+                                          description: Hash based on a specific HTTP header.
+                                          format: string
+                                          type: string
+                                        httpQueryParameterName:
+                                          description: Hash based on a specific HTTP query
+                                            parameter.
+                                          format: string
+                                          type: string
+                                        minimumRingSize:
+                                          type: integer
+                                        useSourceIp:
+                                          description: Hash based on the source IP address.
+                                          type: boolean
+                                      type: object
+                                    localityLbSetting:
                                       properties:
                                         distribute:
-                                          description: 'Optional: only one of distribute or failover can be set. Explicitly specify loadbalancing weight across different zones and geographical locations. Refer to [Locality weighted load balancing](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/locality_weight) If empty, the locality weight is set according to the endpoints number within it.'
+                                          description: 'Optional: only one of distribute or
+                                            failover can be set.'
                                           items:
-                                            description: 'Describes how traffic originating in the ''from'' zone or sub-zone is distributed over a set of ''to'' zones. Syntax for specifying a zone is {region}/{zone}/{sub-zone} and terminal wildcards are allowed on any segment of the specification. Examples: * - matches all localities us-west/* - all zones and sub-zones within the us-west region us-west/zone-1/* - all sub-zones within us-west/zone-1'
                                             properties:
                                               from:
-                                                description: Originating locality, '/' separated, e.g. 'region/zone/sub_zone'.
+                                                description: Originating locality, '/' separated,
+                                                  e.g.
+                                                format: string
                                                 type: string
                                               to:
                                                 additionalProperties:
-                                                  format: int32
                                                   type: integer
-                                                description: Map of upstream localities to traffic distribution weights. The sum of all weights should be == 100. Any locality not assigned a weight will receive no traffic.
+                                                description: Map of upstream localities to
+                                                  traffic distribution weights.
                                                 type: object
                                             type: object
                                           type: array
                                         enabled:
-                                          description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety. e.g. true means that turn on locality load balancing for this DestinationRule no matter what mesh wide settings is.
-                                          properties:
-                                            value:
-                                              description: The bool value.
-                                              type: boolean
-                                          type: object
+                                          description: enable locality load balancing, this
+                                            is DestinationRule-level and will override mesh
+                                            wide settings in entirety.
+                                          nullable: true
+                                          type: boolean
                                         failover:
-                                          description: 'Optional: only failover or distribute can be set. Explicitly specify the region traffic will land on when endpoints in local region becomes unhealthy. Should be used together with OutlierDetection to detect unhealthy endpoints. Note: if no OutlierDetection specified, this will not take effect.'
+                                          description: 'Optional: only failover or distribute
+                                            can be set.'
                                           items:
-                                            description: Specify the traffic failover policy across regions. Since zone and sub-zone failover is supported by default this only needs to be specified for regions when the operator needs to constrain traffic failover so that the default behavior of failing over to any endpoint globally does not apply. This is useful when failing over traffic across regions would not improve service health or may need to be restricted for other reasons like regulatory controls.
                                             properties:
                                               from:
                                                 description: Originating region.
+                                                format: string
                                                 type: string
                                               to:
-                                                description: Destination region the traffic will fail over to when endpoints in the 'from' region becomes unhealthy.
+                                                format: string
                                                 type: string
                                             type: object
                                           type: array
                                       type: object
+                                    simple:
+                                      enum:
+                                        - ROUND_ROBIN
+                                        - LEAST_CONN
+                                        - RANDOM
+                                        - PASSTHROUGH
+                                      type: string
                                   type: object
-                                outlier_detection:
-                                  description: Settings controlling eviction of unhealthy hosts from the load balancing pool
+                                outlierDetection:
                                   properties:
-                                    base_ejection_time:
-                                      description: 'Minimum ejection duration. A host will remain ejected for a period equal to the product of minimum ejection duration and the number of times the host has been ejected. This technique allows the system to automatically increase the ejection period for unhealthy upstream servers. format: 1h/1m/1s/1ms. MUST BE >=1ms. Default is 30s.'
-                                      properties:
-                                        nanos:
-                                          description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                          format: int32
-                                          type: integer
-                                        seconds:
-                                          description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                          format: int64
-                                          type: integer
-                                      type: object
-                                    consecutive_5xx_errors:
-                                      description: "Number of 5xx errors before a host is ejected from the connection pool. When the upstream host is accessed over an opaque TCP connection, connect timeouts, connection error/failure and request failure events qualify as a 5xx error. This feature defaults to 5 but can be disabled by setting the value to 0. \n Note that consecutive_gateway_errors and consecutive_5xx_errors can be used separately or together. Because the errors counted by consecutive_gateway_errors are also included in consecutive_5xx_errors, if the value of consecutive_gateway_errors is greater than or equal to the value of consecutive_5xx_errors, consecutive_gateway_errors will have no effect."
-                                      properties:
-                                        value:
-                                          description: The uint32 value.
-                                          format: int32
-                                          type: integer
-                                      type: object
-                                    consecutive_errors:
-                                      description: Number of errors before a host is ejected from the connection pool. Defaults to 5. When the upstream host is accessed over HTTP, a 502, 503, or 504 return code qualifies as an error. When the upstream host is accessed over an opaque TCP connection, connect timeouts and connection error/failure events qualify as an error. $hide_from_docs
+                                    baseEjectionTime:
+                                      description: Minimum ejection duration.
+                                      type: string
+                                    consecutive5xxErrors:
+                                      description: Number of 5xx errors before a host is ejected
+                                        from the connection pool.
+                                      nullable: true
+                                      type: integer
+                                    consecutiveErrors:
                                       format: int32
                                       type: integer
-                                    consecutive_gateway_errors:
-                                      description: "Number of gateway errors before a host is ejected from the connection pool. When the upstream host is accessed over HTTP, a 502, 503, or 504 return code qualifies as a gateway error. When the upstream host is accessed over an opaque TCP connection, connect timeouts and connection error/failure events qualify as a gateway error. This feature is disabled by default or when set to the value 0. \n Note that consecutive_gateway_errors and consecutive_5xx_errors can be used separately or together. Because the errors counted by consecutive_gateway_errors are also included in consecutive_5xx_errors, if the value of consecutive_gateway_errors is greater than or equal to the value of consecutive_5xx_errors, consecutive_gateway_errors will have no effect."
-                                      properties:
-                                        value:
-                                          description: The uint32 value.
-                                          format: int32
-                                          type: integer
-                                      type: object
+                                    consecutiveGatewayErrors:
+                                      description: Number of gateway errors before a host
+                                        is ejected from the connection pool.
+                                      nullable: true
+                                      type: integer
                                     interval:
-                                      description: 'Time interval between ejection sweep analysis. format: 1h/1m/1s/1ms. MUST BE >=1ms. Default is 10s.'
-                                      properties:
-                                        nanos:
-                                          description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                          format: int32
-                                          type: integer
-                                        seconds:
-                                          description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                          format: int64
-                                          type: integer
-                                      type: object
-                                    max_ejection_percent:
-                                      description: Maximum % of hosts in the load balancing pool for the upstream service that can be ejected. Defaults to 10%.
+                                      description: Time interval between ejection sweep analysis.
+                                      type: string
+                                    maxEjectionPercent:
                                       format: int32
                                       type: integer
-                                    min_health_percent:
-                                      description: Outlier detection will be enabled as long as the associated load balancing pool has at least min_health_percent hosts in healthy mode. When the percentage of healthy hosts in the load balancing pool drops below this threshold, outlier detection will be disabled and the proxy will load balance across all hosts in the pool (healthy and unhealthy). The threshold can be disabled by setting it to 0%. The default is 0% as it's not typically applicable in k8s environments with few pods per service.
+                                    minHealthPercent:
                                       format: int32
                                       type: integer
                                   type: object
-                                port_level_settings:
-                                  description: Traffic policies specific to individual ports. Note that port level settings will override the destination-level settings. Traffic settings specified at the destination-level will not be inherited when overridden by port-level settings, i.e. default values will be applied to fields omitted in port-level traffic policies.
+                                portLevelSettings:
+                                  description: Traffic policies specific to individual ports.
                                   items:
-                                    description: Traffic policies that apply to specific ports of the service
                                     properties:
-                                      connection_pool:
-                                        description: Settings controlling the volume of connections to an upstream service
+                                      connectionPool:
                                         properties:
                                           http:
                                             description: HTTP connection pool settings.
                                             properties:
-                                              h2_upgrade_policy:
-                                                description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+                                              h2UpgradePolicy:
+                                                description: Specify if http1.1 connection
+                                                  should be upgraded to http2 for the associated
+                                                  destination.
+                                                enum:
+                                                  - DEFAULT
+                                                  - DO_NOT_UPGRADE
+                                                  - UPGRADE
+                                                type: string
+                                              http1MaxPendingRequests:
+                                                description: Maximum number of pending HTTP
+                                                  requests to a destination.
                                                 format: int32
                                                 type: integer
-                                              http1_max_pending_requests:
-                                                description: Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+                                              http2MaxRequests:
+                                                description: Maximum number of requests to
+                                                  a backend.
                                                 format: int32
                                                 type: integer
-                                              http2_max_requests:
-                                                description: Maximum number of requests to a backend. Default 2^32-1.
+                                              idleTimeout:
+                                                description: The idle timeout for upstream
+                                                  connection pool connections.
+                                                type: string
+                                              maxRequestsPerConnection:
+                                                description: Maximum number of requests per
+                                                  connection to a backend.
                                                 format: int32
                                                 type: integer
-                                              idle_timeout:
-                                                description: The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. If not set, the default is 1 hour. When the idle timeout is reached the connection will be closed. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.
-                                                properties:
-                                                  nanos:
-                                                    description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                                    format: int32
-                                                    type: integer
-                                                  seconds:
-                                                    description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                                    format: int64
-                                                    type: integer
-                                                type: object
-                                              max_requests_per_connection:
-                                                description: Maximum number of requests per connection to a backend. Setting this parameter to 1 disables keep alive. Default 0, meaning "unlimited", up to 2^29.
+                                              maxRetries:
                                                 format: int32
                                                 type: integer
-                                              max_retries:
-                                                description: Maximum number of retries that can be outstanding to all hosts in a cluster at a given time. Defaults to 2^32-1.
-                                                format: int32
-                                                type: integer
+                                              useClientProtocol:
+                                                description: If set to true, client protocol
+                                                  will be preserved while initiating connection
+                                                  to backend.
+                                                type: boolean
                                             type: object
                                           tcp:
-                                            description: Settings common to both HTTP and TCP upstream connections.
+                                            description: Settings common to both HTTP and
+                                              TCP upstream connections.
                                             properties:
-                                              connect_timeout:
-                                                description: 'TCP connection timeout. format: 1h/1m/1s/1ms. MUST BE >=1ms. Default is 10s.'
-                                                properties:
-                                                  nanos:
-                                                    description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                                    format: int32
-                                                    type: integer
-                                                  seconds:
-                                                    description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                                    format: int64
-                                                    type: integer
-                                                type: object
-                                              max_connections:
-                                                description: Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.
+                                              connectTimeout:
+                                                description: TCP connection timeout.
+                                                type: string
+                                              maxConnections:
+                                                description: Maximum number of HTTP1 /TCP
+                                                  connections to a destination host.
                                                 format: int32
                                                 type: integer
-                                              tcp_keepalive:
-                                                description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+                                              tcpKeepalive:
+                                                description: If set then set SO_KEEPALIVE
+                                                  on the socket to enable TCP Keepalives.
                                                 properties:
                                                   interval:
-                                                    description: The time duration between keep-alive probes. Default is to use the OS level configuration (unless overridden, Linux defaults to 75s.)
-                                                    properties:
-                                                      nanos:
-                                                        description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                                        format: int32
-                                                        type: integer
-                                                      seconds:
-                                                        description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                                        format: int64
-                                                        type: integer
-                                                    type: object
+                                                    description: The time duration between
+                                                      keep-alive probes.
+                                                    type: string
                                                   probes:
-                                                    description: Maximum number of keepalive probes to send without response before deciding the connection is dead. Default is to use the OS level configuration (unless overridden, Linux defaults to 9.)
-                                                    format: int32
                                                     type: integer
                                                   time:
-                                                    description: The time duration a connection needs to be idle before keep-alive probes start being sent. Default is to use the OS level configuration (unless overridden, Linux defaults to 7200s (ie 2 hours.)
-                                                    properties:
-                                                      nanos:
-                                                        description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                                        format: int32
-                                                        type: integer
-                                                      seconds:
-                                                        description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                                        format: int64
-                                                        type: integer
-                                                    type: object
+                                                    type: string
                                                 type: object
                                             type: object
                                         type: object
-                                      load_balancer:
-                                        description: Settings controlling the load balancer algorithms.
+                                      loadBalancer:
+                                        description: Settings controlling the load balancer
+                                          algorithms.
+                                        oneOf:
+                                          - not:
+                                              anyOf:
+                                                - required:
+                                                    - simple
+                                                - properties:
+                                                    consistentHash:
+                                                      oneOf:
+                                                        - not:
+                                                            anyOf:
+                                                              - required:
+                                                                  - httpHeaderName
+                                                              - required:
+                                                                  - httpCookie
+                                                              - required:
+                                                                  - useSourceIp
+                                                              - required:
+                                                                  - httpQueryParameterName
+                                                        - required:
+                                                            - httpHeaderName
+                                                        - required:
+                                                            - httpCookie
+                                                        - required:
+                                                            - useSourceIp
+                                                        - required:
+                                                            - httpQueryParameterName
+                                                  required:
+                                                    - consistentHash
+                                          - required:
+                                              - simple
+                                          - properties:
+                                              consistentHash:
+                                                oneOf:
+                                                  - not:
+                                                      anyOf:
+                                                        - required:
+                                                            - httpHeaderName
+                                                        - required:
+                                                            - httpCookie
+                                                        - required:
+                                                            - useSourceIp
+                                                        - required:
+                                                            - httpQueryParameterName
+                                                  - required:
+                                                      - httpHeaderName
+                                                  - required:
+                                                      - httpCookie
+                                                  - required:
+                                                      - useSourceIp
+                                                  - required:
+                                                      - httpQueryParameterName
+                                            required:
+                                              - consistentHash
                                         properties:
-                                          locality_lb_setting:
-                                            description: Locality load balancer settings, this will override mesh wide settings in entirety, meaning no merging would be performed between this object and the object one in MeshConfig
+                                          consistentHash:
+                                            properties:
+                                              httpCookie:
+                                                description: Hash based on HTTP cookie.
+                                                properties:
+                                                  name:
+                                                    description: Name of the cookie.
+                                                    format: string
+                                                    type: string
+                                                  path:
+                                                    description: Path to set for the cookie.
+                                                    format: string
+                                                    type: string
+                                                  ttl:
+                                                    description: Lifetime of the cookie.
+                                                    type: string
+                                                type: object
+                                              httpHeaderName:
+                                                description: Hash based on a specific HTTP
+                                                  header.
+                                                format: string
+                                                type: string
+                                              httpQueryParameterName:
+                                                description: Hash based on a specific HTTP
+                                                  query parameter.
+                                                format: string
+                                                type: string
+                                              minimumRingSize:
+                                                type: integer
+                                              useSourceIp:
+                                                description: Hash based on the source IP address.
+                                                type: boolean
+                                            type: object
+                                          localityLbSetting:
                                             properties:
                                               distribute:
-                                                description: 'Optional: only one of distribute or failover can be set. Explicitly specify loadbalancing weight across different zones and geographical locations. Refer to [Locality weighted load balancing](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/locality_weight) If empty, the locality weight is set according to the endpoints number within it.'
+                                                description: 'Optional: only one of distribute
+                                                  or failover can be set.'
                                                 items:
-                                                  description: 'Describes how traffic originating in the ''from'' zone or sub-zone is distributed over a set of ''to'' zones. Syntax for specifying a zone is {region}/{zone}/{sub-zone} and terminal wildcards are allowed on any segment of the specification. Examples: * - matches all localities us-west/* - all zones and sub-zones within the us-west region us-west/zone-1/* - all sub-zones within us-west/zone-1'
                                                   properties:
                                                     from:
-                                                      description: Originating locality, '/' separated, e.g. 'region/zone/sub_zone'.
+                                                      description: Originating locality, '/'
+                                                        separated, e.g.
+                                                      format: string
                                                       type: string
                                                     to:
                                                       additionalProperties:
-                                                        format: int32
                                                         type: integer
-                                                      description: Map of upstream localities to traffic distribution weights. The sum of all weights should be == 100. Any locality not assigned a weight will receive no traffic.
+                                                      description: Map of upstream localities
+                                                        to traffic distribution weights.
                                                       type: object
                                                   type: object
                                                 type: array
                                               enabled:
-                                                description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety. e.g. true means that turn on locality load balancing for this DestinationRule no matter what mesh wide settings is.
-                                                properties:
-                                                  value:
-                                                    description: The bool value.
-                                                    type: boolean
-                                                type: object
+                                                description: enable locality load balancing,
+                                                  this is DestinationRule-level and will override
+                                                  mesh wide settings in entirety.
+                                                nullable: true
+                                                type: boolean
                                               failover:
-                                                description: 'Optional: only failover or distribute can be set. Explicitly specify the region traffic will land on when endpoints in local region becomes unhealthy. Should be used together with OutlierDetection to detect unhealthy endpoints. Note: if no OutlierDetection specified, this will not take effect.'
+                                                description: 'Optional: only failover or distribute
+                                                  can be set.'
                                                 items:
-                                                  description: Specify the traffic failover policy across regions. Since zone and sub-zone failover is supported by default this only needs to be specified for regions when the operator needs to constrain traffic failover so that the default behavior of failing over to any endpoint globally does not apply. This is useful when failing over traffic across regions would not improve service health or may need to be restricted for other reasons like regulatory controls.
                                                   properties:
                                                     from:
                                                       description: Originating region.
+                                                      format: string
                                                       type: string
                                                     to:
-                                                      description: Destination region the traffic will fail over to when endpoints in the 'from' region becomes unhealthy.
+                                                      format: string
                                                       type: string
                                                   type: object
                                                 type: array
                                             type: object
+                                          simple:
+                                            enum:
+                                              - ROUND_ROBIN
+                                              - LEAST_CONN
+                                              - RANDOM
+                                              - PASSTHROUGH
+                                            type: string
                                         type: object
-                                      outlier_detection:
-                                        description: Settings controlling eviction of unhealthy hosts from the load balancing pool
+                                      outlierDetection:
                                         properties:
-                                          base_ejection_time:
-                                            description: 'Minimum ejection duration. A host will remain ejected for a period equal to the product of minimum ejection duration and the number of times the host has been ejected. This technique allows the system to automatically increase the ejection period for unhealthy upstream servers. format: 1h/1m/1s/1ms. MUST BE >=1ms. Default is 30s.'
-                                            properties:
-                                              nanos:
-                                                description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                                format: int32
-                                                type: integer
-                                              seconds:
-                                                description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                                format: int64
-                                                type: integer
-                                            type: object
-                                          consecutive_5xx_errors:
-                                            description: "Number of 5xx errors before a host is ejected from the connection pool. When the upstream host is accessed over an opaque TCP connection, connect timeouts, connection error/failure and request failure events qualify as a 5xx error. This feature defaults to 5 but can be disabled by setting the value to 0. \n Note that consecutive_gateway_errors and consecutive_5xx_errors can be used separately or together. Because the errors counted by consecutive_gateway_errors are also included in consecutive_5xx_errors, if the value of consecutive_gateway_errors is greater than or equal to the value of consecutive_5xx_errors, consecutive_gateway_errors will have no effect."
-                                            properties:
-                                              value:
-                                                description: The uint32 value.
-                                                format: int32
-                                                type: integer
-                                            type: object
-                                          consecutive_errors:
-                                            description: Number of errors before a host is ejected from the connection pool. Defaults to 5. When the upstream host is accessed over HTTP, a 502, 503, or 504 return code qualifies as an error. When the upstream host is accessed over an opaque TCP connection, connect timeouts and connection error/failure events qualify as an error. $hide_from_docs
+                                          baseEjectionTime:
+                                            description: Minimum ejection duration.
+                                            type: string
+                                          consecutive5xxErrors:
+                                            description: Number of 5xx errors before a host
+                                              is ejected from the connection pool.
+                                            nullable: true
+                                            type: integer
+                                          consecutiveErrors:
                                             format: int32
                                             type: integer
-                                          consecutive_gateway_errors:
-                                            description: "Number of gateway errors before a host is ejected from the connection pool. When the upstream host is accessed over HTTP, a 502, 503, or 504 return code qualifies as a gateway error. When the upstream host is accessed over an opaque TCP connection, connect timeouts and connection error/failure events qualify as a gateway error. This feature is disabled by default or when set to the value 0. \n Note that consecutive_gateway_errors and consecutive_5xx_errors can be used separately or together. Because the errors counted by consecutive_gateway_errors are also included in consecutive_5xx_errors, if the value of consecutive_gateway_errors is greater than or equal to the value of consecutive_5xx_errors, consecutive_gateway_errors will have no effect."
-                                            properties:
-                                              value:
-                                                description: The uint32 value.
-                                                format: int32
-                                                type: integer
-                                            type: object
+                                          consecutiveGatewayErrors:
+                                            description: Number of gateway errors before a
+                                              host is ejected from the connection pool.
+                                            nullable: true
+                                            type: integer
                                           interval:
-                                            description: 'Time interval between ejection sweep analysis. format: 1h/1m/1s/1ms. MUST BE >=1ms. Default is 10s.'
-                                            properties:
-                                              nanos:
-                                                description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                                format: int32
-                                                type: integer
-                                              seconds:
-                                                description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                                format: int64
-                                                type: integer
-                                            type: object
-                                          max_ejection_percent:
-                                            description: Maximum % of hosts in the load balancing pool for the upstream service that can be ejected. Defaults to 10%.
+                                            description: Time interval between ejection sweep
+                                              analysis.
+                                            type: string
+                                          maxEjectionPercent:
                                             format: int32
                                             type: integer
-                                          min_health_percent:
-                                            description: Outlier detection will be enabled as long as the associated load balancing pool has at least min_health_percent hosts in healthy mode. When the percentage of healthy hosts in the load balancing pool drops below this threshold, outlier detection will be disabled and the proxy will load balance across all hosts in the pool (healthy and unhealthy). The threshold can be disabled by setting it to 0%. The default is 0% as it's not typically applicable in k8s environments with few pods per service.
+                                          minHealthPercent:
                                             format: int32
                                             type: integer
                                         type: object
                                       port:
-                                        description: Specifies the number of a port on the destination service on which this policy is being applied.
                                         properties:
                                           number:
-                                            description: Valid port number
-                                            format: int32
                                             type: integer
                                         type: object
                                       tls:
-                                        description: TLS related settings for connections to the upstream service.
+                                        description: TLS related settings for connections
+                                          to the upstream service.
                                         properties:
-                                          ca_certificates:
-                                            description: 'OPTIONAL: The path to the file containing certificate authority certificates to use in verifying a presented server certificate. If omitted, the proxy will not verify the server''s certificate. Should be empty if mode is `ISTIO_MUTUAL`.'
+                                          caCertificates:
+                                            format: string
                                             type: string
-                                          client_certificate:
-                                            description: REQUIRED if mode is `MUTUAL`. The path to the file holding the client-side TLS certificate to use. Should be empty if mode is `ISTIO_MUTUAL`.
+                                          clientCertificate:
+                                            description: REQUIRED if mode is `MUTUAL`.
+                                            format: string
+                                            type: string
+                                          credentialName:
+                                            format: string
                                             type: string
                                           mode:
-                                            description: Indicates whether connections to this port should be secured using TLS. The value of this field determines how TLS is enforced.
-                                            format: int32
-                                            type: integer
-                                          private_key:
-                                            description: REQUIRED if mode is `MUTUAL`. The path to the file holding the client's private key. Should be empty if mode is `ISTIO_MUTUAL`.
+                                            enum:
+                                              - DISABLE
+                                              - SIMPLE
+                                              - MUTUAL
+                                              - ISTIO_MUTUAL
+                                            type: string
+                                          privateKey:
+                                            description: REQUIRED if mode is `MUTUAL`.
+                                            format: string
                                             type: string
                                           sni:
-                                            description: SNI string to present to the server during TLS handshake.
+                                            description: SNI string to present to the server
+                                              during TLS handshake.
+                                            format: string
                                             type: string
-                                          subject_alt_names:
-                                            description: A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry.
+                                          subjectAltNames:
                                             items:
+                                              format: string
                                               type: string
                                             type: array
                                         type: object
                                     type: object
                                   type: array
                                 tls:
-                                  description: TLS related settings for connections to the upstream service.
+                                  description: TLS related settings for connections to the
+                                    upstream service.
                                   properties:
-                                    ca_certificates:
-                                      description: 'OPTIONAL: The path to the file containing certificate authority certificates to use in verifying a presented server certificate. If omitted, the proxy will not verify the server''s certificate. Should be empty if mode is `ISTIO_MUTUAL`.'
+                                    caCertificates:
+                                      format: string
                                       type: string
-                                    client_certificate:
-                                      description: REQUIRED if mode is `MUTUAL`. The path to the file holding the client-side TLS certificate to use. Should be empty if mode is `ISTIO_MUTUAL`.
+                                    clientCertificate:
+                                      description: REQUIRED if mode is `MUTUAL`.
+                                      format: string
+                                      type: string
+                                    credentialName:
+                                      format: string
                                       type: string
                                     mode:
-                                      description: Indicates whether connections to this port should be secured using TLS. The value of this field determines how TLS is enforced.
-                                      format: int32
-                                      type: integer
-                                    private_key:
-                                      description: REQUIRED if mode is `MUTUAL`. The path to the file holding the client's private key. Should be empty if mode is `ISTIO_MUTUAL`.
+                                      enum:
+                                        - DISABLE
+                                        - SIMPLE
+                                        - MUTUAL
+                                        - ISTIO_MUTUAL
+                                      type: string
+                                    privateKey:
+                                      description: REQUIRED if mode is `MUTUAL`.
+                                      format: string
                                       type: string
                                     sni:
-                                      description: SNI string to present to the server during TLS handshake.
+                                      description: SNI string to present to the server during
+                                        TLS handshake.
+                                      format: string
                                       type: string
-                                    subject_alt_names:
-                                      description: A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry.
+                                    subjectAltNames:
                                       items:
+                                        format: string
                                         type: string
                                       type: array
                                   type: object
                               type: object
                           type: object
                         type: array
-                      traffic_policy:
-                        description: Traffic policies to apply (load balancing policy, connection pool sizes, outlier detection).
+                      trafficPolicy:
                         properties:
-                          connection_pool:
-                            description: Settings controlling the volume of connections to an upstream service
+                          connectionPool:
                             properties:
                               http:
                                 description: HTTP connection pool settings.
                                 properties:
-                                  h2_upgrade_policy:
-                                    description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+                                  h2UpgradePolicy:
+                                    description: Specify if http1.1 connection should be upgraded
+                                      to http2 for the associated destination.
+                                    enum:
+                                      - DEFAULT
+                                      - DO_NOT_UPGRADE
+                                      - UPGRADE
+                                    type: string
+                                  http1MaxPendingRequests:
+                                    description: Maximum number of pending HTTP requests to
+                                      a destination.
                                     format: int32
                                     type: integer
-                                  http1_max_pending_requests:
-                                    description: Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+                                  http2MaxRequests:
+                                    description: Maximum number of requests to a backend.
                                     format: int32
                                     type: integer
-                                  http2_max_requests:
-                                    description: Maximum number of requests to a backend. Default 2^32-1.
+                                  idleTimeout:
+                                    description: The idle timeout for upstream connection
+                                      pool connections.
+                                    type: string
+                                  maxRequestsPerConnection:
+                                    description: Maximum number of requests per connection
+                                      to a backend.
                                     format: int32
                                     type: integer
-                                  idle_timeout:
-                                    description: The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. If not set, the default is 1 hour. When the idle timeout is reached the connection will be closed. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.
-                                    properties:
-                                      nanos:
-                                        description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                        format: int32
-                                        type: integer
-                                      seconds:
-                                        description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                        format: int64
-                                        type: integer
-                                    type: object
-                                  max_requests_per_connection:
-                                    description: Maximum number of requests per connection to a backend. Setting this parameter to 1 disables keep alive. Default 0, meaning "unlimited", up to 2^29.
+                                  maxRetries:
                                     format: int32
                                     type: integer
-                                  max_retries:
-                                    description: Maximum number of retries that can be outstanding to all hosts in a cluster at a given time. Defaults to 2^32-1.
-                                    format: int32
-                                    type: integer
+                                  useClientProtocol:
+                                    description: If set to true, client protocol will be preserved
+                                      while initiating connection to backend.
+                                    type: boolean
                                 type: object
                               tcp:
-                                description: Settings common to both HTTP and TCP upstream connections.
+                                description: Settings common to both HTTP and TCP upstream
+                                  connections.
                                 properties:
-                                  connect_timeout:
-                                    description: 'TCP connection timeout. format: 1h/1m/1s/1ms. MUST BE >=1ms. Default is 10s.'
-                                    properties:
-                                      nanos:
-                                        description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                        format: int32
-                                        type: integer
-                                      seconds:
-                                        description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                        format: int64
-                                        type: integer
-                                    type: object
-                                  max_connections:
-                                    description: Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.
+                                  connectTimeout:
+                                    description: TCP connection timeout.
+                                    type: string
+                                  maxConnections:
+                                    description: Maximum number of HTTP1 /TCP connections
+                                      to a destination host.
                                     format: int32
                                     type: integer
-                                  tcp_keepalive:
-                                    description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+                                  tcpKeepalive:
+                                    description: If set then set SO_KEEPALIVE on the socket
+                                      to enable TCP Keepalives.
                                     properties:
                                       interval:
-                                        description: The time duration between keep-alive probes. Default is to use the OS level configuration (unless overridden, Linux defaults to 75s.)
-                                        properties:
-                                          nanos:
-                                            description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                            format: int32
-                                            type: integer
-                                          seconds:
-                                            description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                            format: int64
-                                            type: integer
-                                        type: object
+                                        description: The time duration between keep-alive
+                                          probes.
+                                        type: string
                                       probes:
-                                        description: Maximum number of keepalive probes to send without response before deciding the connection is dead. Default is to use the OS level configuration (unless overridden, Linux defaults to 9.)
-                                        format: int32
                                         type: integer
                                       time:
-                                        description: The time duration a connection needs to be idle before keep-alive probes start being sent. Default is to use the OS level configuration (unless overridden, Linux defaults to 7200s (ie 2 hours.)
-                                        properties:
-                                          nanos:
-                                            description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                            format: int32
-                                            type: integer
-                                          seconds:
-                                            description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                            format: int64
-                                            type: integer
-                                        type: object
+                                        type: string
                                     type: object
                                 type: object
                             type: object
-                          load_balancer:
+                          loadBalancer:
                             description: Settings controlling the load balancer algorithms.
+                            oneOf:
+                              - not:
+                                  anyOf:
+                                    - required:
+                                        - simple
+                                    - properties:
+                                        consistentHash:
+                                          oneOf:
+                                            - not:
+                                                anyOf:
+                                                  - required:
+                                                      - httpHeaderName
+                                                  - required:
+                                                      - httpCookie
+                                                  - required:
+                                                      - useSourceIp
+                                                  - required:
+                                                      - httpQueryParameterName
+                                            - required:
+                                                - httpHeaderName
+                                            - required:
+                                                - httpCookie
+                                            - required:
+                                                - useSourceIp
+                                            - required:
+                                                - httpQueryParameterName
+                                      required:
+                                        - consistentHash
+                              - required:
+                                  - simple
+                              - properties:
+                                  consistentHash:
+                                    oneOf:
+                                      - not:
+                                          anyOf:
+                                            - required:
+                                                - httpHeaderName
+                                            - required:
+                                                - httpCookie
+                                            - required:
+                                                - useSourceIp
+                                            - required:
+                                                - httpQueryParameterName
+                                      - required:
+                                          - httpHeaderName
+                                      - required:
+                                          - httpCookie
+                                      - required:
+                                          - useSourceIp
+                                      - required:
+                                          - httpQueryParameterName
+                                required:
+                                  - consistentHash
                             properties:
-                              locality_lb_setting:
-                                description: Locality load balancer settings, this will override mesh wide settings in entirety, meaning no merging would be performed between this object and the object one in MeshConfig
+                              consistentHash:
+                                properties:
+                                  httpCookie:
+                                    description: Hash based on HTTP cookie.
+                                    properties:
+                                      name:
+                                        description: Name of the cookie.
+                                        format: string
+                                        type: string
+                                      path:
+                                        description: Path to set for the cookie.
+                                        format: string
+                                        type: string
+                                      ttl:
+                                        description: Lifetime of the cookie.
+                                        type: string
+                                    type: object
+                                  httpHeaderName:
+                                    description: Hash based on a specific HTTP header.
+                                    format: string
+                                    type: string
+                                  httpQueryParameterName:
+                                    description: Hash based on a specific HTTP query parameter.
+                                    format: string
+                                    type: string
+                                  minimumRingSize:
+                                    type: integer
+                                  useSourceIp:
+                                    description: Hash based on the source IP address.
+                                    type: boolean
+                                type: object
+                              localityLbSetting:
                                 properties:
                                   distribute:
-                                    description: 'Optional: only one of distribute or failover can be set. Explicitly specify loadbalancing weight across different zones and geographical locations. Refer to [Locality weighted load balancing](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/locality_weight) If empty, the locality weight is set according to the endpoints number within it.'
+                                    description: 'Optional: only one of distribute or failover
+                                      can be set.'
                                     items:
-                                      description: 'Describes how traffic originating in the ''from'' zone or sub-zone is distributed over a set of ''to'' zones. Syntax for specifying a zone is {region}/{zone}/{sub-zone} and terminal wildcards are allowed on any segment of the specification. Examples: * - matches all localities us-west/* - all zones and sub-zones within the us-west region us-west/zone-1/* - all sub-zones within us-west/zone-1'
                                       properties:
                                         from:
-                                          description: Originating locality, '/' separated, e.g. 'region/zone/sub_zone'.
+                                          description: Originating locality, '/' separated,
+                                            e.g.
+                                          format: string
                                           type: string
                                         to:
                                           additionalProperties:
-                                            format: int32
                                             type: integer
-                                          description: Map of upstream localities to traffic distribution weights. The sum of all weights should be == 100. Any locality not assigned a weight will receive no traffic.
+                                          description: Map of upstream localities to traffic
+                                            distribution weights.
                                           type: object
                                       type: object
                                     type: array
                                   enabled:
-                                    description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety. e.g. true means that turn on locality load balancing for this DestinationRule no matter what mesh wide settings is.
-                                    properties:
-                                      value:
-                                        description: The bool value.
-                                        type: boolean
-                                    type: object
+                                    description: enable locality load balancing, this is DestinationRule-level
+                                      and will override mesh wide settings in entirety.
+                                    nullable: true
+                                    type: boolean
                                   failover:
-                                    description: 'Optional: only failover or distribute can be set. Explicitly specify the region traffic will land on when endpoints in local region becomes unhealthy. Should be used together with OutlierDetection to detect unhealthy endpoints. Note: if no OutlierDetection specified, this will not take effect.'
+                                    description: 'Optional: only failover or distribute can
+                                      be set.'
                                     items:
-                                      description: Specify the traffic failover policy across regions. Since zone and sub-zone failover is supported by default this only needs to be specified for regions when the operator needs to constrain traffic failover so that the default behavior of failing over to any endpoint globally does not apply. This is useful when failing over traffic across regions would not improve service health or may need to be restricted for other reasons like regulatory controls.
                                       properties:
                                         from:
                                           description: Originating region.
+                                          format: string
                                           type: string
                                         to:
-                                          description: Destination region the traffic will fail over to when endpoints in the 'from' region becomes unhealthy.
+                                          format: string
                                           type: string
                                       type: object
                                     type: array
                                 type: object
+                              simple:
+                                enum:
+                                  - ROUND_ROBIN
+                                  - LEAST_CONN
+                                  - RANDOM
+                                  - PASSTHROUGH
+                                type: string
                             type: object
-                          outlier_detection:
-                            description: Settings controlling eviction of unhealthy hosts from the load balancing pool
+                          outlierDetection:
                             properties:
-                              base_ejection_time:
-                                description: 'Minimum ejection duration. A host will remain ejected for a period equal to the product of minimum ejection duration and the number of times the host has been ejected. This technique allows the system to automatically increase the ejection period for unhealthy upstream servers. format: 1h/1m/1s/1ms. MUST BE >=1ms. Default is 30s.'
-                                properties:
-                                  nanos:
-                                    description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                    format: int32
-                                    type: integer
-                                  seconds:
-                                    description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                    format: int64
-                                    type: integer
-                                type: object
-                              consecutive_5xx_errors:
-                                description: "Number of 5xx errors before a host is ejected from the connection pool. When the upstream host is accessed over an opaque TCP connection, connect timeouts, connection error/failure and request failure events qualify as a 5xx error. This feature defaults to 5 but can be disabled by setting the value to 0. \n Note that consecutive_gateway_errors and consecutive_5xx_errors can be used separately or together. Because the errors counted by consecutive_gateway_errors are also included in consecutive_5xx_errors, if the value of consecutive_gateway_errors is greater than or equal to the value of consecutive_5xx_errors, consecutive_gateway_errors will have no effect."
-                                properties:
-                                  value:
-                                    description: The uint32 value.
-                                    format: int32
-                                    type: integer
-                                type: object
-                              consecutive_errors:
-                                description: Number of errors before a host is ejected from the connection pool. Defaults to 5. When the upstream host is accessed over HTTP, a 502, 503, or 504 return code qualifies as an error. When the upstream host is accessed over an opaque TCP connection, connect timeouts and connection error/failure events qualify as an error. $hide_from_docs
+                              baseEjectionTime:
+                                description: Minimum ejection duration.
+                                type: string
+                              consecutive5xxErrors:
+                                description: Number of 5xx errors before a host is ejected
+                                  from the connection pool.
+                                nullable: true
+                                type: integer
+                              consecutiveErrors:
                                 format: int32
                                 type: integer
-                              consecutive_gateway_errors:
-                                description: "Number of gateway errors before a host is ejected from the connection pool. When the upstream host is accessed over HTTP, a 502, 503, or 504 return code qualifies as a gateway error. When the upstream host is accessed over an opaque TCP connection, connect timeouts and connection error/failure events qualify as a gateway error. This feature is disabled by default or when set to the value 0. \n Note that consecutive_gateway_errors and consecutive_5xx_errors can be used separately or together. Because the errors counted by consecutive_gateway_errors are also included in consecutive_5xx_errors, if the value of consecutive_gateway_errors is greater than or equal to the value of consecutive_5xx_errors, consecutive_gateway_errors will have no effect."
-                                properties:
-                                  value:
-                                    description: The uint32 value.
-                                    format: int32
-                                    type: integer
-                                type: object
+                              consecutiveGatewayErrors:
+                                description: Number of gateway errors before a host is ejected
+                                  from the connection pool.
+                                nullable: true
+                                type: integer
                               interval:
-                                description: 'Time interval between ejection sweep analysis. format: 1h/1m/1s/1ms. MUST BE >=1ms. Default is 10s.'
-                                properties:
-                                  nanos:
-                                    description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                    format: int32
-                                    type: integer
-                                  seconds:
-                                    description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                    format: int64
-                                    type: integer
-                                type: object
-                              max_ejection_percent:
-                                description: Maximum % of hosts in the load balancing pool for the upstream service that can be ejected. Defaults to 10%.
+                                description: Time interval between ejection sweep analysis.
+                                type: string
+                              maxEjectionPercent:
                                 format: int32
                                 type: integer
-                              min_health_percent:
-                                description: Outlier detection will be enabled as long as the associated load balancing pool has at least min_health_percent hosts in healthy mode. When the percentage of healthy hosts in the load balancing pool drops below this threshold, outlier detection will be disabled and the proxy will load balance across all hosts in the pool (healthy and unhealthy). The threshold can be disabled by setting it to 0%. The default is 0% as it's not typically applicable in k8s environments with few pods per service.
+                              minHealthPercent:
                                 format: int32
                                 type: integer
                             type: object
-                          port_level_settings:
-                            description: Traffic policies specific to individual ports. Note that port level settings will override the destination-level settings. Traffic settings specified at the destination-level will not be inherited when overridden by port-level settings, i.e. default values will be applied to fields omitted in port-level traffic policies.
+                          portLevelSettings:
+                            description: Traffic policies specific to individual ports.
                             items:
-                              description: Traffic policies that apply to specific ports of the service
                               properties:
-                                connection_pool:
-                                  description: Settings controlling the volume of connections to an upstream service
+                                connectionPool:
                                   properties:
                                     http:
                                       description: HTTP connection pool settings.
                                       properties:
-                                        h2_upgrade_policy:
-                                          description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+                                        h2UpgradePolicy:
+                                          description: Specify if http1.1 connection should
+                                            be upgraded to http2 for the associated destination.
+                                          enum:
+                                            - DEFAULT
+                                            - DO_NOT_UPGRADE
+                                            - UPGRADE
+                                          type: string
+                                        http1MaxPendingRequests:
+                                          description: Maximum number of pending HTTP requests
+                                            to a destination.
                                           format: int32
                                           type: integer
-                                        http1_max_pending_requests:
-                                          description: Maximum number of pending HTTP requests to a destination. Default 2^32-1.
+                                        http2MaxRequests:
+                                          description: Maximum number of requests to a backend.
                                           format: int32
                                           type: integer
-                                        http2_max_requests:
-                                          description: Maximum number of requests to a backend. Default 2^32-1.
+                                        idleTimeout:
+                                          description: The idle timeout for upstream connection
+                                            pool connections.
+                                          type: string
+                                        maxRequestsPerConnection:
+                                          description: Maximum number of requests per connection
+                                            to a backend.
                                           format: int32
                                           type: integer
-                                        idle_timeout:
-                                          description: The idle timeout for upstream connection pool connections. The idle timeout is defined as the period in which there are no active requests. If not set, the default is 1 hour. When the idle timeout is reached the connection will be closed. Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive. Applies to both HTTP1.1 and HTTP2 connections.
-                                          properties:
-                                            nanos:
-                                              description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                              format: int32
-                                              type: integer
-                                            seconds:
-                                              description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                              format: int64
-                                              type: integer
-                                          type: object
-                                        max_requests_per_connection:
-                                          description: Maximum number of requests per connection to a backend. Setting this parameter to 1 disables keep alive. Default 0, meaning "unlimited", up to 2^29.
+                                        maxRetries:
                                           format: int32
                                           type: integer
-                                        max_retries:
-                                          description: Maximum number of retries that can be outstanding to all hosts in a cluster at a given time. Defaults to 2^32-1.
-                                          format: int32
-                                          type: integer
+                                        useClientProtocol:
+                                          description: If set to true, client protocol will
+                                            be preserved while initiating connection to backend.
+                                          type: boolean
                                       type: object
                                     tcp:
-                                      description: Settings common to both HTTP and TCP upstream connections.
+                                      description: Settings common to both HTTP and TCP upstream
+                                        connections.
                                       properties:
-                                        connect_timeout:
-                                          description: 'TCP connection timeout. format: 1h/1m/1s/1ms. MUST BE >=1ms. Default is 10s.'
-                                          properties:
-                                            nanos:
-                                              description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                              format: int32
-                                              type: integer
-                                            seconds:
-                                              description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                              format: int64
-                                              type: integer
-                                          type: object
-                                        max_connections:
-                                          description: Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.
+                                        connectTimeout:
+                                          description: TCP connection timeout.
+                                          type: string
+                                        maxConnections:
+                                          description: Maximum number of HTTP1 /TCP connections
+                                            to a destination host.
                                           format: int32
                                           type: integer
-                                        tcp_keepalive:
-                                          description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+                                        tcpKeepalive:
+                                          description: If set then set SO_KEEPALIVE on the
+                                            socket to enable TCP Keepalives.
                                           properties:
                                             interval:
-                                              description: The time duration between keep-alive probes. Default is to use the OS level configuration (unless overridden, Linux defaults to 75s.)
-                                              properties:
-                                                nanos:
-                                                  description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                                  format: int32
-                                                  type: integer
-                                                seconds:
-                                                  description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                                  format: int64
-                                                  type: integer
-                                              type: object
+                                              description: The time duration between keep-alive
+                                                probes.
+                                              type: string
                                             probes:
-                                              description: Maximum number of keepalive probes to send without response before deciding the connection is dead. Default is to use the OS level configuration (unless overridden, Linux defaults to 9.)
-                                              format: int32
                                               type: integer
                                             time:
-                                              description: The time duration a connection needs to be idle before keep-alive probes start being sent. Default is to use the OS level configuration (unless overridden, Linux defaults to 7200s (ie 2 hours.)
-                                              properties:
-                                                nanos:
-                                                  description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                                  format: int32
-                                                  type: integer
-                                                seconds:
-                                                  description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                                  format: int64
-                                                  type: integer
-                                              type: object
+                                              type: string
                                           type: object
                                       type: object
                                   type: object
-                                load_balancer:
+                                loadBalancer:
                                   description: Settings controlling the load balancer algorithms.
+                                  oneOf:
+                                    - not:
+                                        anyOf:
+                                          - required:
+                                              - simple
+                                          - properties:
+                                              consistentHash:
+                                                oneOf:
+                                                  - not:
+                                                      anyOf:
+                                                        - required:
+                                                            - httpHeaderName
+                                                        - required:
+                                                            - httpCookie
+                                                        - required:
+                                                            - useSourceIp
+                                                        - required:
+                                                            - httpQueryParameterName
+                                                  - required:
+                                                      - httpHeaderName
+                                                  - required:
+                                                      - httpCookie
+                                                  - required:
+                                                      - useSourceIp
+                                                  - required:
+                                                      - httpQueryParameterName
+                                            required:
+                                              - consistentHash
+                                    - required:
+                                        - simple
+                                    - properties:
+                                        consistentHash:
+                                          oneOf:
+                                            - not:
+                                                anyOf:
+                                                  - required:
+                                                      - httpHeaderName
+                                                  - required:
+                                                      - httpCookie
+                                                  - required:
+                                                      - useSourceIp
+                                                  - required:
+                                                      - httpQueryParameterName
+                                            - required:
+                                                - httpHeaderName
+                                            - required:
+                                                - httpCookie
+                                            - required:
+                                                - useSourceIp
+                                            - required:
+                                                - httpQueryParameterName
+                                      required:
+                                        - consistentHash
                                   properties:
-                                    locality_lb_setting:
-                                      description: Locality load balancer settings, this will override mesh wide settings in entirety, meaning no merging would be performed between this object and the object one in MeshConfig
+                                    consistentHash:
+                                      properties:
+                                        httpCookie:
+                                          description: Hash based on HTTP cookie.
+                                          properties:
+                                            name:
+                                              description: Name of the cookie.
+                                              format: string
+                                              type: string
+                                            path:
+                                              description: Path to set for the cookie.
+                                              format: string
+                                              type: string
+                                            ttl:
+                                              description: Lifetime of the cookie.
+                                              type: string
+                                          type: object
+                                        httpHeaderName:
+                                          description: Hash based on a specific HTTP header.
+                                          format: string
+                                          type: string
+                                        httpQueryParameterName:
+                                          description: Hash based on a specific HTTP query
+                                            parameter.
+                                          format: string
+                                          type: string
+                                        minimumRingSize:
+                                          type: integer
+                                        useSourceIp:
+                                          description: Hash based on the source IP address.
+                                          type: boolean
+                                      type: object
+                                    localityLbSetting:
                                       properties:
                                         distribute:
-                                          description: 'Optional: only one of distribute or failover can be set. Explicitly specify loadbalancing weight across different zones and geographical locations. Refer to [Locality weighted load balancing](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/locality_weight) If empty, the locality weight is set according to the endpoints number within it.'
+                                          description: 'Optional: only one of distribute or
+                                            failover can be set.'
                                           items:
-                                            description: 'Describes how traffic originating in the ''from'' zone or sub-zone is distributed over a set of ''to'' zones. Syntax for specifying a zone is {region}/{zone}/{sub-zone} and terminal wildcards are allowed on any segment of the specification. Examples: * - matches all localities us-west/* - all zones and sub-zones within the us-west region us-west/zone-1/* - all sub-zones within us-west/zone-1'
                                             properties:
                                               from:
-                                                description: Originating locality, '/' separated, e.g. 'region/zone/sub_zone'.
+                                                description: Originating locality, '/' separated,
+                                                  e.g.
+                                                format: string
                                                 type: string
                                               to:
                                                 additionalProperties:
-                                                  format: int32
                                                   type: integer
-                                                description: Map of upstream localities to traffic distribution weights. The sum of all weights should be == 100. Any locality not assigned a weight will receive no traffic.
+                                                description: Map of upstream localities to
+                                                  traffic distribution weights.
                                                 type: object
                                             type: object
                                           type: array
                                         enabled:
-                                          description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety. e.g. true means that turn on locality load balancing for this DestinationRule no matter what mesh wide settings is.
-                                          properties:
-                                            value:
-                                              description: The bool value.
-                                              type: boolean
-                                          type: object
+                                          description: enable locality load balancing, this
+                                            is DestinationRule-level and will override mesh
+                                            wide settings in entirety.
+                                          nullable: true
+                                          type: boolean
                                         failover:
-                                          description: 'Optional: only failover or distribute can be set. Explicitly specify the region traffic will land on when endpoints in local region becomes unhealthy. Should be used together with OutlierDetection to detect unhealthy endpoints. Note: if no OutlierDetection specified, this will not take effect.'
+                                          description: 'Optional: only failover or distribute
+                                            can be set.'
                                           items:
-                                            description: Specify the traffic failover policy across regions. Since zone and sub-zone failover is supported by default this only needs to be specified for regions when the operator needs to constrain traffic failover so that the default behavior of failing over to any endpoint globally does not apply. This is useful when failing over traffic across regions would not improve service health or may need to be restricted for other reasons like regulatory controls.
                                             properties:
                                               from:
                                                 description: Originating region.
+                                                format: string
                                                 type: string
                                               to:
-                                                description: Destination region the traffic will fail over to when endpoints in the 'from' region becomes unhealthy.
+                                                format: string
                                                 type: string
                                             type: object
                                           type: array
                                       type: object
+                                    simple:
+                                      enum:
+                                        - ROUND_ROBIN
+                                        - LEAST_CONN
+                                        - RANDOM
+                                        - PASSTHROUGH
+                                      type: string
                                   type: object
-                                outlier_detection:
-                                  description: Settings controlling eviction of unhealthy hosts from the load balancing pool
+                                outlierDetection:
                                   properties:
-                                    base_ejection_time:
-                                      description: 'Minimum ejection duration. A host will remain ejected for a period equal to the product of minimum ejection duration and the number of times the host has been ejected. This technique allows the system to automatically increase the ejection period for unhealthy upstream servers. format: 1h/1m/1s/1ms. MUST BE >=1ms. Default is 30s.'
-                                      properties:
-                                        nanos:
-                                          description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                          format: int32
-                                          type: integer
-                                        seconds:
-                                          description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                          format: int64
-                                          type: integer
-                                      type: object
-                                    consecutive_5xx_errors:
-                                      description: "Number of 5xx errors before a host is ejected from the connection pool. When the upstream host is accessed over an opaque TCP connection, connect timeouts, connection error/failure and request failure events qualify as a 5xx error. This feature defaults to 5 but can be disabled by setting the value to 0. \n Note that consecutive_gateway_errors and consecutive_5xx_errors can be used separately or together. Because the errors counted by consecutive_gateway_errors are also included in consecutive_5xx_errors, if the value of consecutive_gateway_errors is greater than or equal to the value of consecutive_5xx_errors, consecutive_gateway_errors will have no effect."
-                                      properties:
-                                        value:
-                                          description: The uint32 value.
-                                          format: int32
-                                          type: integer
-                                      type: object
-                                    consecutive_errors:
-                                      description: Number of errors before a host is ejected from the connection pool. Defaults to 5. When the upstream host is accessed over HTTP, a 502, 503, or 504 return code qualifies as an error. When the upstream host is accessed over an opaque TCP connection, connect timeouts and connection error/failure events qualify as an error. $hide_from_docs
+                                    baseEjectionTime:
+                                      description: Minimum ejection duration.
+                                      type: string
+                                    consecutive5xxErrors:
+                                      description: Number of 5xx errors before a host is ejected
+                                        from the connection pool.
+                                      nullable: true
+                                      type: integer
+                                    consecutiveErrors:
                                       format: int32
                                       type: integer
-                                    consecutive_gateway_errors:
-                                      description: "Number of gateway errors before a host is ejected from the connection pool. When the upstream host is accessed over HTTP, a 502, 503, or 504 return code qualifies as a gateway error. When the upstream host is accessed over an opaque TCP connection, connect timeouts and connection error/failure events qualify as a gateway error. This feature is disabled by default or when set to the value 0. \n Note that consecutive_gateway_errors and consecutive_5xx_errors can be used separately or together. Because the errors counted by consecutive_gateway_errors are also included in consecutive_5xx_errors, if the value of consecutive_gateway_errors is greater than or equal to the value of consecutive_5xx_errors, consecutive_gateway_errors will have no effect."
-                                      properties:
-                                        value:
-                                          description: The uint32 value.
-                                          format: int32
-                                          type: integer
-                                      type: object
+                                    consecutiveGatewayErrors:
+                                      description: Number of gateway errors before a host
+                                        is ejected from the connection pool.
+                                      nullable: true
+                                      type: integer
                                     interval:
-                                      description: 'Time interval between ejection sweep analysis. format: 1h/1m/1s/1ms. MUST BE >=1ms. Default is 10s.'
-                                      properties:
-                                        nanos:
-                                          description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                          format: int32
-                                          type: integer
-                                        seconds:
-                                          description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                          format: int64
-                                          type: integer
-                                      type: object
-                                    max_ejection_percent:
-                                      description: Maximum % of hosts in the load balancing pool for the upstream service that can be ejected. Defaults to 10%.
+                                      description: Time interval between ejection sweep analysis.
+                                      type: string
+                                    maxEjectionPercent:
                                       format: int32
                                       type: integer
-                                    min_health_percent:
-                                      description: Outlier detection will be enabled as long as the associated load balancing pool has at least min_health_percent hosts in healthy mode. When the percentage of healthy hosts in the load balancing pool drops below this threshold, outlier detection will be disabled and the proxy will load balance across all hosts in the pool (healthy and unhealthy). The threshold can be disabled by setting it to 0%. The default is 0% as it's not typically applicable in k8s environments with few pods per service.
+                                    minHealthPercent:
                                       format: int32
                                       type: integer
                                   type: object
                                 port:
-                                  description: Specifies the number of a port on the destination service on which this policy is being applied.
                                   properties:
                                     number:
-                                      description: Valid port number
-                                      format: int32
                                       type: integer
                                   type: object
                                 tls:
-                                  description: TLS related settings for connections to the upstream service.
+                                  description: TLS related settings for connections to the
+                                    upstream service.
                                   properties:
-                                    ca_certificates:
-                                      description: 'OPTIONAL: The path to the file containing certificate authority certificates to use in verifying a presented server certificate. If omitted, the proxy will not verify the server''s certificate. Should be empty if mode is `ISTIO_MUTUAL`.'
+                                    caCertificates:
+                                      format: string
                                       type: string
-                                    client_certificate:
-                                      description: REQUIRED if mode is `MUTUAL`. The path to the file holding the client-side TLS certificate to use. Should be empty if mode is `ISTIO_MUTUAL`.
+                                    clientCertificate:
+                                      description: REQUIRED if mode is `MUTUAL`.
+                                      format: string
+                                      type: string
+                                    credentialName:
+                                      format: string
                                       type: string
                                     mode:
-                                      description: Indicates whether connections to this port should be secured using TLS. The value of this field determines how TLS is enforced.
-                                      format: int32
-                                      type: integer
-                                    private_key:
-                                      description: REQUIRED if mode is `MUTUAL`. The path to the file holding the client's private key. Should be empty if mode is `ISTIO_MUTUAL`.
+                                      enum:
+                                        - DISABLE
+                                        - SIMPLE
+                                        - MUTUAL
+                                        - ISTIO_MUTUAL
+                                      type: string
+                                    privateKey:
+                                      description: REQUIRED if mode is `MUTUAL`.
+                                      format: string
                                       type: string
                                     sni:
-                                      description: SNI string to present to the server during TLS handshake.
+                                      description: SNI string to present to the server during
+                                        TLS handshake.
+                                      format: string
                                       type: string
-                                    subject_alt_names:
-                                      description: A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry.
+                                    subjectAltNames:
                                       items:
+                                        format: string
                                         type: string
                                       type: array
                                   type: object
                               type: object
                             type: array
                           tls:
-                            description: TLS related settings for connections to the upstream service.
+                            description: TLS related settings for connections to the upstream
+                              service.
                             properties:
-                              ca_certificates:
-                                description: 'OPTIONAL: The path to the file containing certificate authority certificates to use in verifying a presented server certificate. If omitted, the proxy will not verify the server''s certificate. Should be empty if mode is `ISTIO_MUTUAL`.'
+                              caCertificates:
+                                format: string
                                 type: string
-                              client_certificate:
-                                description: REQUIRED if mode is `MUTUAL`. The path to the file holding the client-side TLS certificate to use. Should be empty if mode is `ISTIO_MUTUAL`.
+                              clientCertificate:
+                                description: REQUIRED if mode is `MUTUAL`.
+                                format: string
+                                type: string
+                              credentialName:
+                                format: string
                                 type: string
                               mode:
-                                description: Indicates whether connections to this port should be secured using TLS. The value of this field determines how TLS is enforced.
-                                format: int32
-                                type: integer
-                              private_key:
-                                description: REQUIRED if mode is `MUTUAL`. The path to the file holding the client's private key. Should be empty if mode is `ISTIO_MUTUAL`.
+                                enum:
+                                  - DISABLE
+                                  - SIMPLE
+                                  - MUTUAL
+                                  - ISTIO_MUTUAL
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `MUTUAL`.
+                                format: string
                                 type: string
                               sni:
-                                description: SNI string to present to the server during TLS handshake.
+                                description: SNI string to present to the server during TLS
+                                  handshake.
+                                format: string
                                 type: string
-                              subject_alt_names:
-                                description: A list of alternate names to verify the subject identity in the certificate. If specified, the proxy will verify that the server certificate's subject alt name matches one of the specified values. If specified, this list overrides the value of subject_alt_names from the ServiceEntry.
+                              subjectAltNames:
                                 items:
+                                  format: string
                                   type: string
                                 type: array
                             type: object

--- a/config/crds/servicemesh.kubesphere.io_strategies.yaml
+++ b/config/crds/servicemesh.kubesphere.io_strategies.yaml
@@ -91,455 +91,690 @@ spec:
                     description: Metadata of the virtual services created from this template
                     type: object
                   spec:
-                    description: Spec indicates the behavior of a virtual service.
+                    description: 'Configuration affecting label/content routing, sni routing,
+                      etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
                     properties:
-                      export_to:
-                        description: "A list of namespaces to which this virtual service is exported. Exporting a virtual service allows it to be used by sidecars and gateways defined in other namespaces. This feature provides a mechanism for service owners and mesh administrators to control the visibility of virtual services across namespace boundaries. \n If no namespaces are specified then the virtual service is exported to all namespaces by default. \n The value \".\" is reserved and defines an export to the same namespace that the virtual service is declared in. Similarly the value \"*\" is reserved and defines an export to all namespaces. \n NOTE: in the current release, the `exportTo` value is restricted to \".\" or \"*\" (i.e., the current namespace or all namespaces)."
+                      exportTo:
+                        description: A list of namespaces to which this virtual service is
+                          exported.
                         items:
+                          format: string
                           type: string
                         type: array
                       gateways:
-                        description: The names of gateways and sidecars that should apply these routes. Gateways in other namespaces may be referred to by `<gateway namespace>/<gateway name>`; specifying a gateway with no namespace qualifier is the same as specifying the VirtualService's namespace. A single VirtualService is used for sidecars inside the mesh as well as for one or more gateways. The selection condition imposed by this field can be overridden using the source field in the match conditions of protocol-specific routes. The reserved word `mesh` is used to imply all the sidecars in the mesh. When this field is omitted, the default gateway (`mesh`) will be used, which would apply the rule to all sidecars in the mesh. If a list of gateway names is provided, the rules will apply only to the gateways. To apply the rules to both gateways and sidecars, specify `mesh` as one of the gateway names.
+                        description: The names of gateways and sidecars that should apply
+                          these routes.
                         items:
+                          format: string
                           type: string
                         type: array
                       hosts:
-                        description: "The destination hosts to which traffic is being sent. Could be a DNS name with wildcard prefix or an IP address.  Depending on the platform, short-names can also be used instead of a FQDN (i.e. has no dots in the name). In such a scenario, the FQDN of the host would be derived based on the underlying platform. \n A single VirtualService can be used to describe all the traffic properties of the corresponding hosts, including those for multiple HTTP and TCP ports. Alternatively, the traffic properties of a host can be defined using more than one VirtualService, with certain caveats. Refer to the [Operations Guide](https://istio.io/docs/ops/best-practices/traffic-management/#split-virtual-services) for details. \n *Note for Kubernetes users*: When short names are used (e.g. \"reviews\" instead of \"reviews.default.svc.cluster.local\"), Istio will interpret the short name based on the namespace of the rule, not the service. A rule in the \"default\" namespace containing a host \"reviews\" will be interpreted as \"reviews.default.svc.cluster.local\", irrespective of the actual namespace associated with the reviews service. _To avoid potential misconfigurations, it is recommended to always use fully qualified domain names over short names._ \n The hosts field applies to both HTTP and TCP services. Service inside the mesh, i.e., those found in the service registry, must always be referred to using their alphanumeric names. IP addresses are allowed only for services defined via the Gateway. \n *Note*: It must be empty for a delegate VirtualService."
+                        description: The destination hosts to which traffic is being sent.
                         items:
+                          format: string
                           type: string
                         type: array
                       http:
-                        description: An ordered list of route rules for HTTP traffic. HTTP routes will be applied to platform service ports named 'http-*'/'http2-*'/'grpc-*', gateway ports with protocol HTTP/HTTP2/GRPC/ TLS-terminated-HTTPS and service entry ports using HTTP/HTTP2/GRPC protocols.  The first rule matching an incoming request is used.
+                        description: An ordered list of route rules for HTTP traffic.
                         items:
-                          description: Describes match conditions and actions for routing HTTP/1.1, HTTP2, and gRPC traffic. See VirtualService for usage examples.
                           properties:
-                            cors_policy:
-                              description: Cross-Origin Resource Sharing policy (CORS). Refer to [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for further details about cross origin resource sharing.
+                            corsPolicy:
+                              description: Cross-Origin Resource Sharing policy (CORS).
                               properties:
-                                allow_credentials:
-                                  description: Indicates whether the caller is allowed to send the actual request (not the preflight) using credentials. Translates to `Access-Control-Allow-Credentials` header.
-                                  properties:
-                                    value:
-                                      description: The bool value.
-                                      type: boolean
-                                  type: object
-                                allow_headers:
-                                  description: List of HTTP headers that can be used when requesting the resource. Serialized to Access-Control-Allow-Headers header.
+                                allowCredentials:
+                                  nullable: true
+                                  type: boolean
+                                allowHeaders:
                                   items:
+                                    format: string
                                     type: string
                                   type: array
-                                allow_methods:
-                                  description: List of HTTP methods allowed to access the resource. The content will be serialized into the Access-Control-Allow-Methods header.
+                                allowMethods:
+                                  description: List of HTTP methods allowed to access the
+                                    resource.
                                   items:
+                                    format: string
                                     type: string
                                   type: array
-                                allow_origin:
-                                  description: The list of origins that are allowed to perform CORS requests. The content will be serialized into the Access-Control-Allow-Origin header. Wildcard * will allow all origins. $hide_from_docs
+                                allowOrigin:
+                                  description: The list of origins that are allowed to perform
+                                    CORS requests.
                                   items:
+                                    format: string
                                     type: string
                                   type: array
-                                allow_origins:
-                                  description: String patterns that match allowed origins. An origin is allowed if any of the string matchers match. If a match is found, then the outgoing Access-Control-Allow-Origin would be set to the origin as provided by the client.
+                                allowOrigins:
+                                  description: String patterns that match allowed origins.
                                   items:
-                                    description: Describes how to match a given string in HTTP headers. Match is case-sensitive.
+                                    oneOf:
+                                      - not:
+                                          anyOf:
+                                            - required:
+                                                - exact
+                                            - required:
+                                                - prefix
+                                            - required:
+                                                - regex
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                    properties:
+                                      exact:
+                                        format: string
+                                        type: string
+                                      prefix:
+                                        format: string
+                                        type: string
+                                      regex:
+                                        description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                        format: string
+                                        type: string
                                     type: object
                                   type: array
-                                expose_headers:
-                                  description: A white list of HTTP headers that the browsers are allowed to access. Serialized into Access-Control-Expose-Headers header.
+                                exposeHeaders:
                                   items:
+                                    format: string
                                     type: string
                                   type: array
-                                max_age:
-                                  description: Specifies how long the results of a preflight request can be cached. Translates to the `Access-Control-Max-Age` header.
-                                  properties:
-                                    nanos:
-                                      description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                      format: int32
-                                      type: integer
-                                    seconds:
-                                      description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                      format: int64
-                                      type: integer
-                                  type: object
+                                maxAge:
+                                  type: string
                               type: object
                             delegate:
-                              description: 'Delegate is used to specify the particular VirtualService which can be used to define delegate HTTPRoute. It can be set only when `Route` and `Redirect` are empty, and the route rules of the delegate VirtualService will be merged with that in the current one. **NOTE**:    1. Only one level delegation is supported.    2. The delegate''s HTTPMatchRequest must be a strict subset of the root''s,       otherwise there is a conflict and the HTTPRoute will not take effect.'
                               properties:
                                 name:
                                   description: Name specifies the name of the delegate VirtualService.
+                                  format: string
                                   type: string
                                 namespace:
-                                  description: Namespace specifies the namespace where the delegate VirtualService resides. By default, it is same to the root's.
+                                  description: Namespace specifies the namespace where the
+                                    delegate VirtualService resides.
+                                  format: string
                                   type: string
                               type: object
                             fault:
-                              description: Fault injection policy to apply on HTTP traffic at the client side. Note that timeouts or retries will not be enabled when faults are enabled on the client side.
+                              description: Fault injection policy to apply on HTTP traffic
+                                at the client side.
                               properties:
                                 abort:
-                                  description: Abort Http request attempts and return error codes back to downstream service, giving the impression that the upstream service is faulty.
+                                  oneOf:
+                                    - not:
+                                        anyOf:
+                                          - required:
+                                              - httpStatus
+                                          - required:
+                                              - grpcStatus
+                                          - required:
+                                              - http2Error
+                                    - required:
+                                        - httpStatus
+                                    - required:
+                                        - grpcStatus
+                                    - required:
+                                        - http2Error
                                   properties:
+                                    grpcStatus:
+                                      format: string
+                                      type: string
+                                    http2Error:
+                                      format: string
+                                      type: string
+                                    httpStatus:
+                                      description: HTTP status code to use to abort the Http
+                                        request.
+                                      format: int32
+                                      type: integer
                                     percentage:
-                                      description: Percentage of requests to be aborted with the error code provided.
+                                      description: Percentage of requests to be aborted with
+                                        the error code provided.
                                       properties:
                                         value:
+                                          format: double
                                           type: number
                                       type: object
                                   type: object
                                 delay:
-                                  description: Delay requests before forwarding, emulating various failures such as network issues, overloaded upstream service, etc.
+                                  oneOf:
+                                    - not:
+                                        anyOf:
+                                          - required:
+                                              - fixedDelay
+                                          - required:
+                                              - exponentialDelay
+                                    - required:
+                                        - fixedDelay
+                                    - required:
+                                        - exponentialDelay
                                   properties:
+                                    exponentialDelay:
+                                      type: string
+                                    fixedDelay:
+                                      description: Add a fixed delay before forwarding the
+                                        request.
+                                      type: string
                                     percent:
-                                      description: Percentage of requests on which the delay will be injected (0-100). Use of integer `percent` value is deprecated. Use the double `percentage` field instead.
+                                      description: Percentage of requests on which the delay
+                                        will be injected (0-100).
                                       format: int32
                                       type: integer
                                     percentage:
-                                      description: Percentage of requests on which the delay will be injected.
+                                      description: Percentage of requests on which the delay
+                                        will be injected.
                                       properties:
                                         value:
+                                          format: double
                                           type: number
                                       type: object
                                   type: object
                               type: object
                             headers:
-                              description: Header manipulation rules
                               properties:
                                 request:
-                                  description: Header manipulation rules to apply before forwarding a request to the destination service
                                   properties:
                                     add:
                                       additionalProperties:
+                                        format: string
                                         type: string
-                                      description: Append the given values to the headers specified by keys (will create a comma-separated list of values)
                                       type: object
                                     remove:
-                                      description: Remove a the specified headers
                                       items:
+                                        format: string
                                         type: string
                                       type: array
                                     set:
                                       additionalProperties:
+                                        format: string
                                         type: string
-                                      description: Overwrite the headers specified by key with the given values
                                       type: object
                                   type: object
                                 response:
-                                  description: Header manipulation rules to apply before returning a response to the caller
                                   properties:
                                     add:
                                       additionalProperties:
+                                        format: string
                                         type: string
-                                      description: Append the given values to the headers specified by keys (will create a comma-separated list of values)
                                       type: object
                                     remove:
-                                      description: Remove a the specified headers
                                       items:
+                                        format: string
                                         type: string
                                       type: array
                                     set:
                                       additionalProperties:
+                                        format: string
                                         type: string
-                                      description: Overwrite the headers specified by key with the given values
                                       type: object
                                   type: object
                               type: object
                             match:
-                              description: Match conditions to be satisfied for the rule to be activated. All conditions inside a single match block have AND semantics, while the list of match blocks have OR semantics. The rule is matched if any one of the match blocks succeed.
                               items:
-                                description: "HttpMatchRequest specifies a set of criterion to be met in order for the rule to be applied to the HTTP request. For example, the following restricts the rule to match only requests where the URL path starts with /ratings/v2/ and the request contains a custom `end-user` header with value `jason`. \n {{<tabset category-name=\"example\">}} {{<tab name=\"v1alpha3\" category-value=\"v1alpha3\">}} ```yaml apiVersion: networking.istio.io/v1alpha3 kind: VirtualService metadata:   name: ratings-route spec:   hosts:   - ratings.prod.svc.cluster.local   http:   - match:     - headers:         end-user:           exact: jason       uri:         prefix: \"/ratings/v2/\"       ignoreUriCase: true     route:     - destination:         host: ratings.prod.svc.cluster.local ``` {{</tab>}} \n {{<tab name=\"v1beta1\" category-value=\"v1beta1\">}} ```yaml apiVersion: networking.istio.io/v1beta1 kind: VirtualService metadata:   name: ratings-route spec:   hosts:   - ratings.prod.svc.cluster.local   http:   - match:     - headers:         end-user:           exact: jason       uri:         prefix: \"/ratings/v2/\"       ignoreUriCase: true     route:     - destination:         host: ratings.prod.svc.cluster.local ``` {{</tab>}} {{</tabset>}} \n HTTPMatchRequest CANNOT be empty. **Note:** No regex string match can be set when delegate VirtualService is specified."
                                 properties:
                                   authority:
-                                    description: "HTTP Authority values are case-sensitive and formatted as follows: \n - `exact: \"value\"` for exact string match \n - `prefix: \"value\"` for prefix-based match \n - `regex: \"value\"` for ECMAscript style regex-based match"
+                                    oneOf:
+                                      - not:
+                                          anyOf:
+                                            - required:
+                                                - exact
+                                            - required:
+                                                - prefix
+                                            - required:
+                                                - regex
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                    properties:
+                                      exact:
+                                        format: string
+                                        type: string
+                                      prefix:
+                                        format: string
+                                        type: string
+                                      regex:
+                                        description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                        format: string
+                                        type: string
                                     type: object
                                   gateways:
-                                    description: Names of gateways where the rule should be applied. Gateway names in the top-level `gateways` field of the VirtualService (if any) are overridden. The gateway match is independent of sourceLabels.
+                                    description: Names of gateways where the rule should be
+                                      applied.
                                     items:
+                                      format: string
                                       type: string
                                     type: array
                                   headers:
                                     additionalProperties:
-                                      description: Describes how to match a given string in HTTP headers. Match is case-sensitive.
+                                      oneOf:
+                                        - not:
+                                            anyOf:
+                                              - required:
+                                                  - exact
+                                              - required:
+                                                  - prefix
+                                              - required:
+                                                  - regex
+                                        - required:
+                                            - exact
+                                        - required:
+                                            - prefix
+                                        - required:
+                                            - regex
+                                      properties:
+                                        exact:
+                                          format: string
+                                          type: string
+                                        prefix:
+                                          format: string
+                                          type: string
+                                        regex:
+                                          description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                          format: string
+                                          type: string
                                       type: object
-                                      x-kubernetes-preserve-unknown-fields: true
-                                    description: "The header keys must be lowercase and use hyphen as the separator, e.g. _x-request-id_. \n Header values are case-sensitive and formatted as follows: \n - `exact: \"value\"` for exact string match \n - `prefix: \"value\"` for prefix-based match \n - `regex: \"value\"` for ECMAscript style regex-based match \n If the value is empty and only the name of header is specfied, presence of the header is checked. **Note:** The keys `uri`, `scheme`, `method`, and `authority` will be ignored."
                                     type: object
-                                    x-kubernetes-preserve-unknown-fields: true
-                                  ignore_uri_case:
-                                    description: "Flag to specify whether the URI matching should be case-insensitive. \n **Note:** The case will be ignored only in the case of `exact` and `prefix` URI matches."
+                                  ignoreUriCase:
+                                    description: Flag to specify whether the URI matching
+                                      should be case-insensitive.
                                     type: boolean
                                   method:
-                                    description: "HTTP Method values are case-sensitive and formatted as follows: \n - `exact: \"value\"` for exact string match \n - `prefix: \"value\"` for prefix-based match \n - `regex: \"value\"` for ECMAscript style regex-based match"
+                                    oneOf:
+                                      - not:
+                                          anyOf:
+                                            - required:
+                                                - exact
+                                            - required:
+                                                - prefix
+                                            - required:
+                                                - regex
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                    properties:
+                                      exact:
+                                        format: string
+                                        type: string
+                                      prefix:
+                                        format: string
+                                        type: string
+                                      regex:
+                                        description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                        format: string
+                                        type: string
                                     type: object
                                   name:
-                                    description: The name assigned to a match. The match's name will be concatenated with the parent route's name and will be logged in the access logs for requests matching this route.
+                                    description: The name assigned to a match.
+                                    format: string
                                     type: string
                                   port:
-                                    description: Specifies the ports on the host that is being addressed. Many services only expose a single port or label ports with the protocols they support, in these cases it is not required to explicitly select the port.
-                                    format: int32
+                                    description: Specifies the ports on the host that is being
+                                      addressed.
                                     type: integer
-                                  query_params:
+                                  queryParams:
                                     additionalProperties:
-                                      description: Describes how to match a given string in HTTP headers. Match is case-sensitive.
+                                      oneOf:
+                                        - not:
+                                            anyOf:
+                                              - required:
+                                                  - exact
+                                              - required:
+                                                  - prefix
+                                              - required:
+                                                  - regex
+                                        - required:
+                                            - exact
+                                        - required:
+                                            - prefix
+                                        - required:
+                                            - regex
+                                      properties:
+                                        exact:
+                                          format: string
+                                          type: string
+                                        prefix:
+                                          format: string
+                                          type: string
+                                        regex:
+                                          description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                          format: string
+                                          type: string
                                       type: object
-                                    description: "Query parameters for matching. \n Ex: - For a query parameter like \"?key=true\", the map key would be \"key\" and   the string match could be defined as `exact: \"true\"`. - For a query parameter like \"?key\", the map key would be \"key\" and the   string match could be defined as `exact: \"\"`. - For a query parameter like \"?key=123\", the map key would be \"key\" and the   string match could be defined as `regex: \"\\d+$\"`. Note that this   configuration will only match values like \"123\" but not \"a123\" or \"123a\". \n **Note:** `prefix` matching is currently not supported."
+                                    description: Query parameters for matching.
                                     type: object
                                   scheme:
-                                    description: "URI Scheme values are case-sensitive and formatted as follows: \n - `exact: \"value\"` for exact string match \n - `prefix: \"value\"` for prefix-based match \n - `regex: \"value\"` for ECMAscript style regex-based match"
+                                    oneOf:
+                                      - not:
+                                          anyOf:
+                                            - required:
+                                                - exact
+                                            - required:
+                                                - prefix
+                                            - required:
+                                                - regex
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                    properties:
+                                      exact:
+                                        format: string
+                                        type: string
+                                      prefix:
+                                        format: string
+                                        type: string
+                                      regex:
+                                        description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                        format: string
+                                        type: string
                                     type: object
-                                  source_labels:
+                                  sourceLabels:
                                     additionalProperties:
+                                      format: string
                                       type: string
-                                    description: One or more labels that constrain the applicability of a rule to workloads with the given labels. If the VirtualService has a list of gateways specified in the top-level `gateways` field, it must include the reserved gateway `mesh` for this field to be applicable.
                                     type: object
-                                  source_namespace:
-                                    description: Source namespace constraining the applicability of a rule to workloads in that namespace. If the VirtualService has a list of gateways specified in the top-level `gateways` field, it must include the reserved gateway `mesh` for this field to be applicable.
+                                  sourceNamespace:
+                                    description: Source namespace constraining the applicability
+                                      of a rule to workloads in that namespace.
+                                    format: string
                                     type: string
                                   uri:
-                                    description: "URI to match values are case-sensitive and formatted as follows: \n - `exact: \"value\"` for exact string match \n - `prefix: \"value\"` for prefix-based match \n - `regex: \"value\"` for ECMAscript style regex-based match \n **Note:** Case-insensitive matching could be enabled via the `ignore_uri_case` flag."
+                                    oneOf:
+                                      - not:
+                                          anyOf:
+                                            - required:
+                                                - exact
+                                            - required:
+                                                - prefix
+                                            - required:
+                                                - regex
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                    properties:
+                                      exact:
+                                        format: string
+                                        type: string
+                                      prefix:
+                                        format: string
+                                        type: string
+                                      regex:
+                                        description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                        format: string
+                                        type: string
                                     type: object
-                                  without_headers:
+                                  withoutHeaders:
                                     additionalProperties:
-                                      description: Describes how to match a given string in HTTP headers. Match is case-sensitive.
+                                      oneOf:
+                                        - not:
+                                            anyOf:
+                                              - required:
+                                                  - exact
+                                              - required:
+                                                  - prefix
+                                              - required:
+                                                  - regex
+                                        - required:
+                                            - exact
+                                        - required:
+                                            - prefix
+                                        - required:
+                                            - regex
+                                      properties:
+                                        exact:
+                                          format: string
+                                          type: string
+                                        prefix:
+                                          format: string
+                                          type: string
+                                        regex:
+                                          description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                          format: string
+                                          type: string
                                       type: object
-                                    description: withoutHeader has the same syntax with the header, but has opposite meaning. If a header is matched with a matching rule among withoutHeader, the traffic becomes not matched one.
+                                    description: withoutHeader has the same syntax with the
+                                      header, but has opposite meaning.
                                     type: object
                                 type: object
                               type: array
                             mirror:
-                              description: Mirror HTTP traffic to a another destination in addition to forwarding the requests to the intended destination. Mirrored traffic is on a best effort basis where the sidecar/gateway will not wait for the mirrored cluster to respond before returning the response from the original destination.  Statistics will be generated for the mirrored destination.
                               properties:
                                 host:
-                                  description: "The name of a service from the service registry. Service names are looked up from the platform's service registry (e.g., Kubernetes services, Consul services, etc.) and from the hosts declared by [ServiceEntry](https://istio.io/docs/reference/config/networking/service-entry/#ServiceEntry). Traffic forwarded to destinations that are not found in either of the two, will be dropped. \n *Note for Kubernetes users*: When short names are used (e.g. \"reviews\" instead of \"reviews.default.svc.cluster.local\"), Istio will interpret the short name based on the namespace of the rule, not the service. A rule in the \"default\" namespace containing a host \"reviews will be interpreted as \"reviews.default.svc.cluster.local\", irrespective of the actual namespace associated with the reviews service. To avoid potential misconfiguration, it is recommended to always use fully qualified domain names over short names."
+                                  description: The name of a service from the service registry.
+                                  format: string
                                   type: string
                                 port:
-                                  description: Specifies the port on the host that is being addressed. If a service exposes only a single port it is not required to explicitly select the port.
+                                  description: Specifies the port on the host that is being
+                                    addressed.
                                   properties:
                                     number:
-                                      description: Valid port number
-                                      format: int32
                                       type: integer
                                   type: object
                                 subset:
-                                  description: The name of a subset within the service. Applicable only to services within the mesh. The subset must be defined in a corresponding DestinationRule.
+                                  description: The name of a subset within the service.
+                                  format: string
                                   type: string
                               type: object
                             mirror_percent:
-                              description: Percentage of the traffic to be mirrored by the `mirror` field. Use of integer `mirror_percent` value is deprecated. Use the double `mirror_percentage` field instead
+                              description: Percentage of the traffic to be mirrored by the
+                                `mirror` field.
+                              nullable: true
+                              type: integer
+                            mirrorPercent:
+                              description: Percentage of the traffic to be mirrored by the
+                                `mirror` field.
+                              nullable: true
+                              type: integer
+                            mirrorPercentage:
+                              description: Percentage of the traffic to be mirrored by the
+                                `mirror` field.
                               properties:
                                 value:
-                                  description: The uint32 value.
-                                  format: int32
-                                  type: integer
-                              type: object
-                            mirror_percentage:
-                              description: Percentage of the traffic to be mirrored by the `mirror` field. If this field is absent, all the traffic (100%) will be mirrored. Max value is 100.
-                              properties:
-                                value:
+                                  format: double
                                   type: number
                               type: object
                             name:
-                              description: The name assigned to the route for debugging purposes. The route's name will be concatenated with the match's name and will be logged in the access logs for requests matching this route/match.
+                              description: The name assigned to the route for debugging purposes.
+                              format: string
                               type: string
                             redirect:
-                              description: A HTTP rule can either redirect or forward (default) traffic. If traffic passthrough option is specified in the rule, route/redirect will be ignored. The redirect primitive can be used to send a HTTP 301 redirect to a different URI or Authority.
+                              description: A HTTP rule can either redirect or forward (default)
+                                traffic.
                               properties:
                                 authority:
-                                  description: On a redirect, overwrite the Authority/Host portion of the URL with this value.
+                                  format: string
                                   type: string
-                                redirect_code:
-                                  description: On a redirect, Specifies the HTTP status code to use in the redirect response. The default response code is MOVED_PERMANENTLY (301).
-                                  format: int32
+                                redirectCode:
                                   type: integer
                                 uri:
-                                  description: On a redirect, overwrite the Path portion of the URL with this value. Note that the entire path will be replaced, irrespective of the request URI being matched as an exact path or prefix.
+                                  format: string
                                   type: string
                               type: object
                             retries:
                               description: Retry policy for HTTP requests.
                               properties:
                                 attempts:
-                                  description: Number of retries for a given request. The interval between retries will be determined automatically (25ms+). Actual number of retries attempted depends on the request `timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute).
+                                  description: Number of retries to be allowed for a given
+                                    request.
                                   format: int32
                                   type: integer
-                                per_try_timeout:
-                                  description: 'Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE >=1ms.'
-                                  properties:
-                                    nanos:
-                                      description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                      format: int32
-                                      type: integer
-                                    seconds:
-                                      description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                      format: int64
-                                      type: integer
-                                  type: object
-                                retry_on:
-                                  description: Specifies the conditions under which retry takes place. One or more policies can be specified using a ‘,’ delimited list. See the [retry policies](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on) and [gRPC retry policies](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on) for more details.
+                                perTryTimeout:
+                                  description: Timeout per attempt for a given request, including
+                                    the initial call and any retries.
                                   type: string
-                                retry_remote_localities:
-                                  description: Flag to specify whether the retries should retry to other localities. See the [retry plugin configuration](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/http_connection_management#retry-plugin-configuration) for more details.
-                                  properties:
-                                    value:
-                                      description: The bool value.
-                                      type: boolean
-                                  type: object
+                                retryOn:
+                                  description: Specifies the conditions under which retry
+                                    takes place.
+                                  format: string
+                                  type: string
+                                retryRemoteLocalities:
+                                  description: Flag to specify whether the retries should
+                                    retry to other localities.
+                                  nullable: true
+                                  type: boolean
                               type: object
                             rewrite:
-                              description: Rewrite HTTP URIs and Authority headers. Rewrite cannot be used with Redirect primitive. Rewrite will be performed before forwarding.
+                              description: Rewrite HTTP URIs and Authority headers.
                               properties:
                                 authority:
-                                  description: rewrite the Authority/Host header with this value.
+                                  description: rewrite the Authority/Host header with this
+                                    value.
+                                  format: string
                                   type: string
                                 uri:
-                                  description: rewrite the path (or the prefix) portion of the URI with this value. If the original URI was matched based on prefix, the value provided in this field will replace the corresponding matched prefix.
+                                  format: string
                                   type: string
                               type: object
                             route:
-                              description: A HTTP rule can either redirect or forward (default) traffic. The forwarding target can be one of several versions of a service (see glossary in beginning of document). Weights associated with the service version determine the proportion of traffic it receives.
+                              description: A HTTP rule can either redirect or forward (default)
+                                traffic.
                               items:
-                                description: "Each routing rule is associated with one or more service versions (see glossary in beginning of document). Weights associated with the version determine the proportion of traffic it receives. For example, the following rule will route 25% of traffic for the \"reviews\" service to instances with the \"v2\" tag and the remaining traffic (i.e., 75%) to \"v1\". \n {{<tabset category-name=\"example\">}} {{<tab name=\"v1alpha3\" category-value=\"v1alpha3\">}} ```yaml apiVersion: networking.istio.io/v1alpha3 kind: VirtualService metadata:   name: reviews-route spec:   hosts:   - reviews.prod.svc.cluster.local   http:   - route:     - destination:         host: reviews.prod.svc.cluster.local         subset: v2       weight: 25     - destination:         host: reviews.prod.svc.cluster.local         subset: v1       weight: 75 ``` {{</tab>}} \n {{<tab name=\"v1beta1\" category-value=\"v1beta1\">}} ```yaml apiVersion: networking.istio.io/v1beta1 kind: VirtualService metadata:   name: reviews-route spec:   hosts:   - reviews.prod.svc.cluster.local   http:   - route:     - destination:         host: reviews.prod.svc.cluster.local         subset: v2       weight: 25     - destination:         host: reviews.prod.svc.cluster.local         subset: v1       weight: 75 ``` {{</tab>}} {{</tabset>}} \n And the associated DestinationRule \n {{<tabset category-name=\"example\">}} {{<tab name=\"v1alpha3\" category-value=\"v1alpha3\">}} ```yaml apiVersion: networking.istio.io/v1alpha3 kind: DestinationRule metadata:   name: reviews-destination spec:   host: reviews.prod.svc.cluster.local   subsets:   - name: v1     labels:       version: v1   - name: v2     labels:       version: v2 ``` {{</tab>}} \n {{<tab name=\"v1beta1\" category-value=\"v1beta1\">}} ```yaml apiVersion: networking.istio.io/v1beta1 kind: DestinationRule metadata:   name: reviews-destination spec:   host: reviews.prod.svc.cluster.local   subsets:   - name: v1     labels:       version: v1   - name: v2     labels:       version: v2 ``` {{</tab>}} {{</tabset>}} \n Traffic can also be split across two entirely different services without having to define new subsets. For example, the following rule forwards 25% of traffic to reviews.com to dev.reviews.com \n {{<tabset category-name=\"example\">}} {{<tab name=\"v1alpha3\" category-value=\"v1alpha3\">}} ```yaml apiVersion: networking.istio.io/v1alpha3 kind: VirtualService metadata:   name: reviews-route-two-domains spec:   hosts:   - reviews.com   http:   - route:     - destination:         host: dev.reviews.com       weight: 25     - destination:         host: reviews.com       weight: 75 ``` {{</tab>}} \n {{<tab name=\"v1beta1\" category-value=\"v1beta1\">}} ```yaml apiVersion: networking.istio.io/v1beta1 kind: VirtualService metadata:   name: reviews-route-two-domains spec:   hosts:   - reviews.com   http:   - route:     - destination:         host: dev.reviews.com       weight: 25     - destination:         host: reviews.com       weight: 75 ``` {{</tab>}} {{</tabset>}}"
                                 properties:
                                   destination:
-                                    description: Destination uniquely identifies the instances of a service to which the request/connection should be forwarded to.
                                     properties:
                                       host:
-                                        description: "The name of a service from the service registry. Service names are looked up from the platform's service registry (e.g., Kubernetes services, Consul services, etc.) and from the hosts declared by [ServiceEntry](https://istio.io/docs/reference/config/networking/service-entry/#ServiceEntry). Traffic forwarded to destinations that are not found in either of the two, will be dropped. \n *Note for Kubernetes users*: When short names are used (e.g. \"reviews\" instead of \"reviews.default.svc.cluster.local\"), Istio will interpret the short name based on the namespace of the rule, not the service. A rule in the \"default\" namespace containing a host \"reviews will be interpreted as \"reviews.default.svc.cluster.local\", irrespective of the actual namespace associated with the reviews service. To avoid potential misconfiguration, it is recommended to always use fully qualified domain names over short names."
+                                        description: The name of a service from the service
+                                          registry.
+                                        format: string
                                         type: string
                                       port:
-                                        description: Specifies the port on the host that is being addressed. If a service exposes only a single port it is not required to explicitly select the port.
+                                        description: Specifies the port on the host that is
+                                          being addressed.
                                         properties:
                                           number:
-                                            description: Valid port number
-                                            format: int32
                                             type: integer
                                         type: object
                                       subset:
-                                        description: The name of a subset within the service. Applicable only to services within the mesh. The subset must be defined in a corresponding DestinationRule.
+                                        description: The name of a subset within the service.
+                                        format: string
                                         type: string
                                     type: object
                                   headers:
-                                    description: Header manipulation rules
                                     properties:
                                       request:
-                                        description: Header manipulation rules to apply before forwarding a request to the destination service
                                         properties:
                                           add:
                                             additionalProperties:
+                                              format: string
                                               type: string
-                                            description: Append the given values to the headers specified by keys (will create a comma-separated list of values)
                                             type: object
                                           remove:
-                                            description: Remove a the specified headers
                                             items:
+                                              format: string
                                               type: string
                                             type: array
                                           set:
                                             additionalProperties:
+                                              format: string
                                               type: string
-                                            description: Overwrite the headers specified by key with the given values
                                             type: object
                                         type: object
                                       response:
-                                        description: Header manipulation rules to apply before returning a response to the caller
                                         properties:
                                           add:
                                             additionalProperties:
+                                              format: string
                                               type: string
-                                            description: Append the given values to the headers specified by keys (will create a comma-separated list of values)
                                             type: object
                                           remove:
-                                            description: Remove a the specified headers
                                             items:
+                                              format: string
                                               type: string
                                             type: array
                                           set:
                                             additionalProperties:
+                                              format: string
                                               type: string
-                                            description: Overwrite the headers specified by key with the given values
                                             type: object
                                         type: object
                                     type: object
                                   weight:
-                                    description: The proportion of traffic to be forwarded to the service version. (0-100). Sum of weights across destinations SHOULD BE == 100. If there is only one destination in a rule, the weight value is assumed to be 100.
                                     format: int32
                                     type: integer
                                 type: object
                               type: array
                             timeout:
-                              description: Timeout for HTTP requests.
-                              properties:
-                                nanos:
-                                  description: Signed fractions of a second at nanosecond resolution of the span of time. Durations less than one second are represented with a 0 `seconds` field and a positive or negative `nanos` field. For durations of one second or more, a non-zero value for the `nanos` field must be of the same sign as the `seconds` field. Must be from -999,999,999 to +999,999,999 inclusive.
-                                  format: int32
-                                  type: integer
-                                seconds:
-                                  description: 'Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years'
-                                  format: int64
-                                  type: integer
-                              type: object
+                              description: Timeout for HTTP requests, default is disabled.
+                              type: string
                           type: object
                         type: array
                       tcp:
-                        description: An ordered list of route rules for opaque TCP traffic. TCP routes will be applied to any port that is not a HTTP or TLS port. The first rule matching an incoming request is used.
+                        description: An ordered list of route rules for opaque TCP traffic.
                         items:
-                          description: "Describes match conditions and actions for routing TCP traffic. The following routing rule forwards traffic arriving at port 27017 for mongo.prod.svc.cluster.local to another Mongo server on port 5555. \n {{<tabset category-name=\"example\">}} {{<tab name=\"v1alpha3\" category-value=\"v1alpha3\">}} ```yaml apiVersion: networking.istio.io/v1alpha3 kind: VirtualService metadata:   name: bookinfo-Mongo spec:   hosts:   - mongo.prod.svc.cluster.local   tcp:   - match:     - port: 27017     route:     - destination:         host: mongo.backup.svc.cluster.local         port:           number: 5555 ``` {{</tab>}} \n {{<tab name=\"v1beta1\" category-value=\"v1beta1\">}} ```yaml apiVersion: networking.istio.io/v1beta1 kind: VirtualService metadata:   name: bookinfo-Mongo spec:   hosts:   - mongo.prod.svc.cluster.local   tcp:   - match:     - port: 27017     route:     - destination:         host: mongo.backup.svc.cluster.local         port:           number: 5555 ``` {{</tab>}} {{</tabset>}}"
                           properties:
                             match:
-                              description: Match conditions to be satisfied for the rule to be activated. All conditions inside a single match block have AND semantics, while the list of match blocks have OR semantics. The rule is matched if any one of the match blocks succeed.
                               items:
-                                description: L4 connection match attributes. Note that L4 connection matching support is incomplete.
                                 properties:
-                                  destination_subnets:
-                                    description: IPv4 or IPv6 ip addresses of destination with optional subnet.  E.g., a.b.c.d/xx form or just a.b.c.d.
+                                  destinationSubnets:
+                                    description: IPv4 or IPv6 ip addresses of destination
+                                      with optional subnet.
                                     items:
+                                      format: string
                                       type: string
                                     type: array
                                   gateways:
-                                    description: Names of gateways where the rule should be applied. Gateway names in the top-level `gateways` field of the VirtualService (if any) are overridden. The gateway match is independent of sourceLabels.
+                                    description: Names of gateways where the rule should be
+                                      applied.
                                     items:
+                                      format: string
                                       type: string
                                     type: array
                                   port:
-                                    description: Specifies the port on the host that is being addressed. Many services only expose a single port or label ports with the protocols they support, in these cases it is not required to explicitly select the port.
-                                    format: int32
+                                    description: Specifies the port on the host that is being
+                                      addressed.
                                     type: integer
-                                  source_labels:
+                                  sourceLabels:
                                     additionalProperties:
+                                      format: string
                                       type: string
-                                    description: One or more labels that constrain the applicability of a rule to workloads with the given labels. If the VirtualService has a list of gateways specified in the top-level `gateways` field, it should include the reserved gateway `mesh` in order for this field to be applicable.
                                     type: object
-                                  source_namespace:
-                                    description: Source namespace constraining the applicability of a rule to workloads in that namespace. If the VirtualService has a list of gateways specified in the top-level `gateways` field, it must include the reserved gateway `mesh` for this field to be applicable.
+                                  sourceNamespace:
+                                    description: Source namespace constraining the applicability
+                                      of a rule to workloads in that namespace.
+                                    format: string
                                     type: string
-                                  source_subnet:
-                                    description: IPv4 or IPv6 ip address of source with optional subnet. E.g., a.b.c.d/xx form or just a.b.c.d $hide_from_docs
+                                  sourceSubnet:
+                                    description: IPv4 or IPv6 ip address of source with optional
+                                      subnet.
+                                    format: string
                                     type: string
                                 type: object
                               type: array
                             route:
-                              description: The destination to which the connection should be forwarded to.
+                              description: The destination to which the connection should
+                                be forwarded to.
                               items:
-                                description: L4 routing rule weighted destination.
                                 properties:
                                   destination:
-                                    description: Destination uniquely identifies the instances of a service to which the request/connection should be forwarded to.
                                     properties:
                                       host:
-                                        description: "The name of a service from the service registry. Service names are looked up from the platform's service registry (e.g., Kubernetes services, Consul services, etc.) and from the hosts declared by [ServiceEntry](https://istio.io/docs/reference/config/networking/service-entry/#ServiceEntry). Traffic forwarded to destinations that are not found in either of the two, will be dropped. \n *Note for Kubernetes users*: When short names are used (e.g. \"reviews\" instead of \"reviews.default.svc.cluster.local\"), Istio will interpret the short name based on the namespace of the rule, not the service. A rule in the \"default\" namespace containing a host \"reviews will be interpreted as \"reviews.default.svc.cluster.local\", irrespective of the actual namespace associated with the reviews service. To avoid potential misconfiguration, it is recommended to always use fully qualified domain names over short names."
+                                        description: The name of a service from the service
+                                          registry.
+                                        format: string
                                         type: string
                                       port:
-                                        description: Specifies the port on the host that is being addressed. If a service exposes only a single port it is not required to explicitly select the port.
+                                        description: Specifies the port on the host that is
+                                          being addressed.
                                         properties:
                                           number:
-                                            description: Valid port number
-                                            format: int32
                                             type: integer
                                         type: object
                                       subset:
-                                        description: The name of a subset within the service. Applicable only to services within the mesh. The subset must be defined in a corresponding DestinationRule.
+                                        description: The name of a subset within the service.
+                                        format: string
                                         type: string
                                     type: object
                                   weight:
-                                    description: The proportion of traffic to be forwarded to the service version. If there is only one destination in a rule, all traffic will be routed to it irrespective of the weight.
                                     format: int32
                                     type: integer
                                 type: object
@@ -547,69 +782,72 @@ spec:
                           type: object
                         type: array
                       tls:
-                        description: 'An ordered list of route rule for non-terminated TLS & HTTPS traffic. Routing is typically performed using the SNI value presented by the ClientHello message. TLS routes will be applied to platform service ports named ''https-*'', ''tls-*'', unterminated gateway ports using HTTPS/TLS protocols (i.e. with "passthrough" TLS mode) and service entry ports using HTTPS/TLS protocols.  The first rule matching an incoming request is used.  NOTE: Traffic ''https-*'' or ''tls-*'' ports without associated virtual service will be treated as opaque TCP traffic.'
                         items:
-                          description: "Describes match conditions and actions for routing unterminated TLS traffic (TLS/HTTPS) The following routing rule forwards unterminated TLS traffic arriving at port 443 of gateway called \"mygateway\" to internal services in the mesh based on the SNI value. \n {{<tabset category-name=\"example\">}} {{<tab name=\"v1alpha3\" category-value=\"v1alpha3\">}} ```yaml apiVersion: networking.istio.io/v1alpha3 kind: VirtualService metadata:   name: bookinfo-sni spec:   hosts:   - \"*.bookinfo.com\"   gateways:   - mygateway   tls:   - match:     - port: 443       sniHosts:       - login.bookinfo.com     route:     - destination:         host: login.prod.svc.cluster.local   - match:     - port: 443       sniHosts:       - reviews.bookinfo.com     route:     - destination:         host: reviews.prod.svc.cluster.local ``` {{</tab>}} \n {{<tab name=\"v1beta1\" category-value=\"v1beta1\">}} ```yaml apiVersion: networking.istio.io/v1beta1 kind: VirtualService metadata:   name: bookinfo-sni spec:   hosts:   - \"*.bookinfo.com\"   gateways:   - mygateway   tls:   - match:     - port: 443       sniHosts:       - login.bookinfo.com     route:     - destination:         host: login.prod.svc.cluster.local   - match:     - port: 443       sniHosts:       - reviews.bookinfo.com     route:     - destination:         host: reviews.prod.svc.cluster.local ``` {{</tab>}} {{</tabset>}}"
                           properties:
                             match:
-                              description: Match conditions to be satisfied for the rule to be activated. All conditions inside a single match block have AND semantics, while the list of match blocks have OR semantics. The rule is matched if any one of the match blocks succeed.
                               items:
-                                description: TLS connection match attributes.
                                 properties:
-                                  destination_subnets:
-                                    description: IPv4 or IPv6 ip addresses of destination with optional subnet.  E.g., a.b.c.d/xx form or just a.b.c.d.
+                                  destinationSubnets:
+                                    description: IPv4 or IPv6 ip addresses of destination
+                                      with optional subnet.
                                     items:
+                                      format: string
                                       type: string
                                     type: array
                                   gateways:
-                                    description: Names of gateways where the rule should be applied. Gateway names in the top-level `gateways` field of the VirtualService (if any) are overridden. The gateway match is independent of sourceLabels.
+                                    description: Names of gateways where the rule should be
+                                      applied.
                                     items:
+                                      format: string
                                       type: string
                                     type: array
                                   port:
-                                    description: Specifies the port on the host that is being addressed. Many services only expose a single port or label ports with the protocols they support, in these cases it is not required to explicitly select the port.
-                                    format: int32
+                                    description: Specifies the port on the host that is being
+                                      addressed.
                                     type: integer
-                                  sni_hosts:
-                                    description: SNI (server name indicator) to match on. Wildcard prefixes can be used in the SNI value, e.g., *.com will match foo.example.com as well as example.com. An SNI value must be a subset (i.e., fall within the domain) of the corresponding virtual serivce's hosts.
+                                  sniHosts:
+                                    description: SNI (server name indicator) to match on.
                                     items:
+                                      format: string
                                       type: string
                                     type: array
-                                  source_labels:
+                                  sourceLabels:
                                     additionalProperties:
+                                      format: string
                                       type: string
-                                    description: One or more labels that constrain the applicability of a rule to workloads with the given labels. If the VirtualService has a list of gateways specified in the top-level `gateways` field, it should include the reserved gateway `mesh` in order for this field to be applicable.
                                     type: object
-                                  source_namespace:
-                                    description: Source namespace constraining the applicability of a rule to workloads in that namespace. If the VirtualService has a list of gateways specified in the top-level `gateways` field, it must include the reserved gateway `mesh` for this field to be applicable.
+                                  sourceNamespace:
+                                    description: Source namespace constraining the applicability
+                                      of a rule to workloads in that namespace.
+                                    format: string
                                     type: string
                                 type: object
                               type: array
                             route:
-                              description: The destination to which the connection should be forwarded to.
+                              description: The destination to which the connection should
+                                be forwarded to.
                               items:
-                                description: L4 routing rule weighted destination.
                                 properties:
                                   destination:
-                                    description: Destination uniquely identifies the instances of a service to which the request/connection should be forwarded to.
                                     properties:
                                       host:
-                                        description: "The name of a service from the service registry. Service names are looked up from the platform's service registry (e.g., Kubernetes services, Consul services, etc.) and from the hosts declared by [ServiceEntry](https://istio.io/docs/reference/config/networking/service-entry/#ServiceEntry). Traffic forwarded to destinations that are not found in either of the two, will be dropped. \n *Note for Kubernetes users*: When short names are used (e.g. \"reviews\" instead of \"reviews.default.svc.cluster.local\"), Istio will interpret the short name based on the namespace of the rule, not the service. A rule in the \"default\" namespace containing a host \"reviews will be interpreted as \"reviews.default.svc.cluster.local\", irrespective of the actual namespace associated with the reviews service. To avoid potential misconfiguration, it is recommended to always use fully qualified domain names over short names."
+                                        description: The name of a service from the service
+                                          registry.
+                                        format: string
                                         type: string
                                       port:
-                                        description: Specifies the port on the host that is being addressed. If a service exposes only a single port it is not required to explicitly select the port.
+                                        description: Specifies the port on the host that is
+                                          being addressed.
                                         properties:
                                           number:
-                                            description: Valid port number
-                                            format: int32
                                             type: integer
                                         type: object
                                       subset:
-                                        description: The name of a subset within the service. Applicable only to services within the mesh. The subset must be defined in a corresponding DestinationRule.
+                                        description: The name of a subset within the service.
+                                        format: string
                                         type: string
                                     type: object
                                   weight:
-                                    description: The proportion of traffic to be forwarded to the service version. If there is only one destination in a rule, all traffic will be routed to it irrespective of the weight.
                                     format: int32
                                     type: integer
                                 type: object


### PR DESCRIPTION
Signed-off-by: zackzhangkai <zhangkaiamm@gmail.com>

**What type of PR is this?**

Can not save configure for traffic governance, because of the change api of crd.

Just copy the generated crd from [istio api](https://github.com/istio/api/blob/master/kubernetes/customresourcedefinitions.gen.yaml). No need generate them by ourselves, for the different tools used.