### PR TITLE
fix make cross target failed

### DIFF
--- a/hack/docker_build_multiarch.sh
+++ b/hack/docker_build_multiarch.sh
@@ -23,13 +23,15 @@ fi
 # supported platforms
 PLATFORMS=linux/amd64,linux/arm64
 
-"${CONTAINER_CLI} ${CONTAINER_BUILDER}" \
+# shellcheck disable=SC2086 # inteneded splitting of CONTAINER_BUILDER
+${CONTAINER_CLI} ${CONTAINER_BUILDER} \
   --platform ${PLATFORMS} \
   ${PUSH} \
   -f build/ks-apiserver/Dockerfile \
   -t "${REPO}"/ks-apiserver:"${TAG}" .
 
-"${CONTAINER_CLI} ${CONTAINER_BUILDER}" \
+# shellcheck disable=SC2086 # intended splitting of CONTAINER_BUILDER
+${CONTAINER_CLI} ${CONTAINER_BUILDER} \
   --platform ${PLATFORMS} \
   ${PUSH} \
   -f build/ks-controller-manager/Dockerfile \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind failing-test

### What this PR does / why we need it:
In the previous PR https://github.com/kubesphere/kubesphere/pull/4063, to confront shellcheck word splitting, commit was made https://github.com/kubesphere/kubesphere/commit/04645180c46786ce8afb1ff73faa0c5376f2217d#diff-9149c8955c190ec790395023ceba6cf854778af8658251160656b51cf22f2871R26. But this will cause command not found error, it will expand to 'docker buildx build` which is a string. So this PR will change it back

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
