### PR TITLE
Namespace should not be filterd for Cluster Gateway

### DIFF
--- a/pkg/simple/client/monitoring/prometheus/promql.go
+++ b/pkg/simple/client/monitoring/prometheus/promql.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"strings"
 
+	"kubesphere.io/kubesphere/pkg/constants"
 	"kubesphere.io/kubesphere/pkg/simple/client/monitoring"
 )
 
@@ -482,13 +483,20 @@ func makeIngressMetricExpr(tmpl string, o monitoring.QueryOptions) string {
 	// For monitoring ingress in the specific namespace
 	// GET /namespaces/{namespace}/ingress/{ingress} or
 	// GET /namespaces/{namespace}/ingress
-	if o.NamespaceName != "" {
+	if o.NamespaceName != constants.KubeSphereNamespace {
 		if o.Ingress != "" {
 			ingressSelector = fmt.Sprintf(`exported_namespace="%s", ingress="%s"`, o.NamespaceName, o.Ingress)
 		} else {
 			ingressSelector = fmt.Sprintf(`exported_namespace="%s", ingress=~"%s"`, o.NamespaceName, o.ResourceFilter)
 		}
+	} else {
+		if o.Ingress != "" {
+			ingressSelector = fmt.Sprintf(`ingress="%s"`, o.Ingress)
+		} else {
+			ingressSelector = fmt.Sprintf(`ingress=~"%s"`, o.ResourceFilter)
+		}
 	}
+
 	// job is a reqiuried filter
 	// GET /namespaces/{namespace}/ingress?job=xxx&pod=xxx
 	if o.Job != "" {


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

When the Cluster Gateway is created, it will monitor ingress from all namespaces. So we should not add the namespace filter when querying cluster gateway metrics.

### Which issue(s) this PR fixes:
Fixes #4451

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
 Fixed: No metrics show in cluster gateway dashboard
```

### Additional documentation, usage docs, etc.:

```docs

```
