### PR TITLE
add validation for host cluster name

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -139,6 +139,7 @@ func (s *KubeSphereControllerManagerOptions) Validate() []error {
 	errs = append(errs, s.OpenPitrixOptions.Validate()...)
 	errs = append(errs, s.NetworkOptions.Validate()...)
 	errs = append(errs, s.LdapOptions.Validate()...)
+	errs = append(errs, s.MultiClusterOptions.Validate()...)
 
 	if len(s.ApplicationSelector) != 0 {
 		_, err := labels.Parse(s.ApplicationSelector)

--- a/pkg/simple/client/multicluster/options.go
+++ b/pkg/simple/client/multicluster/options.go
@@ -17,9 +17,11 @@ limitations under the License.
 package multicluster
 
 import (
+	"errors"
 	"time"
 
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 const (
@@ -67,7 +69,18 @@ func NewOptions() *Options {
 }
 
 func (o *Options) Validate() []error {
-	return nil
+	var err []error
+
+	res := validation.IsQualifiedName(o.HostClusterName)
+	if len(res) == 0 {
+		return err
+	}
+
+	err = append(err, errors.New("failed to create the host cluster because of invalid cluster name"))
+	for _, str := range res {
+		err = append(err, errors.New(str))
+	}
+	return err
 }
 
 func (o *Options) AddFlags(fs *pflag.FlagSet, s *Options) {


### PR DESCRIPTION
Signed-off-by: yuswift <yuswift2018@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature


### What this PR does / why we need it:
when users specify the host cluster name, we need to validate it. If it fails, the controller should not start.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
part of #4158 
### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
