### PR TITLE
Update kind-action to v1.2.0

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -26,7 +26,7 @@ jobs:
         run: go mod vendor
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-rc.1
+        uses: helm/kind-action@v1.2.0
         with:
           config: .github/workflows/kind/kind.yaml
 


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

### What type of PR is this?
/kind bug
/kind failing-test

### What this PR does / why we need it:
Older kind action was broken on Github. We need to update to the latest v1.2.0 version to fix the e2e testing.
ref https://github.com/helm/kind-action/issues/42
