### PR TITLE
update capability_controller.go, make sure that annotations is genera…

### DIFF
--- a/pkg/controller/storage/capability/capability_controller.go
+++ b/pkg/controller/storage/capability/capability_controller.go
@@ -21,13 +21,15 @@ package capability
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/labels"
 
 	storagev1 "k8s.io/api/storage/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	storageinformersv1 "k8s.io/client-go/informers/storage/v1"
@@ -89,7 +91,8 @@ func NewController(
 	})
 
 	csiDriverInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: controller.enqueueStorageClassByCSI,
+		AddFunc:    controller.enqueueStorageClassByCSI,
+		DeleteFunc: controller.enqueueStorageClassByCSI,
 	})
 
 	return controller
@@ -202,27 +205,25 @@ func (c *StorageCapabilityController) syncHandler(key string) error {
 
 	// Get StorageClass
 	storageClass, err := c.storageClassLister.Get(name)
+	if err != nil {
+		return err
+	}
 
 	// Cloning and volumeSnapshot support only available for CSI drivers.
 	isCSIStorage := c.hasCSIDriver(storageClass)
-
 	// Annotate storageClass
 	storageClassUpdated := storageClass.DeepCopy()
-	if !isCSIStorage {
-		c.removeAnnotations(storageClassUpdated)
+	if isCSIStorage {
+		c.updateSnapshotAnnotation(storageClassUpdated, isCSIStorage)
+		c.updateCloneVolumeAnnotation(storageClassUpdated, isCSIStorage)
 	} else {
-		err = c.updateStorageClassSnapshotAnnotation(storageClassUpdated, isCSIStorage)
-		if err != nil {
-			return err
-		}
-		err = c.updateCloneVolumeAnnotation(storageClassUpdated, isCSIStorage)
-		if err != nil {
-			return err
-		}
+		c.removeAnnotations(storageClassUpdated)
 	}
-	_, err = c.storageClassClient.Update(context.Background(), storageClassUpdated, metav1.UpdateOptions{})
-	if err != nil {
-		return err
+	if !reflect.DeepEqual(storageClass, storageClassUpdated) {
+		_, err = c.storageClassClient.Update(context.Background(), storageClassUpdated, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -238,27 +239,24 @@ func (c *StorageCapabilityController) hasCSIDriver(storageClass *storagev1.Stora
 	return false
 }
 
-func (c *StorageCapabilityController) updateStorageClassSnapshotAnnotation(storageClass *storagev1.StorageClass, snapshotAllow bool) error {
+func (c *StorageCapabilityController) updateSnapshotAnnotation(storageClass *storagev1.StorageClass, snapshotAllow bool) {
 	if storageClass.Annotations == nil {
 		storageClass.Annotations = make(map[string]string)
 	}
-	_, err := strconv.ParseBool(storageClass.Annotations[annotationAllowSnapshot])
-	// err != nil means annotationAllowSnapshot is not illegal, include empty
-	if err != nil {
+	if _, err := strconv.ParseBool(storageClass.Annotations[annotationAllowSnapshot]); err != nil {
 		storageClass.Annotations[annotationAllowSnapshot] = strconv.FormatBool(snapshotAllow)
 	}
-	return nil
+	return
 }
 
-func (c *StorageCapabilityController) updateCloneVolumeAnnotation(storageClass *storagev1.StorageClass, cloneAllow bool) error {
+func (c *StorageCapabilityController) updateCloneVolumeAnnotation(storageClass *storagev1.StorageClass, cloneAllow bool) {
 	if storageClass.Annotations == nil {
 		storageClass.Annotations = make(map[string]string)
 	}
-	_, err := strconv.ParseBool(storageClass.Annotations[annotationAllowClone])
-	if err != nil {
+	if _, err := strconv.ParseBool(storageClass.Annotations[annotationAllowClone]); err != nil {
 		storageClass.Annotations[annotationAllowClone] = strconv.FormatBool(cloneAllow)
 	}
-	return nil
+	return
 }
 
 func (c *StorageCapabilityController) removeAnnotations(storageClass *storagev1.StorageClass) {

--- a/pkg/controller/storage/capability/capability_controller_test.go
+++ b/pkg/controller/storage/capability/capability_controller_test.go
@@ -270,3 +270,22 @@ func TestStorageClassHadOneAnnotation(t *testing.T) {
 	// Run test
 	fixture.run(getKey(storageClass, t))
 }
+
+func TestStorageClassHadNoCSIDriver(t *testing.T) {
+	fixture := newFixture(t, true)
+	storageClass := newStorageClass("csi-example", "csi.example.com")
+	storageClass.Annotations = map[string]string{}
+	storageClassUpdate := storageClass.DeepCopy()
+	storageClass.Annotations = map[string]string{annotationAllowSnapshot: "false"}
+	storageClass.Annotations = map[string]string{annotationAllowClone: "false"}
+
+	// Object exist
+	fixture.storageObjects = append(fixture.storageObjects, storageClass)
+	fixture.storageClassLister = append(fixture.storageClassLister, storageClass)
+
+	// Action expected
+	fixture.expectUpdateStorageClassAction(storageClassUpdate)
+
+	// Run test
+	fixture.run(getKey(storageClass, t))
+}

--- a/pkg/controller/storage/capability/capability_controller_test.go
+++ b/pkg/controller/storage/capability/capability_controller_test.go
@@ -235,14 +235,13 @@ func TestCreateStorageClass(t *testing.T) {
 func TestStorageClassHadAnnotation(t *testing.T) {
 	fixture := newFixture(t, true)
 	storageClass := newStorageClass("csi-example", "csi.example.com")
-	storageClass.Annotations = map[string]string{annotationAllowSnapshot: "false", annotationAllowClone: "false"}
+	storageClass.Annotations = make(map[string]string)
 	storageClassUpdate := storageClass.DeepCopy()
-	csiDriver := newCSIDriver("csi.example.com")
+	storageClass.Annotations = map[string]string{annotationAllowSnapshot: "false", annotationAllowClone: "false"}
 
 	// Object exist
 	fixture.storageObjects = append(fixture.storageObjects, storageClass)
 	fixture.storageClassLister = append(fixture.storageClassLister, storageClass)
-	fixture.csiDriverLister = append(fixture.csiDriverLister, csiDriver)
 
 	// Action expected
 	fixture.expectUpdateStorageClassAction(storageClassUpdate)


### PR DESCRIPTION
Update capability_controller.go, make sure that annotations is generated correctly.StorageClass without csiDriver will no longer generate false annotations.

Signed-off-by: f10atin9 <f10atin9@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
User create storageclass by helm-charts may generate incorrect annotations before update.
And now if user open some capability incorrectly, capability can hekp user to fix it.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
