### PR TITLE
helm: allows ks-core to mount extra volumes

### DIFF
--- a/config/ks-core/templates/ks-apiserver.yml
+++ b/config/ks-core/templates/ks-apiserver.yml
@@ -39,7 +39,7 @@ spec:
         - containerPort: 9090
           protocol: TCP
         resources:
-          {{- toYaml .Values.apiserverResources | nindent 12 }}
+          {{- toYaml .Values.apiserver.resources | nindent 12 }}
         volumeMounts:
         - mountPath: /var/run/docker.sock
           name: docker-sock
@@ -49,6 +49,9 @@ spec:
           name: kubesphere-config
         - mountPath: /etc/localtime
           name: host-time
+        {{- if .Values.apiserver.extraVolumeMounts }}
+          {{- toYaml .Values.apiserver.extraVolumeMounts | nindent 8 }}
+        {{- end }}
         env:
         {{- if .Values.env }}
         {{- toYaml .Values.env | nindent 8 }}
@@ -106,7 +109,9 @@ spec:
           path: /etc/localtime
           type: ""
         name: host-time
-
+      {{- if .Values.apiserver.extraVolumes }}
+        {{ toYaml .Values.apiserver.extraVolumes | nindent 6 }}
+      {{- end }}
 ---
 
 apiVersion: v1

--- a/config/ks-core/templates/ks-console.yml
+++ b/config/ks-core/templates/ks-console.yml
@@ -27,7 +27,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: ks-console
         resources:
-          {{- toYaml .Values.consoleResources | nindent 12 }}
+          {{- toYaml .Values.console.resources | nindent 12 }}
         volumeMounts:
         - mountPath: /opt/kubesphere/console/server/local_config.yaml
           name: ks-console-config
@@ -36,6 +36,9 @@ spec:
           name: sample-bookinfo
         - mountPath: /etc/localtime
           name: host-time
+        {{- if .Values.console.extraVolumeMounts }}
+          {{- toYaml .Values.console.extraVolumeMounts | nindent 8 }}
+        {{- end }}
         livenessProbe:
           tcpSocket:
             port: 8000
@@ -89,7 +92,10 @@ spec:
           path: /etc/localtime
           type: ""
         name: host-time
-        
+      {{- if .Values.console.extraVolumes }}
+        {{ toYaml .Values.console.extraVolumes | nindent 6 }}
+      {{- end }}
+
 ---
 
 apiVersion: v1

--- a/config/ks-core/templates/ks-controller-manager.yaml
+++ b/config/ks-core/templates/ks-controller-manager.yaml
@@ -44,7 +44,7 @@ spec:
         - containerPort: 8443
           protocol: TCP
         resources:
-          {{- toYaml .Values.controllerManagerResources | nindent 12 }}
+          {{- toYaml .Values.controller.resources | nindent 12 }}
         volumeMounts:
         - mountPath: /etc/kubesphere/
           name: kubesphere-config
@@ -52,6 +52,9 @@ spec:
           name: webhook-secret
         - mountPath: /etc/localtime
           name: host-time
+        {{- if .Values.controller.extraVolumeMounts }}
+          {{- toYaml .Values.controller.extraVolumeMounts | nindent 8 }}
+        {{- end }}
         env:
         {{- if .Values.env }}
         {{- toYaml .Values.env | nindent 8 }}
@@ -62,18 +65,21 @@ spec:
       serviceAccountName: {{ include "ks-core.serviceAccountName" . }}
       terminationGracePeriodSeconds: 30
       volumes:
-        - name: kubesphere-config
-          configMap:
-            name: kubesphere-config
-            defaultMode: 420
-        - name: webhook-secret
-          secret:
-            defaultMode: 420
-            secretName: ks-controller-manager-webhook-cert
-        - hostPath:
-            path: /etc/localtime
-            type: ""
-          name: host-time
+      - name: kubesphere-config
+        configMap:
+          name: kubesphere-config
+          defaultMode: 420
+      - name: webhook-secret
+        secret:
+          defaultMode: 420
+          secretName: ks-controller-manager-webhook-cert
+      - hostPath:
+          path: /etc/localtime
+          type: ""
+        name: host-time
+      {{- if .Values.controller.extraVolumes }}
+        {{ toYaml .Values.controller.extraVolumes | nindent 6 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/config/ks-core/values.yaml
+++ b/config/ks-core/values.yaml
@@ -44,10 +44,6 @@ config:
   multicluster: {}
   monitoring: {}
 
-console:
-  port: 30880
-  type: NodePort
-
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -74,30 +70,6 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-apiserverResources:
-  limits:
-    cpu: 1
-    memory: 1024Mi
-  requests:
-    cpu: 20m
-    memory: 100Mi
-
-consoleResources:
-  limits:
-    cpu: 1
-    memory: 1024Mi
-  requests:
-    cpu: 20m
-    memory: 100Mi
-
-controllerManagerResources:
-  limits:
-    cpu: 1
-    memory: 1000Mi
-  requests:
-    cpu: 30m
-    memory: 50Mi
-
 # Kubernetes Version shows in KubeSphere console
 kube_version: "v1.19.4"
 
@@ -117,3 +89,65 @@ tolerations:
 
 affinity: {}
 env: []
+
+## deployment specific configuration
+
+apiserver:
+  resources:
+    limits:
+      cpu: 1
+      memory: 1024Mi
+    requests:
+      cpu: 20m
+      memory: 100Mi
+
+  extraVolumeMounts: []
+  ## Additional volumeMounts to the apiserver container.
+  #  - name: example-config
+  #   mountPath: /etc/kubesphere/example
+
+  extraVolumes: []
+  ## Additional volumes to the apiserver pod.
+  #  - name: example-config
+  #    emptyDir: {}
+
+console:
+  port: 30880
+  type: NodePort
+  resources:
+    limits:
+      cpu: 1
+      memory: 1024Mi
+    requests:
+      cpu: 20m
+      memory: 100Mi
+
+  extraVolumeMounts: []
+  ## Additional volumeMounts to the console container.
+  #  - name: example-config
+  #   mountPath: /etc/kubesphere/example
+
+  extraVolumes: []
+  ## Additional volumes to the console pod.
+  #  - name: example-config
+  #    emptyDir: {}
+
+controller:
+  resources:
+    limits:
+      cpu: 1
+      memory: 1000Mi
+    requests:
+      cpu: 30m
+      memory: 50Mi
+
+  extraVolumeMounts: []
+  ## Additional volumeMounts to the controller container.
+  #  - name: example-config
+  #   mountPath: /etc/kubesphere/example
+
+  extraVolumes: []
+  ## Additional volumes to the controller pod.
+  #  - name: example-config
+  #    emptyDir: {}
+


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

### What type of PR is this?
/kind feature

### What this PR does / why we need it:
This PR would allow the ks-core helm chart to mount extra volumes.  

Feature #3055 requires loading the gateway helm chart and configuration file from the local filesystem.  We can either package them into the container image or mount them when deploying. Mount those files as volumes would provide more flexibility, Users can upgrade the components independently. 

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
