### PR TITLE
Search gateway logs with ES

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -256,7 +256,7 @@ func (s *APIServer) installKubeSphereAPIs() {
 	urlruntime.Must(notificationkapisv2beta1.AddToContainer(s.container, s.InformerFactory, s.KubernetesClient.Kubernetes(),
 		s.KubernetesClient.KubeSphere()))
 	urlruntime.Must(notificationkapisv2beta2.AddToContainer(s.container, s.Config.NotificationOptions))
-	urlruntime.Must(gatewayv1alpha1.AddToContainer(s.container, s.Config.GatewayOptions, s.RuntimeCache, s.RuntimeClient, s.InformerFactory, s.KubernetesClient.Kubernetes()))
+	urlruntime.Must(gatewayv1alpha1.AddToContainer(s.container, s.Config.GatewayOptions, s.RuntimeCache, s.RuntimeClient, s.InformerFactory, s.KubernetesClient.Kubernetes(), s.LoggingClient))
 }
 
 func (s *APIServer) Run(ctx context.Context) (err error) {

--- a/pkg/kapis/gateway/v1alpha1/handler.go
+++ b/pkg/kapis/gateway/v1alpha1/handler.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/emicklei/go-restful"
 	corev1 "k8s.io/api/core/v1"
@@ -31,30 +32,39 @@ import (
 	"kubesphere.io/api/gateway/v1alpha1"
 
 	"kubesphere.io/kubesphere/pkg/api"
+	loggingv1alpha2 "kubesphere.io/kubesphere/pkg/api/logging/v1alpha2"
 	"kubesphere.io/kubesphere/pkg/apiserver/query"
 	"kubesphere.io/kubesphere/pkg/informers"
 	operator "kubesphere.io/kubesphere/pkg/models/gateway"
-
+	"kubesphere.io/kubesphere/pkg/models/logging"
 	servererr "kubesphere.io/kubesphere/pkg/server/errors"
 	"kubesphere.io/kubesphere/pkg/simple/client/gateway"
+	loggingclient "kubesphere.io/kubesphere/pkg/simple/client/logging"
 	conversionsv1 "kubesphere.io/kubesphere/pkg/utils/conversions/core/v1"
+	"kubesphere.io/kubesphere/pkg/utils/stringutils"
 )
 
 type handler struct {
 	options *gateway.Options
 	gw      operator.GatewayOperator
 	factory informers.InformerFactory
+	lo      logging.LoggingOperator
 }
 
 //newHandler create an instance of the handler
-func newHandler(options *gateway.Options, cache cache.Cache, client client.Client, factory informers.InformerFactory, k8sClient kubernetes.Interface) *handler {
+func newHandler(options *gateway.Options, cache cache.Cache, client client.Client, factory informers.InformerFactory, k8sClient kubernetes.Interface, loggingClient loggingclient.Client) *handler {
 	conversionsv1.RegisterConversions(scheme.Scheme)
 	// Do not register Gateway scheme globally. Which will cause conflict in ks-controller-manager.
 	v1alpha1.AddToScheme(client.Scheme())
+	var lo logging.LoggingOperator
+	if loggingClient != nil {
+		lo = logging.NewLoggingOperator(loggingClient)
+	}
 	return &handler{
 		options: options,
 		factory: factory,
 		gw:      operator.NewGatewayOperator(client, cache, options, factory, k8sClient),
+		lo:      lo,
 	}
 }
 
@@ -172,4 +182,60 @@ func (h *handler) PodLog(request *restful.Request, response *restful.Response) {
 		api.HandleError(response, request, err)
 		return
 	}
+}
+
+func (h *handler) PodLogSearch(request *restful.Request, response *restful.Response) {
+	if h.lo == nil {
+		api.HandleError(response, request, fmt.Errorf("logging isn't enabled"))
+		return
+	}
+
+	ns := request.PathParameter("namespace")
+	logQuery, err := loggingv1alpha2.ParseQueryParameter(request)
+	if err != nil {
+		api.HandleError(response, request, err)
+		return
+	}
+	// ES log will be filted by pods and namespace by default.
+	pods, err := h.gw.GetPods(ns, &query.Query{})
+	if err != nil {
+		api.HandleError(response, request, err)
+		return
+	}
+
+	var podfilter []string
+	namespaceCreateTimeMap := make(map[string]*time.Time)
+	var ar loggingv1alpha2.APIResponse
+
+	for _, p := range pods.Items {
+		pod, ok := p.(*corev1.Pod)
+		if ok {
+			podfilter = append(podfilter, pod.Name)
+			namespaceCreateTimeMap[pod.Namespace] = nil
+		}
+	}
+
+	sf := loggingclient.SearchFilter{
+		NamespaceFilter: namespaceCreateTimeMap,
+		PodFilter:       podfilter,
+		PodSearch:       stringutils.Split(logQuery.PodSearch, ","),
+		ContainerSearch: stringutils.Split(logQuery.ContainerSearch, ","),
+		ContainerFilter: stringutils.Split(logQuery.ContainerFilter, ","),
+		LogSearch:       stringutils.Split(logQuery.LogSearch, ","),
+		Starttime:       logQuery.StartTime,
+		Endtime:         logQuery.EndTime,
+	}
+
+	noHit := len(namespaceCreateTimeMap) == 0 || len(podfilter) == 0
+	if noHit {
+		ar.Logs = &loggingclient.Logs{}
+	} else {
+		ar, err = h.lo.SearchLogs(sf, logQuery.From, logQuery.Size, logQuery.Sort)
+		if err != nil {
+			api.HandleError(response, request, err)
+			return
+		}
+	}
+
+	response.WriteEntity(ar)
 }


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@kubesphere.io>

### What type of PR is this?
/kind feature

### What this PR does / why we need it:
Added a new API to query gateway logs from ElasticSearch.  
When the logging component is enabled in KubeSphere, all the logs will be saved into ES. Which provided the searching and filtering ability of the gateway logs. 

### Which issue(s) this PR fixes:
Fixes ##3055

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
None
```

### Additional documentation, usage docs, etc.:
```docs

```
