### PR TITLE
Fix inconsistent user status in member cluster

### DIFF
--- a/staging/src/kubesphere.io/api/types/v1beta1/federateduser_types.go
+++ b/staging/src/kubesphere.io/api/types/v1beta1/federateduser_types.go
@@ -45,7 +45,10 @@ type FederatedUserSpec struct {
 }
 
 type UserTemplate struct {
-	Spec v1alpha2.UserSpec `json:"spec,omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              v1alpha2.UserSpec `json:"spec"`
+	// +optional
+	Status v1alpha2.UserStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Signed-off-by: hongming <hongming@kubesphere.io>


### What type of PR is this?
/kind bug

The user label [will not be synchronized to the member cluster](https://github.com/kubesphere/kubesphere/blob/release-3.1/pkg/controller/user/user_controller.go#L335-L341), but the user controller in the member cluster will modify the user status according to the incorrect label. In fact, the user status is controlled by the user controller in the host cluster.

### What this PR does / why we need it:

The user status is inconsistent due to the user label cannot be synchronized to the member cluster. The user-controller in the member cluster should not manage user spec and user status(which is managed by kubefed).
 
### Which issue(s) this PR fixes:

Fixes #4167

### Does this PR introduced a user-facing change?

```release-note
NONE
```