### PR TITLE
fix API specification for #4194

### DIFF
--- a/pkg/kapis/monitoring/v1alpha3/dashboard_template_test.sh
+++ b/pkg/kapis/monitoring/v1alpha3/dashboard_template_test.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-curl -d '{"grafanaDashboardUrl":"https://grafana.com/api/dashboards/7362/revisions/5/download", "description":"this is a test dashboard."}' -H "Content-Type: application/json" localhost:9090/kapis/monitoring.kubesphere.io/v1alpha3/clusterdashboard/test1/template
+curl -d '{"grafanaDashboardUrl":"https://grafana.com/api/dashboards/7362/revisions/5/download", "description":"this is a test dashboard."}' -H "Content-Type: application/json" localhost:9090/kapis/monitoring.kubesphere.io/v1alpha3/clusterdashboards/test1/template

--- a/pkg/kapis/monitoring/v1alpha3/dashboard_template_test.sh
+++ b/pkg/kapis/monitoring/v1alpha3/dashboard_template_test.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-curl -d '{"grafanaDashboardName":"test2","grafanaDashboardUrl":"https://grafana.com/api/dashboards/7362/revisions/5/download"}' -H "Content-Type: application/json" localhost:9090/kapis/monitoring.kubesphere.io/v1alpha3/dashboard/template
+curl -d '{"grafanaDashboardUrl":"https://grafana.com/api/dashboards/7362/revisions/5/download"}' -H "Content-Type: application/json" localhost:9090/kapis/monitoring.kubesphere.io/v1alpha3/clusterdashboard/test1/template

--- a/pkg/kapis/monitoring/v1alpha3/dashboard_template_test.sh
+++ b/pkg/kapis/monitoring/v1alpha3/dashboard_template_test.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-curl -d '{"grafanaDashboardUrl":"https://grafana.com/api/dashboards/7362/revisions/5/download"}' -H "Content-Type: application/json" localhost:9090/kapis/monitoring.kubesphere.io/v1alpha3/clusterdashboard/test1/template
+curl -d '{"grafanaDashboardUrl":"https://grafana.com/api/dashboards/7362/revisions/5/download", "description":"this is a test dashboard."}' -H "Content-Type: application/json" localhost:9090/kapis/monitoring.kubesphere.io/v1alpha3/clusterdashboard/test1/template

--- a/pkg/kapis/monitoring/v1alpha3/handler.go
+++ b/pkg/kapis/monitoring/v1alpha3/handler.go
@@ -383,13 +383,16 @@ func (h handler) handleGrafanaDashboardImport(req *restful.Request, resp *restfu
 		return
 	}
 
+	annotation := map[string]string{"kubesphere.io/description": entity.Description}
+
 	dashboard := monitoringdashboardv1alpha2.ClusterDashboard{
 		TypeMeta: v1.TypeMeta{
 			APIVersion: convertedDashboard.APIVersion,
 			Kind:       convertedDashboard.Kind,
 		},
 		ObjectMeta: v1.ObjectMeta{
-			Name: convertedDashboard.Metadata["name"],
+			Name:        convertedDashboard.Metadata["name"],
+			Annotations: annotation,
 		},
 		Spec: *convertedDashboard.Spec,
 	}

--- a/pkg/kapis/monitoring/v1alpha3/handler.go
+++ b/pkg/kapis/monitoring/v1alpha3/handler.go
@@ -328,7 +328,9 @@ func (h handler) handleGrafanaDashboardImport(req *restful.Request, resp *restfu
 		return
 	}
 
