### PR TITLE
fix gitMajor and gitMinor missing in version api

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -80,6 +80,7 @@ kube::version::get_version_vars() {
       # the "major" and "minor" versions and whether this is the exact tagged
       # version or whether the tree is between two tagged versions.
       if [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?([+].*)?$ ]]; then
+        # shellcheck disable=SC2034 
         KUBE_GIT_MAJOR=${BASH_REMATCH[1]}
         KUBE_GIT_MINOR=${BASH_REMATCH[2]}
         if [[ -n "${BASH_REMATCH[4]}" ]]; then


### PR DESCRIPTION
### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
Current API version output like the following, `gitMajor` and `gitMinor` is missing.
```
{
 "gitVersion": "v3.2.0-alpha.1",
 "gitMajor": "unknown",
 "gitMinor": "unknown",
 "gitCommit": "6f434252dfd3b1fa5aea200e2b96e0cd4252e230",
 "gitTreeState": "clean",
 "buildDate": "2021-09-29T13:36:55Z",
 "goVersion": "go1.16.3",
 "compiler": "gc",
 "platform": "linux/amd64",
 "kubernetes": {
  "major": "1",
  "minor": "21",
  "gitVersion": "v1.21.5",
  "gitCommit": "aea7bbadd2fc0cd689de94a54e5b7b758869d691",
  "gitTreeState": "clean",
  "buildDate": "2021-09-15T21:04:16Z",
  "goVersion": "go1.16.8",
  "compiler": "gc",
  "platform": "linux/amd64"
 }
}
```

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
