### PR TITLE
fix e2e auth error

### DIFF
--- a/pkg/models/auth/password.go
+++ b/pkg/models/auth/password.go
@@ -129,7 +129,8 @@ func (p *passwordAuthenticator) Authenticate(_ context.Context, username, passwo
 			return nil, "", err
 		}
 		u := &authuser.DefaultInfo{
-			Name: user.Name,
+			Name:   user.Name,
+			Groups: user.Spec.Groups,
 		}
 		// check if the password is initialized
 		if uninitialized := user.Annotations[iamv1alpha2.UninitializedAnnotation]; uninitialized != "" {

--- a/pkg/models/iam/am/am.go
+++ b/pkg/models/iam/am/am.go
@@ -1091,19 +1091,21 @@ func (am *amOperator) ListGroupRoleBindings(workspace string, query *query.Query
 			result = append(result, roleBinding)
 		}
 	}
-	devOpsProjects, err := am.devopsProjectLister.List(labels.SelectorFromSet(labels.Set{tenantv1alpha1.WorkspaceLabel: workspace}))
-	if err != nil {
-		return nil, err
-	}
-	for _, devOpsProject := range devOpsProjects {
-		roleBindings, err := am.roleBindingGetter.List(devOpsProject.Name, query)
+	if am.devopsProjectLister != nil {
+		devOpsProjects, err := am.devopsProjectLister.List(labels.SelectorFromSet(labels.Set{tenantv1alpha1.WorkspaceLabel: workspace}))
 		if err != nil {
-			klog.Error(err)
 			return nil, err
 		}
-		for _, obj := range roleBindings.Items {
-			roleBinding := obj.(*rbacv1.RoleBinding)
-			result = append(result, roleBinding)
+		for _, devOpsProject := range devOpsProjects {
+			roleBindings, err := am.roleBindingGetter.List(devOpsProject.Name, query)
+			if err != nil {
+				klog.Error(err)
+				return nil, err
+			}
+			for _, obj := range roleBindings.Items {
+				roleBinding := obj.(*rbacv1.RoleBinding)
+				result = append(result, roleBinding)
+			}
 		}
 	}
 	return result, nil

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -155,6 +155,9 @@ func (f *Framework) GenericClient(userAgent string) client.Client {
 		Host:     ctx.Host,
 		Username: ctx.Username,
 		Password: ctx.Password,
+		ContentConfig: rest.ContentConfig{
+			ContentType: runtime.ContentTypeJSON,
+		},
 	}
 
 	rest.AddUserAgent(config, userAgent)

--- a/test/e2e/framework/iam/utils.go
+++ b/test/e2e/framework/iam/utils.go
@@ -34,13 +34,10 @@ import (
 func NewClient(s *runtime.Scheme, user, passsword string) (client.Client, error) {
 
 	ctx := framework.TestContext
-	token, err := getToken(ctx.Host, user, passsword)
-	if err != nil {
-		return nil, err
-	}
 	config := &rest.Config{
-		Host:        ctx.Host,
-		BearerToken: token.AccessToken,
+		Host:     ctx.Host,
+		Username: user,
+		Password: passsword,
 	}
 
 	return generic.New(config, client.Options{Scheme: s})
@@ -48,13 +45,10 @@ func NewClient(s *runtime.Scheme, user, passsword string) (client.Client, error)
 
 func NewRestClient(user, passsword string) (*restclient.RestClient, error) {
 	ctx := framework.TestContext
-	token, err := getToken(ctx.Host, user, passsword)
-	if err != nil {
-		return nil, err
-	}
 	config := &rest.Config{
-		Host:        ctx.Host,
-		BearerToken: token.AccessToken,
+		Host:     ctx.Host,
+		Username: user,
+		Password: passsword,
 	}
 
 	return restclient.NewForConfig(config)

--- a/test/e2e/groups.go
+++ b/test/e2e/groups.go
@@ -27,6 +27,7 @@ import (
 
 	"kubesphere.io/api/iam/v1alpha2"
 
+	"kubesphere.io/kubesphere/pkg/utils/stringutils"
 	"kubesphere.io/kubesphere/test/e2e/constant"
 	"kubesphere.io/kubesphere/test/e2e/framework"
 	"kubesphere.io/kubesphere/test/e2e/framework/iam"
@@ -72,6 +73,11 @@ var _ = Describe("Groups", func() {
 			By("Assign user to Group")
 			_, err = restClient.IamV1alpha2().Groups().CreateBinding(context.TODO(), workspace, group, UserName)
 			framework.ExpectNoError(err)
+
+			Eventually(func() bool {
+				user, err := iam.GetUser(adminClient, UserName)
+				return err == nil && stringutils.FindString(user.Spec.Groups, group) != -1
+			}, timeout, interval).Should(BeTrue())
 
 			By("Creating a new client with user authentication")
 			userClient, err = iam.NewClient(f.GetScheme(), u.Name, constant.DefaultPassword)


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
There are a few issues that caused the e2e testing to be broken.
1. An client id must be provided when using the Oauth authentication. So we change to basic authentication when running the e2e.
2. Fixed that Group permission was not authorized when using the Basic Authentication.
3. Fixed nil error when DevOps component is not enabled.

### Which issue(s) this PR fixes:

Fixes ##4386

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
None
```

### Additional documentation, usage docs, etc.:
```docs

```
