### PR TITLE
fix wrong target in Dockerfile

### DIFF
--- a/hack/docker_build.sh
+++ b/hack/docker_build.sh
@@ -32,7 +32,7 @@ ${CONTAINER_CLI} ${CONTAINER_BUILDER} \
   --build-arg TARGETARCH=${TARGETARCH} \
   --build-arg TARGETOS=${TARGETOS} \
   -f build/ks-controller-manager/Dockerfile \
-  -t "${REPO}"/ks-apiserver:"${TAG}" .
+  -t "${REPO}"/ks-controller-manager:"${TAG}" .
 
 if [[ -z "${DRY_RUN:-}" ]]; then
   ${CONTAINER_CLI} push "${REPO}"/ks-apiserver:"${TAG}"

--- a/hack/docker_build_multiarch.sh
+++ b/hack/docker_build_multiarch.sh
@@ -33,5 +33,5 @@ ${CONTAINER_CLI} ${CONTAINER_BUILDER} \
   --platform ${PLATFORMS} \
   ${PUSH} \
   -f build/ks-controller-manager/Dockerfile \
-  -t "${REPO}"/ks-apiserver:"${TAG}" .
+  -t "${REPO}"/ks-controller-manager:"${TAG}" .
 


### PR DESCRIPTION
### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake

### What this PR does / why we need it:
In https://github.com/kubesphere/kubesphere/pull/3990 we refactor Dockerfile with multiple stage build, but wrong targets were introduced.

https://github.com/kubesphere/kubesphere/pull/3990/files#diff-acf28dd706a2c51c8f5f62d96c3fa355f615a9eb1beed336a2f2822fe67b9126R35 should be
```
${CONTAINER_CLI} ${CONTAINER_BUILDER} \
  --build-arg TARGETARCH=${TARGETARCH} \
  --build-arg TARGETOS=${TARGETOS} \
  -f build/ks-controller-manager/Dockerfile \
  -t "${REPO}"/ks-controller-manager:"${TAG}" .
```

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/hold