### PR TITLE
feature: support setting host cluster name

### DIFF
--- a/cmd/controller-manager/app/controllers.go
+++ b/cmd/controller-manager/app/controllers.go
@@ -190,7 +190,8 @@ func addControllers(
 			client.Config(),
 			kubesphereInformer.Cluster().V1alpha1().Clusters(),
 			client.KubeSphere().ClusterV1alpha1().Clusters(),
-			multiClusterOptions.ClusterControllerResyncSecond)
+			multiClusterOptions.ClusterControllerResyncPeriod,
+			multiClusterOptions.HostClusterName)
 	}
 
 	var nsnpController manager.Runnable

--- a/pkg/controller/cluster/cluster_controller.go
+++ b/pkg/controller/cluster/cluster_controller.go
@@ -155,6 +155,8 @@ type clusterController struct {
 	clusterMap map[string]*clusterData
 
 	resyncPeriod time.Duration
+
+	hostClusterNmae string
 }
 
 func NewClusterController(
@@ -163,6 +165,7 @@ func NewClusterController(
 	clusterInformer clusterinformer.ClusterInformer,
 	clusterClient clusterclient.ClusterInterface,
 	resyncPeriod time.Duration,
+	hostClusterName string,
 ) *clusterController {
 
 	broadcaster := record.NewBroadcaster()
@@ -182,6 +185,7 @@ func NewClusterController(
 		workerLoopPeriod: time.Second,
 		clusterMap:       make(map[string]*clusterData),
 		resyncPeriod:     resyncPeriod,
+		hostClusterNmae:  hostClusterName,
 	}
 	c.clusterLister = clusterInformer.Lister()
 	c.clusterHasSynced = clusterInformer.Informer().HasSynced
@@ -317,6 +321,7 @@ func (c *clusterController) reconcileHostCluster() error {
 	// no host cluster, create one
 	if len(clusters) == 0 {
 		hostCluster.Spec.Connection.KubeConfig = hostKubeConfig
+		hostCluster.Name = c.hostClusterNmae
 		_, err = c.clusterClient.Create(context.TODO(), hostCluster, metav1.CreateOptions{})
 		return err
 	} else if len(clusters) > 1 {

--- a/pkg/simple/client/multicluster/options.go
+++ b/pkg/simple/client/multicluster/options.go
@@ -22,7 +22,10 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const DefaultResyncPeriod = 120 * time.Second
+const (
+	DefaultResyncPeriod    = 120 * time.Second
+	DefaultHostClusterName = "host"
+)
 
 type Options struct {
 	// Enable
@@ -43,11 +46,14 @@ type Options struct {
 	// AgentImage is the image used when generating deployment for all cluster agents.
 	AgentImage string `json:"agentImage,omitempty"`
 
-	// ClusterControllerResyncSecond is the resync period used by cluster controller.
-	ClusterControllerResyncSecond time.Duration `json:"clusterControllerResyncSecond,omitempty" yaml:"clusterControllerResyncSecond"`
+	// ClusterControllerResyncPeriod is the resync period used by cluster controller.
+	ClusterControllerResyncPeriod time.Duration `json:"clusterControllerResyncPeriod,omitempty" yaml:"clusterControllerResyncPeriod"`
+
+	// HostClusterName is the name of the control plane cluster, default set to host.
+	HostClusterName string `json:"hostClusterName,omitempty" yaml:"hostClusterName"`
 }
 
-// NewOptions() returns a default nil options
+// NewOptions returns a default nil options
 func NewOptions() *Options {
 	return &Options{
 		Enable:                        false,
@@ -55,7 +61,8 @@ func NewOptions() *Options {
 		ProxyPublishAddress:           "",
 		ProxyPublishService:           "",
 		AgentImage:                    "kubesphere/tower:v1.0",
-		ClusterControllerResyncSecond: DefaultResyncPeriod,
+		ClusterControllerResyncPeriod: DefaultResyncPeriod,
+		HostClusterName:               DefaultHostClusterName,
 	}
 }
 
@@ -78,6 +85,9 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, s *Options) {
 	fs.StringVar(&o.AgentImage, "agent-image", s.AgentImage, ""+
 		"This field is used when generating deployment yaml for agent.")
 
-	fs.DurationVar(&o.ClusterControllerResyncSecond, "cluster-controller-resync-second", s.ClusterControllerResyncSecond,
-		"Cluster controller resync second to sync cluster resource. e.g. 2m 5m 10m ... default set to 2m")
+	fs.DurationVar(&o.ClusterControllerResyncPeriod, "cluster-controller-resync-period", s.ClusterControllerResyncPeriod,
+		"Cluster controller resync period to sync cluster resource. e.g. 2m 5m 10m ... default set to 2m")
+
+	fs.StringVar(&o.HostClusterName, "host-cluster-name", s.HostClusterName, "the name of the control plane"+
+		" cluster, default set to host")
 }


### PR DESCRIPTION
Signed-off-by: yuswift <yuswift2018@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature
### What this PR does / why we need it:
We can set the host cluster name in the `kubesphere.yaml` now, e.g:
```
authentication:
  authenticateRateLimiterMaxTries: 10
  authenticateRateLimiterDuration: 10m0s
  loginHistoryRetentionPeriod: 168h
  maximumClockSkew: 10s
  multipleLogin: True
  kubectlImage: kubesphere/kubectl:v1.19.1
  jwtSecret: "qTcNlzhUlTa6bjo4lZaXG1Xr"
network:
  ippoolType: none
multicluster:
  enable: true
  agentImage: kubesphere/tower:v0.2.0
  proxyPublishService: tower.kubesphere-system.svc
  hostClusterName: control
```
### Which issue(s) this PR fixes:

part of #4158 
### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
the cluster controller now supports setting the host cluster name, default set to host
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
