### PR TITLE
Fix NPE in user_controller

### DIFF
--- a/pkg/controller/user/user_controller_test.go
+++ b/pkg/controller/user/user_controller_test.go
@@ -99,7 +99,7 @@ func TestDoNothing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.Reconcile(context.Background(), reconcile.Request{
+	result, err := c.Reconcile(context.Background(), reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: user.Name},
 	})
 	if err != nil {
@@ -108,22 +108,15 @@ func TestDoNothing(t *testing.T) {
 
 	// append finalizer
 	updateEvent := <-w.ResultChan()
-	assert.Equal(t, updateEvent.Type, watch.Modified)
+	assert.Equal(t, watch.Modified, updateEvent.Type)
 	assert.NotNil(t, updateEvent.Object)
 	user = updateEvent.Object.(*iamv1alpha2.User)
 	assert.NotNil(t, user)
 	assert.NotEmpty(t, user.Finalizers)
 
-	result, err := c.Reconcile(context.Background(), reconcile.Request{
-		NamespacedName: types.NamespacedName{Name: user.Name},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	updateEvent = <-w.ResultChan()
 	// encrypt password
-	assert.Equal(t, updateEvent.Type, watch.Modified)
+	assert.Equal(t, watch.Modified, updateEvent.Type)
 	assert.NotNil(t, updateEvent.Object)
 	user = updateEvent.Object.(*iamv1alpha2.User)
 	assert.NotNil(t, user)
@@ -132,12 +125,12 @@ func TestDoNothing(t *testing.T) {
 	// becomes active after password encrypted
 	updateEvent = <-w.ResultChan()
 	user = updateEvent.Object.(*iamv1alpha2.User)
-	assert.Equal(t, *user.Status.State, iamv1alpha2.UserActive)
+	assert.Equal(t, iamv1alpha2.UserActive, *user.Status.State)
 
 	// block user
 	updateEvent = <-w.ResultChan()
 	user = updateEvent.Object.(*iamv1alpha2.User)
-	assert.Equal(t, *user.Status.State, iamv1alpha2.UserAuthLimitExceeded)
+	assert.Equal(t, iamv1alpha2.UserAuthLimitExceeded, *user.Status.State)
 	assert.True(t, result.Requeue)
 
 	time.Sleep(result.RequeueAfter + time.Second)
@@ -151,5 +144,5 @@ func TestDoNothing(t *testing.T) {
 	// unblock user
 	updateEvent = <-w.ResultChan()
 	user = updateEvent.Object.(*iamv1alpha2.User)
-	assert.Equal(t, *user.Status.State, iamv1alpha2.UserActive)
+	assert.Equal(t, iamv1alpha2.UserActive, *user.Status.State)
 }

--- a/pkg/controller/workspacerole/workspacerole_controller.go
+++ b/pkg/controller/workspacerole/workspacerole_controller.go
@@ -122,7 +122,6 @@ func (r *Reconciler) bindWorkspace(ctx context.Context, logger logr.Logger, work
 		return client.IgnoreNotFound(err)
 	}
 	if !metav1.IsControlledBy(workspaceRole, &workspace) {
-		workspaceRole = workspaceRole.DeepCopy()
 		workspaceRole.OwnerReferences = k8sutil.RemoveWorkspaceOwnerReference(workspaceRole.OwnerReferences)
 		if err := controllerutil.SetControllerReference(&workspace, workspaceRole, r.Scheme); err != nil {
 			logger.Error(err, "set controller reference failed")
@@ -151,6 +150,7 @@ func (r *Reconciler) multiClusterSync(ctx context.Context, logger logr.Logger, w
 					logger.Error(err, "create federated workspace role failed")
 					return err
 				}
+				return nil
 			}
 		}
 		logger.Error(err, "get federated workspace role failed")
@@ -174,10 +174,6 @@ func (r *Reconciler) multiClusterSync(ctx context.Context, logger logr.Logger, w
 
 func newFederatedWorkspaceRole(workspaceRole *iamv1alpha2.WorkspaceRole) (*typesv1beta1.FederatedWorkspaceRole, error) {
 	federatedWorkspaceRole := &typesv1beta1.FederatedWorkspaceRole{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       typesv1beta1.FederatedWorkspaceRoleKind,
-			APIVersion: typesv1beta1.SchemeGroupVersion.String(),
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: workspaceRole.Name,
 		},
@@ -206,7 +202,6 @@ func (r *Reconciler) ensureNotControlledByKubefed(ctx context.Context, logger lo
 		if workspaceRole.Labels == nil {
 			workspaceRole.Labels = make(map[string]string)
 		}
-		workspaceRole = workspaceRole.DeepCopy()
 		workspaceRole.Labels[constants.KubefedManagedLabel] = "false"
 		if err := r.Update(ctx, workspaceRole); err != nil {
 			logger.Error(err, "update kubefed managed label failed")


### PR DESCRIPTION
### What type of PR is this?

/kind bug


### What this PR does / why we need it:

Fix NPE in user_controller, following stack trace was reported: 

```
E1011 15:35:41.268877       1 controller.go:190] controller-runtime/manager/controller/application-controller "msg"="Could not wait for Cache to sync" "error"="failed to wait for application-controller caches to sync: no matches for kind \"Ingress\" in version \"networking.k8s.io/v1\"" "reconciler group"="app.k8s.io" "reconciler kind"="Application"
I1011 15:35:41.269004       1 controller.go:227] controller-runtime/manager/controller/workspace-controller "msg"="Shutdown signal received,waiting for all workers to finish" "reconciler group"="tenant.kubesphere.io" "reconciler kind"="Workspace"
E1011 15:35:41.269097       1 user_controller.go:528] Timeout: failed waiting for *v1alpha2.LoginRecord Informer to sync
E1011 15:35:41.269119       1 user_controller.go:208] Timeout: failed waiting for *v1alpha2.LoginRecord Informer to sync
E1011 15:35:41.269214       1 user_controller.go:528] Timeout: failed waiting for *v1alpha2.LoginRecord Informer to sync
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1756ba5]

goroutine 1419 [running]:
kubesphere.io/api/iam/v1alpha2.(*User).GetObjectKind(0x0, 0x335c378, 0x0)
        <autogenerated>:1 +0x5
k8s.io/client-go/tools/reference.GetReference(0xc000200af0, 0x32d1f30, 0x0, 0xc00126fb50, 0x15bfe15, 0xc0012d0e40)
        /workspace/vendor/k8s.io/client-go/tools/reference/ref.go:59 +0x14d
k8s.io/client-go/tools/record.(*recorderImpl).generateEvent(0xc000d5cec0, 0x32d1f30, 0x0, 0x0, 0x2e9b9d1, 0x7, 0x2ea1376, 0xa, 0xc001cb0a20,0x52)
        /workspace/vendor/k8s.io/client-go/tools/record/event.go:327 +0x5d
k8s.io/client-go/tools/record.(*recorderImpl).Event(0xc000d5cec0, 0x32d1f30, 0x0, 0x2e9b9d1, 0x7, 0x2ea1376, 0xa, 0xc001cb0a20, 0x52)
        /workspace/vendor/k8s.io/client-go/tools/record/event.go:352 +0x97
sigs.k8s.io/controller-runtime/pkg/internal/recorder.(*lazyRecorder).Event(0xc000e5b8c0, 0x32d1f30, 0x0, 0x2e9b9d1, 0x7, 0x2ea1376, 0xa, 0xc001cb0a20, 0x52)
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/recorder/recorder.go:156 +0xf0
kubesphere.io/kubesphere/pkg/controller/user.(*Reconciler).Reconcile(0xc000e7e580, 0x331de80, 0xc001cb9a70, 0x0, 0x0, 0xc0017009d0, 0x8, 0xc001cb9a70, 0xc000b80000, 0x2c11020, ...)
        /workspace/pkg/controller/user/user_controller.go:209 +0xaee
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000ea0280, 0x331ddd8, 0xc0000a6e40, 0x2b60d20, 0xc0011c8340)
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:298 +0x30d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000ea0280, 0x331ddd8, 0xc0000a6e40, 0x72746e6f632d6500)
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:253 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2(0xc00117ee70, 0xc000ea0280, 0x331ddd8, 0xc0000a6e40)
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:214 +0x6b
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:210 +0x425
```

The first argument of `record.EventRecorder.Event` must not be nil.


Fix invalid kind of in workspacetemplate_controller.

```
E1012 15:21:40.472854       1 workspacetemplate_controller.go:206] controllers/workspacetemplate-controller "msg"="create federated workspace failed" "error"="FederatedWorkspaceRole.types.kubefed.io \"sss\" is invalid: kind: Invalid value: \"FederatedWorkspaceRole\": must be FederatedWorkspace" "workspacetemplate"={"Namespace":"","Name":"sss"}
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```
