### PR TITLE
Fix panic due to nil pointer exception

### DIFF
--- a/pkg/kapis/terminal/v1alpha2/handler.go
+++ b/pkg/kapis/terminal/v1alpha2/handler.go
@@ -47,6 +47,7 @@ type terminalHandler struct {
 
 func newTerminalHandler(client kubernetes.Interface, authorizer authorizer.Authorizer, config *rest.Config) *terminalHandler {
 	return &terminalHandler{
+		authorizer: authorizer,
 		terminaler: terminal.NewTerminaler(client, config),
 	}
 }


### PR DESCRIPTION
Signed-off-by: hongming <talonwan@yunify.com>


### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Fix panic error due to nil pointer exception. It's caused by https://github.com/kubesphere/kubesphere/pull/3956.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubesphere/kubesphere/pull/3042
