### PR TITLE
support setting cluster name under single cluster scenario

### DIFF
--- a/config/ks-core/templates/ks-console-config.yml
+++ b/config/ks-core/templates/ks-console-config.yml
@@ -22,6 +22,7 @@ data:
         kubernetes: {{ .Values.kube_version }}
         openpitrix: {{ .Chart.AppVersion }}
       enableKubeConfig: true
+    defaultClusterName: {{ .Values.console.defaultClusterName }}
 kind: ConfigMap
 metadata:
   name: ks-console-config

--- a/config/ks-core/values.yaml
+++ b/config/ks-core/values.yaml
@@ -114,6 +114,7 @@ apiserver:
 console:
   port: 30880
   type: NodePort
+  defaultClusterName: "default"
   resources:
     limits:
       cpu: 1


### PR DESCRIPTION
Signed-off-by: yuswift <yuswift2018@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
part of #4158 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
The users now can set the cluster name under a single cluster scenario
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
