### PR TITLE
Fix failed to delete workspace in multi-cluster enviroment

### DIFF
--- a/staging/src/kubesphere.io/api/types/v1beta1/register.go
+++ b/staging/src/kubesphere.io/api/types/v1beta1/register.go
@@ -79,6 +79,8 @@ func init() {
 		&FederatedUserList{},
 		&FederatedGroup{},
 		&FederatedGroupList{},
+		&FederatedGroupBinding{},
+		&FederatedGroupBindingList{},
 		&FederatedWorkspace{},
 		&FederatedWorkspaceList{},
 		&FederatedWorkspaceRole{},


### PR DESCRIPTION
### What type of PR is this?

/kind bug
/kind regression

### What this PR does / why we need it:

Fix regression bug, failed to delete workspace in multi-cluster enviroment.

The following is the error logs:

```
E1021 10:52:37.341222       1 workspacetemplate_controller.go:121] controllers/workspacetemplate-controller "msg"="failed to delete related workspace" "error"="the server does not allow this method on the requested resource" "workspacetemplate"={"Namespace":"","Name":"test-cxl"}
E1021 10:54:21.077197       1 workspacetemplate_controller.go:121] controllers/workspacetemplate-controller "msg"="failed to delete related workspace" "error"="the server does not allow this method on the requested resource" "workspacetemplate"={"Namespace":"","Name":"test-docker-id"}
W1021 10:56:20.163887       1 reflector.go:436] pkg/client/informers/externalversions/factory.go:128: watch of *v1beta1.FederatedGroupBinding ended with: an error on the server ("unable to decode an event from the watch stream: unable to decode watch event: no kind \"FederatedGroupBinding\" is registered for version \"types.kubefed.io/v1beta1\" in scheme \"pkg/client/clientset/versioned/scheme/register.go:43\"") has prevented the request from succeeding
E1021 10:58:02.922612       1 workspacetemplate_controller.go:121] controllers/workspacetemplate-controller "msg"="failed to delete related workspace" "error"="the server does not allow this method on the requested resource" "workspacetemplate"={"Namespace":"","Name":"test-cxl"}
W1021 11:07:06.691152       1 reflector.go:436] pkg/client/informers/externalversions/factory.go:128: watch of *v1beta1.FederatedGroupBinding ended with: an error on the server ("unable to decode an event from the watch stream: unable to decode watch event: no kind \"FederatedGroupBinding\" is registered for version \"types.kubefed.io/v1beta1\" in scheme \"pkg/client/clientset/versioned/scheme/register.go:43\"") has prevented the request from succeeding
```

The root cause is `DELETE https://10.233.0.1:443/api/v1/namespaces?labelSelector=kubesphere.io%2Fworkspace%3D<xxx>` is not allowed.

```
I1021 13:00:10.975287       1 request.go:1123] Request Body: {"kind":"DeleteOptions","apiVersion":"v1"}
I1021 13:00:10.975392       1 round_trippers.go:435] curl -k -v -XDELETE  -H "Authorization: Bearer <masked>" -H "Accept: application/json" -H "Content-Type: application/json" -H "User-Agent: controller-manager/v0.0.0 (linux/amd64) kubernetes/$Format" 'https://10.233.0.1:443/api/v1/namespaces?labelSelector=kubesphere.io%2Fworkspace%3Dttx4'
I1021 13:00:10.976261       1 round_trippers.go:454] DELETE https://10.233.0.1:443/api/v1/namespaces?labelSelector=kubesphere.io%2Fworkspace%3Dttx4 405 Method Not Allowed in 0 milliseconds
I1021 13:00:10.976274       1 round_trippers.go:460] Response Headers:
I1021 13:00:10.976280       1 round_trippers.go:463]     X-Kubernetes-Pf-Flowschema-Uid: 3f908545-bbf9-45eb-a9d0-37028ceb8be4
I1021 13:00:10.976285       1 round_trippers.go:463]     X-Kubernetes-Pf-Prioritylevel-Uid: 2ee103d8-45f4-46ab-b1b6-5ce8e7b00e02
I1021 13:00:10.976288       1 round_trippers.go:463]     Content-Length: 197
I1021 13:00:10.976292       1 round_trippers.go:463]     Date: Thu, 21 Oct 2021 05:00:10 GMT
I1021 13:00:10.976311       1 round_trippers.go:463]     Cache-Control: no-cache, private
I1021 13:00:10.976318       1 round_trippers.go:463]     Content-Type: application/json
I1021 13:00:10.976338       1 request.go:1123] Response Body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"the server does not allow this method on the requested resource","reason":"MethodNotAllowed","details":{},"code":405}
E1021 13:00:10.976480       1 workspacetemplate_controller.go:121] controllers/workspacetemplate-controller "msg"="failed to delete related workspace" "error"="the server does not allow this method on the requested resource" "workspacetemplate"={"Namespace":"","Name":"ttx4"}
```

### Special notes for reviewers:

It's able to verified with `wansir/ks-controller-manager:latest`.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```
