### PR TITLE
update ingress version in ks-core chart

### DIFF
--- a/config/ks-core/templates/ks-apiserver.yml
+++ b/config/ks-core/templates/ks-apiserver.yml
@@ -41,9 +41,6 @@ spec:
         resources:
           {{- toYaml .Values.apiserver.resources | nindent 12 }}
         volumeMounts:
-        - mountPath: /var/run/docker.sock
-          name: docker-sock
-          readOnly: true
         - mountPath: /etc/kubesphere/ingress-controller
           name: ks-router-config
         - mountPath: /etc/kubesphere/
@@ -95,10 +92,6 @@ spec:
             - {{ .Release.Namespace }}
 {{- end }}
       volumes:
-      - hostPath:
-          path: /var/run/docker.sock
-          type: ""
-        name: docker-sock
       - configMap:
           defaultMode: 420
           name: ks-router-config

--- a/config/ks-core/templates/ks-apiserver.yml
+++ b/config/ks-core/templates/ks-apiserver.yml
@@ -43,12 +43,14 @@ spec:
         volumeMounts:
         - mountPath: /var/run/docker.sock
           name: docker-sock
+          readOnly: true
         - mountPath: /etc/kubesphere/ingress-controller
           name: ks-router-config
         - mountPath: /etc/kubesphere/
           name: kubesphere-config
         - mountPath: /etc/localtime
           name: host-time
+          readOnly: true
         {{- if .Values.apiserver.extraVolumeMounts }}
           {{- toYaml .Values.apiserver.extraVolumeMounts | nindent 8 }}
         {{- end }}

--- a/config/ks-core/templates/ks-console.yml
+++ b/config/ks-core/templates/ks-console.yml
@@ -36,6 +36,7 @@ spec:
           name: sample-bookinfo
         - mountPath: /etc/localtime
           name: host-time
+          readOnly: true
         {{- if .Values.console.extraVolumeMounts }}
           {{- toYaml .Values.console.extraVolumeMounts | nindent 8 }}
         {{- end }}

--- a/config/ks-core/templates/ks-controller-manager.yaml
+++ b/config/ks-core/templates/ks-controller-manager.yaml
@@ -52,6 +52,7 @@ spec:
           name: webhook-secret
         - mountPath: /etc/localtime
           name: host-time
+          readOnly: true
         {{- if .Values.controller.extraVolumeMounts }}
           {{- toYaml .Values.controller.extraVolumeMounts | nindent 8 }}
         {{- end }}

--- a/config/ks-core/templates/sample-bookinfo-configmap.yaml
+++ b/config/ks-core/templates/sample-bookinfo-configmap.yaml
@@ -355,7 +355,7 @@ data:
           targetPort: 9080
 
     ---
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       namespace: servicemesh
@@ -367,10 +367,13 @@ data:
       rules:
         - http:
             paths:
-              - path: /
-                backend:
-                  serviceName: productpage
-                  servicePort: 9080
+            - backend:
+                service:
+                  name: productpage
+                  port:
+                    number: 9080
+              path: /
+              pathType: ImplementationSpecific
           host: productpage.servicemesh.139.198.121.92.nip.io
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@kubesphere.io>

### What type of PR is this?
/kind bug
/kind flake
### What this PR does / why we need it:
Since #4068 we have upgraded the Ingress API versions to networking.k8s.io/v1. but the sample app still uses the old API version. So we have to upgrade it to the networking.k8s.io/v1 version.

### Which issue(s) this PR fixes:
Fixes #4283

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
