### PR TITLE
Use the status sub-client to update when the status of the object changes

### DIFF
--- a/pkg/controller/user/user_controller.go
+++ b/pkg/controller/user/user_controller.go
@@ -465,7 +465,7 @@ func (r *Reconciler) syncUserStatus(ctx context.Context, user *iamv1alpha2.User)
 					State:              &active,
 					LastTransitionTime: &metav1.Time{Time: time.Now()},
 				}
-				err := r.Update(ctx, expected, &client.UpdateOptions{})
+				err := r.Status().Update(ctx, expected, &client.UpdateOptions{})
 				if err != nil {
 					return nil, err
 				}
@@ -480,7 +480,7 @@ func (r *Reconciler) syncUserStatus(ctx context.Context, user *iamv1alpha2.User)
 					State:              &disabled,
 					LastTransitionTime: &metav1.Time{Time: time.Now()},
 				}
-				err := r.Update(ctx, expected, &client.UpdateOptions{})
+				err := r.Status().Update(ctx, expected, &client.UpdateOptions{})
 				if err != nil {
 					return nil, err
 				}
@@ -499,7 +499,7 @@ func (r *Reconciler) syncUserStatus(ctx context.Context, user *iamv1alpha2.User)
 				State:              &active,
 				LastTransitionTime: &metav1.Time{Time: time.Now()},
 			}
-			err := r.Update(ctx, expected, &client.UpdateOptions{})
+			err := r.Status().Update(ctx, expected, &client.UpdateOptions{})
 			if err != nil {
 				return nil, err
 			}
@@ -518,7 +518,7 @@ func (r *Reconciler) syncUserStatus(ctx context.Context, user *iamv1alpha2.User)
 				State:              &active,
 				LastTransitionTime: &metav1.Time{Time: time.Now()},
 			}
-			err := r.Update(ctx, expected, &client.UpdateOptions{})
+			err := r.Status().Update(ctx, expected, &client.UpdateOptions{})
 			if err != nil {
 				return nil, err
 			}
@@ -554,7 +554,7 @@ func (r *Reconciler) syncUserStatus(ctx context.Context, user *iamv1alpha2.User)
 			LastTransitionTime: &metav1.Time{Time: time.Now()},
 		}
 
-		err = r.Update(ctx, expected, &client.UpdateOptions{})
+		err = r.Status().Update(ctx, expected, &client.UpdateOptions{})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
/kind bug

### What this PR does / why we need it:

The `FederatedUser` CRD enabled the status subresource, we are using the wrong client to update the object when the `status` changes.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4296

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @zryfish @wansir 