### PR TITLE
Upgrade ingress api version to networking.k8s.io/v1

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -106,7 +106,7 @@ var SupportedGroupVersionResources = map[ClientType][]schema.GroupVersionResourc
 		{Group: "batch", Version: "v1", Resource: "jobs"},
 		{Group: "batch", Version: "v1beta1", Resource: "cronjobs"},
 
-		{Group: "extensions", Version: "v1beta1", Resource: "ingresses"},
+		{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
 
 		{Group: "autoscaling", Version: "v2beta2", Resource: "horizontalpodautoscalers"},
 	},

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -405,7 +405,7 @@ func (s *APIServer) waitForResourceSync(ctx context.Context) error {
 		{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses"},
 		{Group: "batch", Version: "v1", Resource: "jobs"},
 		{Group: "batch", Version: "v1beta1", Resource: "cronjobs"},
-		{Group: "extensions", Version: "v1beta1", Resource: "ingresses"},
+		{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
 		{Group: "autoscaling", Version: "v2beta2", Resource: "horizontalpodautoscalers"},
 		{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"},
 	}

--- a/pkg/models/quotas/quotas.go
+++ b/pkg/models/quotas/quotas.go
@@ -47,7 +47,7 @@ var supportedResources = map[string]schema.GroupVersionResource{
 	podsKey:                   {Group: "", Version: "v1", Resource: "pods"},
 	servicesKey:               {Group: "", Version: "v1", Resource: "services"},
 	persistentvolumeclaimsKey: {Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
-	ingressKey:                {Group: "extensions", Version: "v1beta1", Resource: "ingresses"},
+	ingressKey:                {Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
 	jobsKey:                   {Group: "batch", Version: "v1", Resource: "jobs"},
 	cronJobsKey:               {Group: "batch", Version: "v1beta1", Resource: "cronjobs"},
 	s2iBuilders:               {Group: "devops.kubesphere.io", Version: "v1alpha1", Resource: "s2ibuilders"},

--- a/pkg/models/resources/v1alpha2/ingress/ingresses.go
+++ b/pkg/models/resources/v1alpha2/ingress/ingresses.go
@@ -19,7 +19,7 @@ package ingress
 import (
 	"sort"
 
-	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/networking/v1"
 	"k8s.io/client-go/informers"
 
 	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha2"
@@ -37,10 +37,10 @@ func NewIngressSearcher(informers informers.SharedInformerFactory) v1alpha2.Inte
 }
 
 func (s *ingressSearcher) Get(namespace, name string) (interface{}, error) {
-	return s.informers.Extensions().V1beta1().Ingresses().Lister().Ingresses(namespace).Get(name)
+	return s.informers.Networking().V1().Ingresses().Lister().Ingresses(namespace).Get(name)
 }
 
-func (*ingressSearcher) match(match map[string]string, item *v1beta1.Ingress) bool {
+func (*ingressSearcher) match(match map[string]string, item *v1.Ingress) bool {
 	for k, v := range match {
 		if !v1alpha2.ObjectMetaExactlyMath(k, v, item.ObjectMeta) {
 			return false
@@ -49,7 +49,7 @@ func (*ingressSearcher) match(match map[string]string, item *v1beta1.Ingress) bo
 	return true
 }
 
-func (*ingressSearcher) fuzzy(fuzzy map[string]string, item *v1beta1.Ingress) bool {
+func (*ingressSearcher) fuzzy(fuzzy map[string]string, item *v1.Ingress) bool {
 	for k, v := range fuzzy {
 		if !v1alpha2.ObjectMetaFuzzyMath(k, v, item.ObjectMeta) {
 			return false
@@ -59,13 +59,13 @@ func (*ingressSearcher) fuzzy(fuzzy map[string]string, item *v1beta1.Ingress) bo
 }
 
 func (s *ingressSearcher) Search(namespace string, conditions *params.Conditions, orderBy string, reverse bool) ([]interface{}, error) {
-	ingresses, err := s.informers.Extensions().V1beta1().Ingresses().Lister().Ingresses(namespace).List(labels.Everything())
+	ingresses, err := s.informers.Networking().V1().Ingresses().Lister().Ingresses(namespace).List(labels.Everything())
 
 	if err != nil {
 		return nil, err
 	}
 
-	result := make([]*v1beta1.Ingress, 0)
+	result := make([]*v1.Ingress, 0)
 
 	if len(conditions.Match) == 0 && len(conditions.Fuzzy) == 0 {
 		result = ingresses

--- a/pkg/models/resources/v1alpha3/ingress/ingresses.go
+++ b/pkg/models/resources/v1alpha3/ingress/ingresses.go
@@ -17,7 +17,7 @@ limitations under the License.
 package ingress
 
 import (
-	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 
@@ -35,12 +35,12 @@ func New(sharedInformers informers.SharedInformerFactory) v1alpha3.Interface {
 }
 
 func (g *ingressGetter) Get(namespace, name string) (runtime.Object, error) {
-	return g.sharedInformers.Extensions().V1beta1().Ingresses().Lister().Ingresses(namespace).Get(name)
+	return g.sharedInformers.Networking().V1().Ingresses().Lister().Ingresses(namespace).Get(name)
 }
 
 func (g *ingressGetter) List(namespace string, query *query.Query) (*api.ListResult, error) {
 	// first retrieves all deployments within given namespace
-	ingresses, err := g.sharedInformers.Extensions().V1beta1().Ingresses().Lister().Ingresses(namespace).List(query.Selector())
+	ingresses, err := g.sharedInformers.Networking().V1().Ingresses().Lister().Ingresses(namespace).List(query.Selector())
 	if err != nil {
 		return nil, err
 	}
@@ -55,12 +55,12 @@ func (g *ingressGetter) List(namespace string, query *query.Query) (*api.ListRes
 
 func (g *ingressGetter) compare(left runtime.Object, right runtime.Object, field query.Field) bool {
 
-	leftIngress, ok := left.(*v1beta1.Ingress)
+	leftIngress, ok := left.(*v1.Ingress)
 	if !ok {
 		return false
 	}
 
-	rightIngress, ok := right.(*v1beta1.Ingress)
+	rightIngress, ok := right.(*v1.Ingress)
 	if !ok {
 		return false
 	}
@@ -74,7 +74,7 @@ func (g *ingressGetter) compare(left runtime.Object, right runtime.Object, field
 }
 
 func (g *ingressGetter) filter(object runtime.Object, filter query.Filter) bool {
-	deployment, ok := object.(*v1beta1.Ingress)
+	deployment, ok := object.(*v1.Ingress)
 	if !ok {
 		return false
 	}

--- a/pkg/models/resources/v1alpha3/ingress/ingresses_test.go
+++ b/pkg/models/resources/v1alpha3/ingress/ingresses_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -81,20 +81,20 @@ func TestListIngresses(t *testing.T) {
 }
 
 var (
-	foo1 = &v1beta1.Ingress{
+	foo1 = &v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo1",
 			Namespace: "bar",
 		},
 	}
 
-	foo2 = &v1beta1.Ingress{
+	foo2 = &v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo2",
 			Namespace: "bar",
 		},
 	}
-	bar1 = &v1beta1.Ingress{
+	bar1 = &v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar1",
 			Namespace: "bar",
@@ -109,7 +109,7 @@ func prepare() v1alpha3.Interface {
 	informer := informers.NewSharedInformerFactory(client, 0)
 
 	for _, ingress := range ingresses {
-		informer.Extensions().V1beta1().Ingresses().Informer().GetIndexer().Add(ingress)
+		informer.Networking().V1().Ingresses().Informer().GetIndexer().Add(ingress)
 	}
 
 	return New(informer)

--- a/pkg/models/resources/v1alpha3/resource/resource.go
+++ b/pkg/models/resources/v1alpha3/resource/resource.go
@@ -108,7 +108,7 @@ func NewResourceGetter(factory informers.InformerFactory, cache cache.Cache) *Re
 	namespacedResourceGetters[schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}] = pod.New(factory.KubernetesSharedInformerFactory())
 	namespacedResourceGetters[schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"}] = node.New(factory.KubernetesSharedInformerFactory())
 	namespacedResourceGetters[schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}] = serviceaccount.New(factory.KubernetesSharedInformerFactory())
-	namespacedResourceGetters[schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "ingresses"}] = ingress.New(factory.KubernetesSharedInformerFactory())
+	namespacedResourceGetters[schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"}] = ingress.New(factory.KubernetesSharedInformerFactory())
 	namespacedResourceGetters[schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}] = networkpolicy.New(factory.KubernetesSharedInformerFactory())
 	namespacedResourceGetters[schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"}] = job.New(factory.KubernetesSharedInformerFactory())
 	namespacedResourceGetters[schema.GroupVersionResource{Group: "app.k8s.io", Version: "v1beta1", Resource: "applications"}] = application.New(cache)

--- a/staging/src/kubesphere.io/api/types/v1beta1/federatedingress_types.go
+++ b/staging/src/kubesphere.io/api/types/v1beta1/federatedingress_types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -45,7 +45,7 @@ type FederatedIngressSpec struct {
 }
 
 type IngressTemplate struct {
-	Spec extensionsv1beta1.IngressSpec `json:"spec,omitempty"`
+	Spec networkingv1.IngressSpec `json:"spec,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Signed-off-by: wenhuwang <976400757@qq.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind api-change
/kind feature
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
Ingress is the core component that is used by the KubeSphere Routes feature. KubeSphere is still using the old api "extensions/v1beta1" both Frontend and Backend. However "extensions/v1beta1" Ingress is deprecated in v1.14+, unavailable in v1.22+. So we need to upgrade it to the latest version to be compatible with the higher version Kubernetes cluster.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4068

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
