### PR TITLE
fix wrong Makefile usage in nightly build workflow

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -44,16 +44,10 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-          bash hack/docker_build.sh master
 
           if [[ $? == 0 ]]; then
             tag=nightly-$(date '+%Y%m%d')
-
-            docker tag kubespheredev/ks-apiserver kubespheredev/ks-apiserver:${tag}
-            docker tag kubespheredev/ks-controller-manager kubespheredev/ks-controller-manager:${tag}
-
-            docker push kubespheredev/ks-apiserver:${tag}
-            docker push kubespheredev/ks-controller-manager:${tag}
+            REPO=kubespheredev TAG=${tag} make container-push
           else
             exit -1
           fi


### PR DESCRIPTION
Signed-off-by: yuswift <yuswift2018@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug


### What this PR does / why we need it:
#3990 has refactored the`Makefile` &`Dockerfile` , but it only modified the `build` & `multi-arch build` workflow, we still need to modify the `nightly-build` workflow.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes none

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
