### PR TITLE
add kind-e2e to Makefile

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Downloading go dependencies
-        run: go mod vendor
-
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
         with:
@@ -44,3 +41,4 @@ jobs:
           status: ${{ job.status }}
           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
         if: failure()
+

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
           tag=nightly-$(date '+%Y%m%d')
-          REPO=kubespheredev TAG=${tag} make container-push
+          REPO=kubespheredev TAG=${tag} make container-cross-push
 
       - name: slack
         uses: 8398a7/action-slack@v3

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ verify-all: ; $(info $(M)...Begin to run all verify scripts hack/verify-*.sh.)  
 e2e: ;$(info $(M)...Begin to build e2e binary.)  @ ## Build e2e binary.
 	hack/build_e2e.sh test/e2e
 
+kind-e2e: ;$(info $(M)...Run e2e test.) @ ## Run e2e test in kind.
+	hack/kind_e2e.sh
+
 # Run go fmt against code 
 fmt: ;$(info $(M)...Begin to run go fmt against code.)  @ ## Run go fmt against code.
 	gofmt -w ./pkg ./cmd ./tools ./api

--- a/hack/deploy-kubesphere.sh
+++ b/hack/deploy-kubesphere.sh
@@ -41,14 +41,10 @@ if [[ "${KIND_LOAD_IMAGE:-}" == "y" ]]; then
     kind load docker-image "$REPO/ks-controller-manager:$TAG" --name="${KIND_CLUSTER_NAME:-kind}"
 fi
 
-# Download the latest ks-install to deploy KubeSphere
-wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 --tries 3 https://raw.githubusercontent.com/kubesphere/ks-installer/master/deploy/kubesphere-installer.yaml
-wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 --tries 3 https://raw.githubusercontent.com/kubesphere/ks-installer/master/deploy/cluster-configuration.yaml
-
 #TODO: override ks-apiserver and ks-controller-manager images with specific tag
+kubectl apply -f https://raw.githubusercontent.com/kubesphere/ks-installer/master/deploy/kubesphere-installer.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubesphere/ks-installer/master/deploy/cluster-configuration.yaml
 
-kubectl apply -f kubesphere-installer.yaml
-kubectl apply -f cluster-configuration.yaml
 
 wait_for_installation_finish
 

--- a/hack/kind_e2e.sh
+++ b/hack/kind_e2e.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Copyright 2021 The KubeSphere Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+KIND_LOG_LEVEL="1"
+
+if [ -n "${DEBUG}" ]; then
+  set -x
+  KIND_LOG_LEVEL="6"
+fi
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}"/hack/lib/init.sh
+
+cleanup() {
+  kind delete cluster \
+    --verbosity="${KIND_LOG_LEVEL}" \
+    --name "${KIND_CLUSTER_NAME}"
+}
+
+trap cleanup EXIT
+
+export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-kubesphere-e2e}
+
+if ! command -v kind --version &> /dev/null; then
+  echo "kind is not installed. Use the package manager or visit the official site https://kind.sigs.k8s.io/"
+  exit 1
+fi
+
+echo "Creating Kubernetes cluster with kind"
+
+export K8S_VERSION=${K8S_VERSION:-v1.21.1}
+
+kind create cluster \
+  --verbosity="${KIND_LOG_LEVEL}" \
+  --name "${KIND_CLUSTER_NAME}" \
+  --config "${KUBE_ROOT}"/test/e2e/kind.yaml \
+  --retain \
+  --image kindest/node:"${K8S_VERSION}"
+
+echo "Kubernetes cluster:"
+kubectl get nodes -o wide
+
+echo "Deploy KubeSphere"
+"${KUBE_ROOT}"/hack/deploy-kubesphere.sh
+
+echo "Run e2e test"
+go test ./test/e2e
+

--- a/test/e2e/kind.yaml
+++ b/test/e2e/kind.yaml
@@ -1,0 +1,18 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: /etc/localtime
+    containerPath: /etc/localtime
+  extraPortMappings:
+  - containerPort: 30881
+    hostPort: 9090
+- role: worker
+  extraMounts:
+  - hostPath: /etc/localtime
+    containerPath: /etc/localtime
+- role: worker
+  extraMounts:
+  - hostPath: /etc/localtime
+    containerPath: /etc/localtime


### PR DESCRIPTION
### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

### What this PR does / why we need it:
Add `kind-e2e` to entry to Makefile, now developers can use `make kind-e2e` to run e2e test locally.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
