### PR TITLE
Make ks-apiserver be easier to run locally with kube config

### DIFF
--- a/pkg/models/openpitrix/attachments.go
+++ b/pkg/models/openpitrix/attachments.go
@@ -15,6 +15,7 @@ package openpitrix
 
 import (
 	"bytes"
+
 	"github.com/go-openapi/strfmt"
 	"k8s.io/klog"
 

--- a/pkg/simple/client/k8s/options.go
+++ b/pkg/simple/client/k8s/options.go
@@ -18,6 +18,7 @@ package k8s
 
 import (
 	"os"
+	"os/user"
 	"path"
 
 	"k8s.io/client-go/util/homedir"
@@ -54,8 +55,16 @@ func NewKubernetesOptions() (option *KubernetesOptions) {
 	}
 
 	// make it be easier for those who wants to run api-server locally
-	userHomeConfig := path.Join(homedir.HomeDir(), ".kube/config")
-	if _, err := os.Stat(userHomeConfig); !os.IsNotExist(err) {
+	homePath := homedir.HomeDir()
+	if homePath == "" {
+		// try os/user.HomeDir when $HOME is unset.
+		if u, err := user.Current(); err == nil {
+			homePath = u.HomeDir
+		}
+	}
+
+	userHomeConfig := path.Join(homePath, ".kube/config")
+	if _, err := os.Stat(userHomeConfig); err == nil {
 		option.KubeConfig = userHomeConfig
 	}
 	return

--- a/pkg/simple/client/k8s/options.go
+++ b/pkg/simple/client/k8s/options.go
@@ -18,6 +18,9 @@ package k8s
 
 import (
 	"os"
+	"path"
+
+	"k8s.io/client-go/util/homedir"
 
 	"github.com/spf13/pflag"
 
@@ -44,12 +47,18 @@ type KubernetesOptions struct {
 }
 
 // NewKubernetesOptions returns a `zero` instance
-func NewKubernetesOptions() *KubernetesOptions {
-	return &KubernetesOptions{
-		KubeConfig: "",
-		QPS:        1e6,
-		Burst:      1e6,
+func NewKubernetesOptions() (option *KubernetesOptions) {
+	option = &KubernetesOptions{
+		QPS:   1e6,
+		Burst: 1e6,
 	}
+
+	// make it be easier for those who wants to run api-server locally
+	userHomeConfig := path.Join(homedir.HomeDir(), ".kube/config")
+	if _, err := os.Stat(userHomeConfig); !os.IsNotExist(err) {
+		option.KubeConfig = userHomeConfig
+	}
+	return
 }
 
 func (k *KubernetesOptions) Validate() []error {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As I mentioned in the title, users can run ks-apiserver locally.

**Which issue(s) this PR fixes**:
None.

**Special notes for reviewers**:
None.

**Additional documentation, usage docs, etc.**:
None.
