### PR TITLE
feat: package gateway helm chart into docker image

### DIFF
--- a/build/ks-controller-manager/Dockerfile
+++ b/build/ks-controller-manager/Dockerfile
@@ -9,9 +9,11 @@ ARG TARGETARCH
 ARG TARGETOS
 ARG HELM_VERSION=v3.5.2
 ARG KUSTOMIZE_VERSION=v4.2.0
+ARG INGRESS_NGINX_VERSION=3.35.0
 
 ENV OUTDIR=/out
 RUN mkdir -p ${OUTDIR}/usr/local/bin
+RUN mkdir -p ${OUTDIR}/var/helm-charts
 
 WORKDIR /tmp
 
@@ -26,7 +28,12 @@ RUN mv /tmp/${TARGETOS}-${TARGETARCH}/helm ${OUTDIR}/usr/local/bin/
 ADD https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz /tmp
 RUN tar xvzf /tmp/kustomize_${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz -C /tmp
 RUN mv /tmp/kustomize ${OUTDIR}/usr/local/bin/
-    
+
+
+# Install Nginx Ingress Helm Chart
+ADD https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-${INGRESS_NGINX_VERSION}/ingress-nginx-${INGRESS_NGINX_VERSION}.tgz /tmp
+RUN tar xvzf /tmp/ingress-nginx-${INGRESS_NGINX_VERSION}.tgz -C /tmp
+RUN mv /tmp/ingress-nginx ${OUTDIR}/var/helm-charts/
 
 # Build
 
@@ -34,12 +41,17 @@ FROM golang:1.16.3 as build_context
 
 ENV OUTDIR=/out
 RUN mkdir -p ${OUTDIR}/usr/local/bin/
+RUN mkdir -p ${OUTDIR}/var/helm-charts
 
 WORKDIR /workspace
 ADD . /workspace/
 
 RUN make ks-controller-manager
 RUN mv /workspace/bin/cmd/controller-manager ${OUTDIR}/usr/local/bin/
+
+# Copy gateway config and helm chart
+RUN mv /workspace/config/gateway ${OUTDIR}/var/helm-charts/
+RUN mv /workspace/config/watches.yaml ${OUTDIR}/var/helm-charts/
 
 # Final Image
 

--- a/config/watches.yaml
+++ b/config/watches.yaml
@@ -1,0 +1,14 @@
+# Use the 'create api' subcommand to add watches to this file.
+- group: gateway.kubesphere.io
+  version: v1alpha1
+  kind: Nginx
+  chart: /var/helm-charts/ingress-nginx
+- group: gateway.kubesphere.io
+  version: v1alpha1
+  kind: Gateway
+  chart: /var/helm-charts/gateway
+# uncomment the following 2 lines, if only allow to run global scope or namespaced scope.
+# Leave the option to CR, when allow to run global and namespaced together.
+  # overrideValues:
+  #   controller.scope.enabled: $SCOPE_ENABLED
+#+kubebuilder:scaffold:watch


### PR DESCRIPTION
### What type of PR is this?
/kind feature

### What this PR does / why we need it:
Package Gateway and Nginx Ingress helm chart into docker image.  Users can use the new gateway feature out of the box.

### Which issue(s) this PR fixes:
Fixes ##3055

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
None
```

### Additional documentation, usage docs, etc.:
```docs

```
