### PR TITLE
Support query pods by status

### DIFF
--- a/pkg/models/resources/v1alpha3/pod/pods.go
+++ b/pkg/models/resources/v1alpha3/pod/pods.go
@@ -28,9 +28,10 @@ import (
 )
 
 const (
-	filedNameName    = "nodeName"
-	filedPVCName     = "pvcName"
-	filedServiceName = "serviceName"
+	fieldNodeName    = "nodeName"
+	fieldPVCName     = "pvcName"
+	fieldServiceName = "serviceName"
+	fieldStatus      = "status"
 )
 
 type podsGetter struct {
@@ -82,12 +83,14 @@ func (p *podsGetter) filter(object runtime.Object, filter query.Filter) bool {
 		return false
 	}
 	switch filter.Field {
-	case filedNameName:
+	case fieldNodeName:
 		return pod.Spec.NodeName == string(filter.Value)
-	case filedPVCName:
+	case fieldPVCName:
 		return p.podBindPVC(pod, string(filter.Value))
-	case filedServiceName:
+	case fieldServiceName:
 		return p.podBelongToService(pod, string(filter.Value))
+	case fieldStatus:
+		return string(pod.Status.Phase) == string(filter.Value)
 	default:
 		return v1alpha3.DefaultObjectMetaFilter(pod.ObjectMeta, filter)
 	}

--- a/pkg/models/resources/v1alpha3/pod/pods_test.go
+++ b/pkg/models/resources/v1alpha3/pod/pods_test.go
@@ -51,7 +51,7 @@ func TestListPods(t *testing.T) {
 				Filters:   map[query.Field]query.Value{query.FieldNamespace: query.Value("default")},
 			},
 			&api.ListResult{
-				Items:      []interface{}{foo4, foo3, foo2, foo1},
+				Items:      []interface{}{foo5, foo4, foo3, foo2, foo1},
 				TotalItems: len(pods),
 			},
 			nil,
@@ -68,11 +68,32 @@ func TestListPods(t *testing.T) {
 				Ascending: false,
 				Filters: map[query.Field]query.Value{
 					query.FieldNamespace: query.Value("default"),
-					filedPVCName:         query.Value(foo4.Spec.Volumes[0].PersistentVolumeClaim.ClaimName),
+					fieldPVCName:         query.Value(foo4.Spec.Volumes[0].PersistentVolumeClaim.ClaimName),
 				},
 			},
 			&api.ListResult{
 				Items:      []interface{}{foo4},
+				TotalItems: 1,
+			},
+			nil,
+		},
+		{
+			"test status filter",
+			"default",
+			&query.Query{
+				Pagination: &query.Pagination{
+					Limit:  10,
+					Offset: 0,
+				},
+				SortBy:    query.FieldName,
+				Ascending: false,
+				Filters: map[query.Field]query.Value{
+					query.FieldNamespace: query.Value("default"),
+					fieldStatus:          query.Value(corev1.PodRunning),
+				},
+			},
+			&api.ListResult{
+				Items:      []interface{}{foo5},
 				TotalItems: 1,
 			},
 			nil,
@@ -133,7 +154,16 @@ var (
 			},
 		},
 	}
-	pods = []interface{}{foo1, foo2, foo3, foo4}
+	foo5 = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo5",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+	pods = []interface{}{foo1, foo2, foo3, foo4, foo5}
 )
 
 func prepare() v1alpha3.Interface {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind feature

### What this PR does / why we need it:

This PR adds status filtering to the `kapis/resources.kubesphere.io/v1alpha3/pods` API, which now allows you to filter pods with a specific status by the `status` query parameter, eg: 

```
/kapis/resources.kubesphere.io/v1alpha3/pods?sortBy=startTime&limit=10&status=Running
```

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Support query pods by status.
```

/cc @zryfish 
