### PR TITLE
Allows to override nginx ingress controller image in kubesphere config

### DIFF
--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -315,12 +315,11 @@ func run(s *options.KubeSphereControllerManagerOptions, ctx context.Context) err
 		klog.Fatalf("Unable to create ResourceQuota controller: %v", err)
 	}
 
-	helmReconciler := helm.Reconciler{}
 	if !s.GatewayOptions.IsEmpty() {
-		helmReconciler.WatchFiles = append(helmReconciler.WatchFiles, s.GatewayOptions.WatchesPath)
-	}
-	if err := helmReconciler.SetupWithManager(mgr); err != nil {
-		klog.Fatalf("Unable to create helm controller: %v", err)
+		helmReconciler := helm.Reconciler{GatewayOptions: s.GatewayOptions}
+		if err := helmReconciler.SetupWithManager(mgr); err != nil {
+			klog.Fatalf("Unable to create helm controller: %v", err)
+		}
 	}
 
 	// TODO(jeff): refactor config with CRD

--- a/config/gateway/values.yaml
+++ b/config/gateway/values.yaml
@@ -14,6 +14,7 @@ controller:
     repository: kubesphere/nginx-ingress-controller
     tag: "v0.48.1"
     pullPolicy: IfNotPresent
+    digest: ""
 
 
 service:

--- a/pkg/controller/helm/helm_controller.go
+++ b/pkg/controller/helm/helm_controller.go
@@ -23,25 +23,26 @@ import (
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"kubesphere.io/kubesphere/pkg/simple/client/gateway"
+
 	"github.com/operator-framework/helm-operator-plugins/pkg/annotation"
 	"github.com/operator-framework/helm-operator-plugins/pkg/reconciler"
 	"github.com/operator-framework/helm-operator-plugins/pkg/watches"
 )
 
 type Reconciler struct {
-	WatchFiles []string
+	GatewayOptions *gateway.Options
 }
 
 // SetupWithManager creates reconilers for each helm package that defined in the WatchFiles.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	var watchKinds []watches.Watch
-	for _, file := range r.WatchFiles {
-		ws, err := watches.Load(file)
-		if err != nil {
-			return err
-		}
-		watchKinds = append(watchKinds, ws...)
+
+	ws, err := watches.Load(r.GatewayOptions.WatchesPath)
+	if err != nil {
+		return err
 	}
+	watchKinds = append(watchKinds, ws...)
 
 	for _, w := range watchKinds {
 		// Register controller with the factory
@@ -58,7 +59,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		r, err := reconciler.New(
 			reconciler.WithChart(*w.Chart),
 			reconciler.WithGroupVersionKind(w.GroupVersionKind),
-			reconciler.WithOverrideValues(w.OverrideValues),
+			reconciler.WithOverrideValues(r.defaultConfiguration()),
 			reconciler.SkipDependentWatches(w.WatchDependentResources != nil && !*w.WatchDependentResources),
 			reconciler.WithMaxConcurrentReconciles(maxConcurrentReconciles),
 			reconciler.WithReconcilePeriod(reconcilePeriod),
@@ -75,4 +76,15 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		klog.Info("configured watch", "gvk", w.GroupVersionKind, "chartPath", w.ChartPath, "maxConcurrentReconciles", maxConcurrentReconciles, "reconcilePeriod", reconcilePeriod)
 	}
 	return nil
+}
+
+func (r *Reconciler) defaultConfiguration() map[string]string {
+	var overrideValues = make(map[string]string)
+	if r.GatewayOptions.Repository != "" {
+		overrideValues["controller.image.repository"] = r.GatewayOptions.Repository
+	}
+	if r.GatewayOptions.Tag != "" {
+		overrideValues["controller.image.tag"] = r.GatewayOptions.Tag
+	}
+	return overrideValues
 }

--- a/pkg/controller/helm/helm_controller_test.go
+++ b/pkg/controller/helm/helm_controller_test.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"kubesphere.io/kubesphere/pkg/simple/client/gateway"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -79,8 +81,7 @@ var _ = Context("Helm reconcier", func() {
 			mgr, err := ctrl.NewManager(cfg, ctrl.Options{MetricsBindAddress: "0"})
 			Expect(err).NotTo(HaveOccurred(), "failed to create a manager")
 
-			reconciler := &Reconciler{}
-			reconciler.WatchFiles = append(reconciler.WatchFiles, f.Name())
+			reconciler := &Reconciler{GatewayOptions: &gateway.Options{WatchesPath: f.Name()}}
 			err = reconciler.SetupWithManager(mgr)
 			Expect(err).NotTo(HaveOccurred(), "failed to setup helm reconciler")
 

--- a/pkg/simple/client/gateway/options.go
+++ b/pkg/simple/client/gateway/options.go
@@ -26,6 +26,8 @@ import (
 type Options struct {
 	WatchesPath string `json:"watchesPath,omitempty" yaml:"watchesPath"`
 	Namespace   string `json:"namespace,omitempty" yaml:"namespace"`
+	Repository  string `json:"repository,omitempty" yaml:"repository"`
+	Tag         string `json:"tag,omitempty" yaml:"tag"`
 }
 
 // NewGatewayOptions creates a default Gateway Option
@@ -33,6 +35,8 @@ func NewGatewayOptions() *Options {
 	return &Options{
 		WatchesPath: "",
 		Namespace:   "", //constants.KubeSphereControlNamespace
+		Repository:  "",
+		Tag:         "",
 	}
 }
 
@@ -59,4 +63,6 @@ func (s *Options) ApplyTo(options *Options) {
 func (s *Options) AddFlags(fs *pflag.FlagSet, c *Options) {
 	fs.StringVar(&s.WatchesPath, "watches-path", c.WatchesPath, "Path to the watches file to use.")
 	fs.StringVar(&s.Namespace, "namespace", c.Namespace, "Working Namespace of the Gateway's Ingress Controller.")
+	fs.StringVar(&s.Repository, "repository", c.Repository, "The Gateway Controller's image repository")
+	fs.StringVar(&s.Tag, "tag", c.Tag, "The Gateway Controller's image tag")
 }


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
When deploymnet kubesphere offline. the all the docker image will be changed to a local repo. So all the docker image need to be configuralbe. 

Added 2 flag  Repository&TAG  to the gateway options. So we can overide the default image in helm chart.

related: https://github.com/kubesphere/ks-installer/pull/1797
### Which issue(s) this PR fixes:
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
None
```

### Additional documentation, usage docs, etc.:
```docs

```
/cc @pixiake 
