### PR TITLE
Fix typo in kubesphere gateway template and bookstore sample

### DIFF
--- a/config/ks-core/templates/ks-router-config.tpl
+++ b/config/ks-core/templates/ks-router-config.tpl
@@ -25,7 +25,7 @@
           serviceAccountName: kubesphere-router-serviceaccount
           containers:
             - name: nginx-ingress-controller
-              image: image: {{ .Values.image.nginx_ingress_controller_repo }}:{{ .Values.image.nginx_ingress_controller_tag | default .Chart.AppVersion}}
+              image: {{ .Values.image.nginx_ingress_controller_repo }}:{{ .Values.image.nginx_ingress_controller_tag | default .Chart.AppVersion}}
               args:
                 - /nginx-ingress-controller
                 - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/config/ks-core/templates/sample-bookinfo-configmap.yaml
+++ b/config/ks-core/templates/sample-bookinfo-configmap.yaml
@@ -76,7 +76,7 @@ data:
                   cpu: '1'
                   memory: 1000Mi
               imagePullPolicy: IfNotPresent
-              image: {{- .Values.image.bookinfo_productpage_v1_repo }}:{{- .Values.image.bookinfo_productpage_v1_tag }}
+              image: {{ .Values.image.bookinfo_productpage_v1_repo }}:{{ .Values.image.bookinfo_productpage_v1_tag }}
               ports:
                 - name: http-web
                   protocol: TCP
@@ -156,7 +156,7 @@ data:
                   cpu: '1'
                   memory: 1000Mi
               imagePullPolicy: IfNotPresent
-              image: {{- .Values.image.bookinfo_reviews_v1_repo }}:{{- .Values.image.bookinfo_reviews_v1_tag }}
+              image: {{ .Values.image.bookinfo_reviews_v1_repo }}:{{ .Values.image.bookinfo_reviews_v1_tag }}
               ports:
                 - name: http-web
                   protocol: TCP
@@ -236,7 +236,7 @@ data:
                   cpu: '1'
                   memory: 1000Mi
               imagePullPolicy: IfNotPresent
-              image: {{- .Values.image.bookinfo_details_v1_repo }}:{{- .Values.image.bookinfo_details_v1_tag }}
+              image: {{ .Values.image.bookinfo_details_v1_repo }}:{{ .Values.image.bookinfo_details_v1_tag }}
               ports:
                 - name: http-web
                   protocol: TCP
@@ -316,7 +316,7 @@ data:
                   cpu: '1'
                   memory: 1000Mi
               imagePullPolicy: IfNotPresent
-              image: {{- .Values.image.bookinfo_ratings_v1_repo }}:{{- .Values.image.bookinfo_ratings_v1_tag }}
+              image: {{ .Values.image.bookinfo_ratings_v1_repo }}:{{ .Values.image.bookinfo_ratings_v1_tag }}
               ports:
                 - name: http-web
                   protocol: TCP


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
There is a typo in the gateway template, which causes the gateway can't be created.
And found another typo in the bookstore template.
Both issues were introduced by #3896
### Which issue(s) this PR fixes:
Fixes #4041

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
