### PR TITLE
add etcd_server_is_leader metric to query

### DIFF
--- a/pkg/models/monitoring/named_metrics.go
+++ b/pkg/models/monitoring/named_metrics.go
@@ -279,6 +279,7 @@ var EtcdMetrics = []string{
 	"etcd_server_total",
 	"etcd_server_up_total",
 	"etcd_server_has_leader",
+	"etcd_server_is_leader",
 	"etcd_server_leader_changes",
 	"etcd_server_proposals_failed_rate",
 	"etcd_server_proposals_applied_rate",

--- a/pkg/simple/client/monitoring/prometheus/promql.go
+++ b/pkg/simple/client/monitoring/prometheus/promql.go
@@ -209,6 +209,7 @@ var promQLTemplates = map[string]string{
 	"etcd_server_total":                          `count(up{job="etcd"})`,
 	"etcd_server_up_total":                       `etcd:up:sum`,
 	"etcd_server_has_leader":                     `label_replace(etcd_server_has_leader, "node_ip", "$1", "instance", "(.*):.*")`,
+	"etcd_server_is_leader":                      `label_replace(etcd_server_is_leader, "node_ip", "$1", "instance", "(.*):.*")`,
 	"etcd_server_leader_changes":                 `label_replace(etcd:etcd_server_leader_changes_seen:sum_changes, "node_ip", "$1", "node", "(.*)")`,
 	"etcd_server_proposals_failed_rate":          `avg(etcd:etcd_server_proposals_failed:sum_irate)`,
 	"etcd_server_proposals_applied_rate":         `avg(etcd:etcd_server_proposals_applied:sum_irate)`,


### PR DESCRIPTION
### What type of PR is this?

/kind optimization

### What this PR does / why we need it:

Make `etcd_server_is_leader` querable then console may show which etcd member is a leader

### Which issue(s) this PR fixes:

Fixes #
https://github.com/kubesphere/kubesphere/issues/1077

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


/area monitoring
/cc @benjaminhuo 
