### PR TITLE
fix regression bug failed to create federateduser

### DIFF
--- a/pkg/controller/user/user_controller.go
+++ b/pkg/controller/user/user_controller.go
@@ -288,6 +288,9 @@ func (r *Reconciler) multiClusterSync(ctx context.Context, user *iamv1alpha2.Use
 	federatedUser := &typesv1beta1.FederatedUser{}
 	err := r.Get(ctx, types.NamespacedName{Name: user.Name}, federatedUser)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return r.createFederatedUser(ctx, user)
+		}
 		return err
 	}
 
@@ -306,10 +309,6 @@ func (r *Reconciler) multiClusterSync(ctx context.Context, user *iamv1alpha2.Use
 
 func (r *Reconciler) createFederatedUser(ctx context.Context, user *iamv1alpha2.User) error {
 	federatedUser := &typesv1beta1.FederatedUser{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       iamv1alpha2.FedUserKind,
-			APIVersion: iamv1alpha2.FedUserResource.Group + "/" + iamv1alpha2.FedUserResource.Version,
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: user.Name,
 		},


### PR DESCRIPTION
Signed-off-by: hongming <hongming@kubesphere.io>


### What type of PR is this?

/kind bug
/kind regression

### What this PR does / why we need it:

Fix regression bug in  #4228, failed to create federated users.

ks-controller-manager error logs:

```
E0918 14:39:34.013636       1 controller.go:304] controller-runtime/manager/controller/user-controller "msg"="Reconciler error" "error"="FederatedUser.types.kubefed.io \"test-tt\" not found" "name"="test" "namespace"="" "reconciler group"="iam.kubesphere.io" "reconciler kind"="User"
E0918 14:39:34.013657       1 controller.go:304] controller-runtime/manager/controller/user-controller "msg"="Reconciler error" "error"="FederatedUser.types.kubefed.io \"admin\" not found" "name"="admin" "namespace"="" "reconciler group"="iam.kubesphere.io" "reconciler kind"="User"
```


### Does this PR introduced a user-facing change?

```release-note
None
```