### PR TITLE
Feature: support installing kubesphere-core with helm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,11 +98,19 @@ docker-build-no-test: ks-apiserver ks-controller-manager
 	hack/docker_build.sh
 
 helm-package:
-	ls config/crds/ | grep -v types.kubefed.io | xargs -i cp -r config/crds/{} config/ks-core/crds/
+	ls config/crds/ | xargs -i cp -r config/crds/{} config/ks-core/crds/
 	helm package config/ks-core --app-version=v3.1.0 --version=0.1.0 -d ./bin
 
 helm-deploy:
+	ls config/crds/ | xargs -i cp -r config/crds/{} config/ks-core/crds/
+	- kubectl create ns kubesphere-controls-system
 	helm upgrade --install ks-core ./config/ks-core -n kubesphere-system --create-namespace
+	kubectl apply -f https://raw.githubusercontent.com/kubesphere/ks-installer/master/roles/ks-core/prepare/files/ks-init/role-templates.yaml
+
+helm-uninstall:
+	- kubectl delete ns kubesphere-controls-system
+	helm uninstall ks-core -n kubesphere-system
+	kubectl delete -f https://raw.githubusercontent.com/kubesphere/ks-installer/master/roles/ks-core/prepare/files/ks-init/role-templates.yaml
 
 # Run tests
 test: fmt vet


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Support installing kubesphere-core with helm.
Since #3896 has created helm chart for ks-core, we just need to create `kubesphere-controls-system` namespace and some role templates for iam, then we can install ks-core with `helm`, which can reduce the complexity of installation.
To install ks-core with helm, just run 
```
make helm-deploy
```
To uninstall it, run
```
make helm-uninstall
```

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
see #3847 

**Special notes for reviewers**:
I'm not sure if we need to update README to let kubesphere users know how to install ks-core with helm. if so, I will ask sig-docs to do that.
