### PR TITLE
feat: load configuration from Environment variables

### DIFF
--- a/config/ks-core/templates/ks-apiserver.yml
+++ b/config/ks-core/templates/ks-apiserver.yml
@@ -49,6 +49,10 @@ spec:
           name: kubesphere-config
         - mountPath: /etc/localtime
           name: host-time
+        env:
+        {{- if .Values.env }}
+        {{- toYaml .Values.env | nindent 8 }}
+        {{- end }}
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/config/ks-core/templates/ks-controller-manager.yaml
+++ b/config/ks-core/templates/ks-controller-manager.yaml
@@ -52,6 +52,10 @@ spec:
           name: webhook-secret
         - mountPath: /etc/localtime
           name: host-time
+        env:
+        {{- if .Values.env }}
+        {{- toYaml .Values.env | nindent 8 }}
+        {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/config/ks-core/values.yaml
+++ b/config/ks-core/values.yaml
@@ -116,3 +116,4 @@ tolerations:
     tolerationSeconds: 60
 
 affinity: {}
+env: []

--- a/pkg/apiserver/config/config.go
+++ b/pkg/apiserver/config/config.go
@@ -141,6 +141,11 @@ func TryLoadFromDisk() (*Config, error) {
 	// Load from current working directory, only used for debugging
 	viper.AddConfigPath(".")
 
+	// Load from Environment variables
+	viper.SetEnvPrefix("kubesphere")
+	viper.AutomaticEnv()
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			return nil, err

--- a/pkg/apiserver/config/config_test.go
+++ b/pkg/apiserver/config/config_test.go
@@ -85,7 +85,7 @@ func newTestConfig() (*Config, error) {
 		RedisOptions: &cache.Options{
 			Host:     "localhost",
 			Port:     6379,
-			Password: "P@88w0rd",
+			Password: "KUBESPHERE_REDIS_PASSWORD",
 			DB:       0,
 		},
 		S3Options: &s3.Options{
@@ -215,6 +215,9 @@ func TestGet(t *testing.T) {
 	}
 	saveTestConfig(t, conf)
 	defer cleanTestConfig(t)
+
+	conf.RedisOptions.Password = "P@88w0rd"
+	os.Setenv("KUBESPHERE_REDIS_PASSWORD", "P@88w0rd")
 
 	conf2, err := TryLoadFromDisk()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

### What type of PR is this?
/kind feature
/kind flake

### What this PR does / why we need it:
This PR adds support reading application configuration from environment variables. For example, the Redis password can be either configurated in CLI by the `--redis-password` flag, YAML file, or environment variable "KUBESPHERE_REDIS_PASSWORD".

For security reasons, users should not save the passwords in the ConfigMap or Deployment's CLI flags.  In Kubernetes practice, We should save security information into a Secret. Then either mount the Secret as a Volume or Environment variable.  
In the feature, all the security configurations used by ks-apiserver would be saved into Secret and mount as Environment variables.  

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?

```release-note
NONE
```

### Additional documentation, usage docs, etc.:
```docs

```
