### PR TITLE
go build with vendor by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,10 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 OUTPUT_DIR=bin
-GOFLAGS=-mod=vendor
+ifeq (${GOFLAGS},)
+	# go build with vendor by default.
+	export GOFLAGS=-mod=vendor
+endif
 define ALL_HELP_INFO
 # Build code.
 #

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -31,6 +31,8 @@ PATH="${GOBIN}:${PATH}"
 
 # Install tools we need
 pushd "${KUBE_ROOT}/hack/tools" >/dev/null
+  # As GOFLAGS may equal to `-mod=vendor`, we must download the modules to vendor or go install will fail.
+  go mod vendor
   GO111MODULE=on go install github.com/client9/misspell/cmd/misspell
 popd >/dev/null
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
Set `GOFLAGS` to `-mod=vendor` by default to enable go build with vendor.

Currently, `make all`, `make ks-apiserver` and other make target will download the modules, this is unnecessary as all of the modules are include in `vendor/` dir.  This PR export `GOFLAGS=-mod=vendor` by default, so the `go build`,  `go test` or `go vet` will use the modules in vendor/ dir.  

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4094 

### Special notes for reviewers:
```
```


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


