### PR TITLE
Add scheduling parameters for ks-core chart

### DIFF
--- a/config/ks-core/templates/ks-apiserver.yml
+++ b/config/ks-core/templates/ks-apiserver.yml
@@ -68,29 +68,14 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: In
-                values:
-                - ""
-{{- if gt .Values.replicaCount 1.0 }}
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - topologyKey: kubernetes.io/hostname
-            labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - ks-apiserver
-            namespaces:
-            - {{ .Release.Namespace }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       - configMap:
           defaultMode: 420

--- a/config/ks-core/templates/ks-console.yml
+++ b/config/ks-core/templates/ks-console.yml
@@ -54,29 +54,14 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: In
-                values:
-                - ""
-{{- if gt .Values.replicaCount 1.0 }}
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - topologyKey: kubernetes.io/hostname
-            labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - ks-console
-            namespaces:
-            - {{ .Release.Namespace }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       - configMap:
           defaultMode: 420

--- a/config/ks-core/templates/ks-controller-manager.yaml
+++ b/config/ks-core/templates/ks-controller-manager.yaml
@@ -85,29 +85,14 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: In
-                values:
-                - ""
-{{- if gt .Values.replicaCount 1.0 }}
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - topologyKey: kubernetes.io/hostname
-            labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - ks-controller-manager
-            namespaces:
-            - {{ .Release.Namespace }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 
 ---
 

--- a/config/ks-core/values.yaml
+++ b/config/ks-core/values.yaml
@@ -74,6 +74,8 @@ securityContext: {}
 # Kubernetes Version shows in KubeSphere console
 kube_version: "v1.19.4"
 
+env: []
+
 tolerations: 
   - key: node-role.kubernetes.io/master
     effect: NoSchedule
@@ -89,7 +91,8 @@ tolerations:
     tolerationSeconds: 60
 
 affinity: {}
-env: []
+
+nodeSelector: {}
 
 ## deployment specific configuration
 


### PR DESCRIPTION
Signed-off-by: pixiake <guofeng@yunify.com>

### What type of PR is this?
/kind cleanup


### What this PR does / why we need it:
Add scheduling parameters (`nodeSelector` and `affinity`) for ks-core chart.


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
Users can customize configure scheduling parameters in the values file of ks-core‘s helm chart.

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

```release-note
```


