### PR TITLE
upgrade kubebuilder envtest to v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ kustomize/network/etcd
 apiserver.local.config
 tmp/
 kubesphere.yaml
+testbin/

--- a/hack/setup-kubebuilder-env.sh
+++ b/hack/setup-kubebuilder-env.sh
@@ -5,6 +5,6 @@
 SHELL="/usr/bin/env bash -o pipefail"
 
 ENVTEST_ASSETS_DIR=$(pwd)/testbin
-mkdir -p ${ENVTEST_ASSETS_DIR}
-test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools ${ENVTEST_ASSETS_DIR}; setup_envtest_env ${ENVTEST_ASSETS_DIR}
+mkdir -p "${ENVTEST_ASSETS_DIR}"
+test -f "${ENVTEST_ASSETS_DIR}"/setup-envtest.sh || curl -sSLo "${ENVTEST_ASSETS_DIR}"/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
+source "${ENVTEST_ASSETS_DIR}"/setup-envtest.sh; fetch_envtest_tools "${ENVTEST_ASSETS_DIR}"; setup_envtest_env "${ENVTEST_ASSETS_DIR}"

--- a/hack/setup-kubebuilder-env.sh
+++ b/hack/setup-kubebuilder-env.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Setting SHELL to bash allows bash commands to be executed by recipes.
+# This is a requirement for 'setup-envtest.sh' in the test target.
+# Options are set to exit when a recipe line exits non-zero or a piped command fails.
+SHELL="/usr/bin/env bash -o pipefail"
+
+ENVTEST_ASSETS_DIR=$(pwd)/testbin
+mkdir -p ${ENVTEST_ASSETS_DIR}
+test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
+source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools ${ENVTEST_ASSETS_DIR}; setup_envtest_env ${ENVTEST_ASSETS_DIR}


### PR DESCRIPTION
Signed-off-by: yuswift <yuswift2018@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
/kind failing-test


### What this PR does / why we need it:
We used to use `hack/install_kubebuilder.sh` to install `kubebuillder` libraries(e.g. etcd, kube-apiserver). However, the libraries version is 1.16, which is not compatible with 1.22. I updated the Makefile by referring to the [docs](https://book.kubebuilder.io/migration/manually_migration_guide_v2_v3.html?highlight=envtes#to-allow-automatic-downloads).
BTW, the `hack/install_kubebuilder.sh` file is no longer needed, we can remove it in the future. I've opened a new issue.
### Which issue(s) this PR fixes:

part of #4127 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
Bump kubebuilder envtest to v3, the users don't need to install the kubebuilder with `hack/install_kubebuilder.sh` anymore.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
