### PR TITLE
feat: add default gateway pod affinity

### DIFF
--- a/config/gateway/templates/nginx-ingress.yaml
+++ b/config/gateway/templates/nginx-ingress.yaml
@@ -20,6 +20,11 @@ spec:
     config: {{ toYaml .Values.controller.config | nindent 6 }}
     {{- end }}
 
+    {{- if hasKey .Values.deployment.annotations "servicemesh.kubesphere.io/enabled" }}
+    podAnnotations:
+      sidecar.istio.io/inject: {{ get .Values.deployment.annotations "servicemesh.kubesphere.io/enabled" }}
+    {{- end }}
+
     ## Annotations to be added to the controller config configuration configmap
     ##
     configAnnotations: {}
@@ -126,27 +131,26 @@ spec:
     ## Affinity and anti-affinity
     ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
     ##
-    affinity: {}
-      # # An example of preferred pod anti-affinity, weight is in the range 1-100
-      # podAntiAffinity:
-      #   preferredDuringSchedulingIgnoredDuringExecution:
-      #   - weight: 100
-      #     podAffinityTerm:
-      #       labelSelector:
-      #         matchExpressions:
-      #         - key: app.kubernetes.io/name
-      #           operator: In
-      #           values:
-      #           - ingress-nginx
-      #         - key: app.kubernetes.io/instance
-      #           operator: In
-      #           values:
-      #           - ingress-nginx
-      #         - key: app.kubernetes.io/component
-      #           operator: In
-      #           values:
-      #           - controller
-      #       topologyKey: kubernetes.io/hostname
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - ingress-nginx
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                - {{ .Release.Name }}-ingress
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - controller
+            topologyKey: kubernetes.io/hostname
 
       # # An example of required pod anti-affinity
       # podAntiAffinity:


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@kubesphere.io>
### What type of PR is this?
/kind feature

### What this PR does / why we need it:
When scaling gateway workloads, pods should spread to all nodes to balance the networking and CPU, etc.  

### Which issue(s) this PR fixes:
Fixes # #3055 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
None
```

### Additional documentation, usage docs, etc.:
```docs

```
