### PR TITLE
OAuthClient with {client_id:kubesphere} must be config,if not, use De…

### DIFF
--- a/cmd/ks-apiserver/app/options/options.go
+++ b/cmd/ks-apiserver/app/options/options.go
@@ -245,6 +245,11 @@ func (s *ServerRunOptions) NewAPIServer(stopCh <-chan struct{}) (*apiserver.APIS
 		klog.Fatalf("unable to create issuer: %v", err)
 	}
 
+	err = s.AuthenticationOptions.OAuthOptions.CheckDefaultOAuthClient()
+	if err != nil {
+		return nil, fmt.Errorf("Check default OAuth client error: %v", err)
+	}
+
 	apiServer.Server = server
 
 	return apiServer, nil


### PR DESCRIPTION
### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
-->

### What this PR does / why we need it:
use  kubesphere as the client_id is kubesphere internal characteristics，user do not know how to config it,
so we need to init a default oauth client, use kubesphere as its name.

### Does this PR introduced a user-facing change?
1. without this RP, you must config auth clients, if not ,will cause the following problem ：
![image](https://user-images.githubusercontent.com/7297771/138672685-e91fff17-8d20-4aaa-ad2e-877dd10bc447.png)

with this RP, you do not need config auth clients, this RP use kubesphere as default client

2.without this RP ,from v3.3.1 upgrade to the latest version without the kubesphere.yaml congfig changed, will cause the problem:“the OAuth client was not found” ,and this RP can fix this problem.
```release-note
Add kubsphere as default OAuthClient.
```