### PR TITLE
Support skip information reconfirm when using external IDP

### DIFF
--- a/pkg/apiserver/authentication/oauth/oauth_options.go
+++ b/pkg/apiserver/authentication/oauth/oauth_options.go
@@ -37,7 +37,8 @@ const (
 	GrantHandlerPrompt GrantHandlerType = "prompt"
 	// GrantHandlerDeny auto-denies client authorization grant requests
 	GrantHandlerDeny GrantHandlerType = "deny"
-	// MappingMethodAuto  The default value.The user will automatically create and mapping when login successful.
+	// MappingMethodAuto  The default value.
+	// The user will automatically create and mapping when login successful.
 	// Fails if a user with that username is already mapped to another identity.
 	MappingMethodAuto MappingMethod = "auto"
 	// MappingMethodLookup Looks up an existing identity, user identity mapping, and user, but does not automatically
@@ -140,6 +141,11 @@ type IdentityProviderOptions struct {
 	//            provision users or identities. Using this method requires you to manually provision users.
 	//  - mixed:  A user entity can be mapped with multiple identifyProvider.
 	MappingMethod MappingMethod `json:"mappingMethod" yaml:"mappingMethod"`
+
+	// DisableLoginConfirmation means that when the user login successfully,
+	// reconfirm the account information is not required.
+	// Username from IDP must math [a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
+	DisableLoginConfirmation bool `json:"disableLoginConfirmation" yaml:"disableLoginConfirmation"`
 
 	// The type of identify provider
 	// OpenIDIdentityProvider LDAPIdentityProvider GitHubIdentityProvider

--- a/pkg/apiserver/authentication/oauth/oauth_options_test.go
+++ b/pkg/apiserver/authentication/oauth/oauth_options_test.go
@@ -136,7 +136,7 @@ identityProviders:
 	if err := yaml.Unmarshal([]byte(config), &options); err != nil {
 		t.Error(err)
 	}
-	expected := `{"identityProviders":[{"name":"ldap","mappingMethod":"auto","type":"LDAPIdentityProvider","provider":{"host":"xxxx.sn.mynetname.net:389","loginAttribute":"uid","mailAttribute":"mail","managerDN":"uid=root,cn=users,dc=xxxx,dc=sn,dc=mynetname,dc=net","userSearchBase":"dc=xxxx,dc=sn,dc=mynetname,dc=net"}},{"name":"github","mappingMethod":"mixed","type":"GitHubIdentityProvider","provider":{"clientID":"xxxxxx","endpoint":{"authURL":"https://github.com/login/oauth/authorize","tokenURL":"https://github.com/login/oauth/access_token"},"redirectURL":"https://ks-console/oauth/redirect","scopes":["user"]}}],"accessTokenMaxAge":3600000000000,"accessTokenInactivityTimeout":1800000000000}`
+	expected := `{"identityProviders":[{"name":"ldap","mappingMethod":"auto","disableLoginConfirmation":false,"type":"LDAPIdentityProvider","provider":{"host":"xxxx.sn.mynetname.net:389","loginAttribute":"uid","mailAttribute":"mail","managerDN":"uid=root,cn=users,dc=xxxx,dc=sn,dc=mynetname,dc=net","userSearchBase":"dc=xxxx,dc=sn,dc=mynetname,dc=net"}},{"name":"github","mappingMethod":"mixed","disableLoginConfirmation":false,"type":"GitHubIdentityProvider","provider":{"clientID":"xxxxxx","endpoint":{"authURL":"https://github.com/login/oauth/authorize","tokenURL":"https://github.com/login/oauth/access_token"},"redirectURL":"https://ks-console/oauth/redirect","scopes":["user"]}}],"accessTokenMaxAge":3600000000000,"accessTokenInactivityTimeout":1800000000000}`
 	output, _ := json.Marshal(options)
 	if expected != string(output) {
 		t.Errorf("expected: %s, but got: %s", expected, output)

--- a/pkg/controller/user/user_webhook.go
+++ b/pkg/controller/user/user_webhook.go
@@ -58,6 +58,10 @@ func (a *EmailValidator) Handle(ctx context.Context, req admission.Request) admi
 }
 
 func emailAlreadyExist(users v1alpha2.UserList, user *v1alpha2.User) bool {
+	// empty email is allowed
+	if user.Spec.Email == "" {
+		return false
+	}
 	for _, exist := range users.Items {
 		if exist.Spec.Email == user.Spec.Email && exist.Name != user.Name {
 			return true


### PR DESCRIPTION
Signed-off-by: hongming <hongming@kubesphere.io>


### What type of PR is this?

/kind feature
/area auth


### What this PR does / why we need it:

Skip information confirmation will reduce user login steps when using a custom identity provider.

### Which issue(s) this PR fixes:

Fixes #4177

### Does this PR introduced a user-facing change?

```release-note
Support skip information confirmation when using external IDP
```