-	if entity.GrafanaDashboardName == "" {
+	grafanaDashboardName := req.PathParameter("grafanaDashboardName")
+
+	if grafanaDashboardName == "" {
 		err := errors.New("the requested parameter grafanaDashboardName cannot be empty")
 		api.HandleBadRequest(resp, nil, err)
 		return
@@ -375,7 +377,7 @@ func (h handler) handleGrafanaDashboardImport(req *restful.Request, resp *restfu
 	}
 
 	c := converter.NewConverter()
-	convertedDashboard, err := c.ConvertToDashboard(grafanaDashboardContent, true, "", entity.GrafanaDashboardName)
+	convertedDashboard, err := c.ConvertToDashboard(grafanaDashboardContent, true, "", grafanaDashboardName)
 	if err != nil {
 		api.HandleBadRequest(resp, nil, err)
 		return
@@ -406,7 +408,7 @@ func (h handler) handleGrafanaDashboardImport(req *restful.Request, resp *restfu
 		DoRaw(ctx)
 
 	if err == nil {
-		api.HandleBadRequest(resp, nil, errors.New("a dashboard with the same name already exists!"))
+		api.HandleBadRequest(resp, nil, errors.New("a dashboard with the same name already exists."))
 		return
 	}
 

--- a/pkg/kapis/monitoring/v1alpha3/register.go
+++ b/pkg/kapis/monitoring/v1alpha3/register.go
@@ -506,9 +506,10 @@ func AddToContainer(c *restful.Container, k8sClient kubernetes.Interface, monito
 		Returns(http.StatusOK, respOK, monitoring.Metric{})).
 		Produces(restful.MIME_JSON)
 
-	ws.Route(ws.POST("/dashboard/template").
+	ws.Route(ws.POST("/clusterdashboard/{grafanaDashboardName}/template").
 		To(h.handleGrafanaDashboardImport).
-		Doc("Convert Grafana templates to KubeSphere dashboards.").
+		Doc("Convert Grafana templates to KubeSphere clusterdashboards.").
+		Param(ws.PathParameter("grafanaDashboardName", "The name of the Grafana template to be converted").DataType("string").Required(true)).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.DashboardTag}).
 		Writes(monitoringdashboardv1alpha2.ClusterDashboard{}).
 		Returns(http.StatusOK, respOK, monitoringdashboardv1alpha2.ClusterDashboard{})).

--- a/pkg/kapis/monitoring/v1alpha3/register.go
+++ b/pkg/kapis/monitoring/v1alpha3/register.go
@@ -506,7 +506,7 @@ func AddToContainer(c *restful.Container, k8sClient kubernetes.Interface, monito
 		Returns(http.StatusOK, respOK, monitoring.Metric{})).
 		Produces(restful.MIME_JSON)
 
-	ws.Route(ws.POST("/clusterdashboard/{grafanaDashboardName}/template").
+	ws.Route(ws.POST("/clusterdashboards/{grafanaDashboardName}/template").
 		To(h.handleGrafanaDashboardImport).
 		Doc("Convert Grafana templates to KubeSphere clusterdashboards.").
 		Param(ws.PathParameter("grafanaDashboardName", "The name of the Grafana template to be converted").DataType("string").Required(true)).

--- a/pkg/simple/client/monitoring/types.go
+++ b/pkg/simple/client/monitoring/types.go
@@ -52,6 +52,7 @@ type MetricData struct {
 type DashboardEntity struct {
 	GrafanaDashboardUrl     string `json:"grafanaDashboardUrl,omitempty"`
 	GrafanaDashboardContent string `json:"grafanaDashboardContent,omitempty"`
+	Description             string `json:"description,omitempty"`
 }
 
 // The first element is the timestamp, the second is the metric value.

--- a/pkg/simple/client/monitoring/types.go
+++ b/pkg/simple/client/monitoring/types.go
@@ -50,7 +50,6 @@ type MetricData struct {
 }
 
 type DashboardEntity struct {
-	GrafanaDashboardName    string `json:"grafanaDashboardName"`
 	GrafanaDashboardUrl     string `json:"grafanaDashboardUrl,omitempty"`
 	GrafanaDashboardContent string `json:"grafanaDashboardContent,omitempty"`
 }


### PR DESCRIPTION
Signed-off-by: zhu733756 <talonzhu@yunify.com>

Import Grafana template and convert it to KubeSphere dashboard

/kind design
/area monitoring
/area observability
/kind feature-request
/area console

### What this PR does / why we need it:
 
fixes #4194 for better API specification.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
fixes #4194 for better API specification, see issue #4194  or pr #4195 for a detailed introduction.

### Special notes for reviewers:
Currently, this API only supports create clusterdashboards.

The API changes to:
```
/kapis/monitoring.kubesphere.io/v1alpha3/clusterdashboards/{grafanaDashboardName}/template
```

Add new field `Description` to the post body:
- Description:  the description of this dashboard.

A sample can be described as follow:
```
#! /bin/bash
curl -d '{"grafanaDashboardUrl":"https://grafana.com/api/dashboards/7362/revisions/5/download", "description":"this is a test dashboard."}' -H "Content-Type: application/json" localhost:9090/kapis/monitoring.kubesphere.io/v1alpha3/clusterdashboards/test1/template
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

/cc @benjaminhuo @wansir 