### PR TITLE
Convert compoent  kubeedge to edgeruntime

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -73,6 +73,7 @@ import (
 	configv1alpha2 "kubesphere.io/kubesphere/pkg/kapis/config/v1alpha2"
 	devopsv1alpha2 "kubesphere.io/kubesphere/pkg/kapis/devops/v1alpha2"
 	devopsv1alpha3 "kubesphere.io/kubesphere/pkg/kapis/devops/v1alpha3"
+	edgeruntimev1alpha1 "kubesphere.io/kubesphere/pkg/kapis/edgeruntime/v1alpha1"
 	gatewayv1alpha1 "kubesphere.io/kubesphere/pkg/kapis/gateway/v1alpha1"
 	iamapi "kubesphere.io/kubesphere/pkg/kapis/iam/v1alpha2"
 	kubeedgev1alpha1 "kubesphere.io/kubesphere/pkg/kapis/kubeedge/v1alpha1"
@@ -254,6 +255,7 @@ func (s *APIServer) installKubeSphereAPIs() {
 		s.KubernetesClient.Prometheus(), s.AlertingClient, s.Config.AlertingOptions))
 	urlruntime.Must(version.AddToContainer(s.container, s.KubernetesClient.Discovery()))
 	urlruntime.Must(kubeedgev1alpha1.AddToContainer(s.container, s.Config.KubeEdgeOptions.Endpoint))
+	urlruntime.Must(edgeruntimev1alpha1.AddToContainer(s.container, s.Config.EdgeRuntimeOptions.Endpoint))
 	urlruntime.Must(notificationkapisv2beta1.AddToContainer(s.container, s.InformerFactory, s.KubernetesClient.Kubernetes(),
 		s.KubernetesClient.KubeSphere()))
 	urlruntime.Must(notificationkapisv2beta2.AddToContainer(s.container, s.Config.NotificationOptions))

--- a/pkg/apiserver/config/config.go
+++ b/pkg/apiserver/config/config.go
@@ -33,6 +33,7 @@ import (
 	"kubesphere.io/kubesphere/pkg/simple/client/auditing"
 	"kubesphere.io/kubesphere/pkg/simple/client/cache"
 	"kubesphere.io/kubesphere/pkg/simple/client/devops/jenkins"
+	"kubesphere.io/kubesphere/pkg/simple/client/edgeruntime"
 	"kubesphere.io/kubesphere/pkg/simple/client/events"
 	"kubesphere.io/kubesphere/pkg/simple/client/gateway"
 	"kubesphere.io/kubesphere/pkg/simple/client/gpu"
@@ -107,6 +108,7 @@ type Config struct {
 	AlertingOptions       *alerting.Options       `json:"alerting,omitempty" yaml:"alerting,omitempty" mapstructure:"alerting"`
 	NotificationOptions   *notification.Options   `json:"notification,omitempty" yaml:"notification,omitempty" mapstructure:"notification"`
 	KubeEdgeOptions       *kubeedge.Options       `json:"kubeedge,omitempty" yaml:"kubeedge,omitempty" mapstructure:"kubeedge"`
+	EdgeRuntimeOptions    *edgeruntime.Options    `json:"edgeruntime,omitempty" yaml:"edgeruntime,omitempty" mapstructure:"edgeruntime"`
 	MeteringOptions       *metering.Options       `json:"metering,omitempty" yaml:"metering,omitempty" mapstructure:"metering"`
 	GatewayOptions        *gateway.Options        `json:"gateway,omitempty" yaml:"gateway,omitempty" mapstructure:"gateway"`
 	GPUOptions            *gpu.Options            `json:"gpu,omitempty" yaml:"gpu,omitempty" mapstructure:"gpu"`
@@ -135,6 +137,7 @@ func New() *Config {
 		EventsOptions:         events.NewEventsOptions(),
 		AuditingOptions:       auditing.NewAuditingOptions(),
 		KubeEdgeOptions:       kubeedge.NewKubeEdgeOptions(),
+		EdgeRuntimeOptions:    edgeruntime.NewEdgeRuntimeOptions(),
 		MeteringOptions:       metering.NewMeteringOptions(),
 		GatewayOptions:        gateway.NewGatewayOptions(),
 		GPUOptions:            gpu.NewGPUOptions(),
@@ -305,6 +308,10 @@ func (conf *Config) stripEmptyOptions() {
 
 	if conf.KubeEdgeOptions != nil && conf.KubeEdgeOptions.Endpoint == "" {
 		conf.KubeEdgeOptions = nil
+	}
+
+	if conf.EdgeRuntimeOptions != nil && conf.EdgeRuntimeOptions.Endpoint == "" {
+		conf.EdgeRuntimeOptions = nil
 	}
 
 	if conf.GPUOptions != nil && len(conf.GPUOptions.Kinds) == 0 {

--- a/pkg/apiserver/config/config_test.go
+++ b/pkg/apiserver/config/config_test.go
@@ -38,6 +38,7 @@ import (
 	"kubesphere.io/kubesphere/pkg/simple/client/auditing"
 	"kubesphere.io/kubesphere/pkg/simple/client/cache"
 	"kubesphere.io/kubesphere/pkg/simple/client/devops/jenkins"
+	edgeruntime "kubesphere.io/kubesphere/pkg/simple/client/edgeruntime"
 	"kubesphere.io/kubesphere/pkg/simple/client/events"
 	"kubesphere.io/kubesphere/pkg/simple/client/gateway"
 	"kubesphere.io/kubesphere/pkg/simple/client/gpu"
@@ -182,6 +183,9 @@ func newTestConfig() (*Config, error) {
 		KubeEdgeOptions: &kubeedge.Options{
 			Endpoint: "http://edge-watcher.kubeedge.svc/api/",
 		},
+		EdgeRuntimeOptions: &edgeruntime.Options{
+			Endpoint: "http://edgeservice.kubeedge.svc/api/",
+		},
 		MeteringOptions: &metering.Options{
 			RetentionDay: "7d",
 		},
@@ -277,6 +281,7 @@ func TestStripEmptyOptions(t *testing.T) {
 	config.EventsOptions = &events.Options{Host: ""}
 	config.AuditingOptions = &auditing.Options{Host: ""}
 	config.KubeEdgeOptions = &kubeedge.Options{Endpoint: ""}
+	config.EdgeRuntimeOptions = &edgeruntime.Options{Endpoint: ""}
 
 	config.stripEmptyOptions()
 
@@ -294,7 +299,8 @@ func TestStripEmptyOptions(t *testing.T) {
 		config.MultiClusterOptions != nil ||
 		config.EventsOptions != nil ||
 		config.AuditingOptions != nil ||
-		config.KubeEdgeOptions != nil {
+		config.KubeEdgeOptions != nil ||
+		config.EdgeRuntimeOptions != nil {
 		t.Fatal("config stripEmptyOptions failed")
 	}
 }

--- a/pkg/kapis/edgeruntime/v1alpha1/register.go
+++ b/pkg/kapis/edgeruntime/v1alpha1/register.go
@@ -24,8 +24,7 @@ import (
 )
 
 // there are no versions specified cause we want to proxy all versions of requests to backend service
-// Deprecated: this api group would be removed in v4.0
-var GroupVersion = schema.GroupVersion{Group: "kubeedge.kubesphere.io", Version: ""}
+var GroupVersion = schema.GroupVersion{Group: "edgeruntime.kubesphere.io", Version: ""}
 
 func AddToContainer(container *restful.Container, endpoint string) error {
 	proxy, err := generic.NewGenericProxy(endpoint, GroupVersion.Group, GroupVersion.Version)

--- a/pkg/kapis/generic/generic.go
+++ b/pkg/kapis/generic/generic.go
@@ -41,6 +41,9 @@ type genericProxy struct {
 
 	// api version
 	Version string
+
+	// mark as desprecated
+	desprecated bool
 }
 
 func NewGenericProxy(endpoint string, groupName string, version string) (*genericProxy, error) {
@@ -57,6 +60,10 @@ func NewGenericProxy(endpoint string, groupName string, version string) (*generi
 		GroupName: groupName,
 		Version:   version,
 	}, nil
+}
+
+func (g *genericProxy) SetProxyDesprecated() {
+	g.desprecated = true
 }
 
 // currently, we only support proxy GET/PUT/POST/DELETE/PATCH.
@@ -93,6 +100,10 @@ func (g *genericProxy) AddToContainer(container *restful.Container) error {
 }
 
 func (g *genericProxy) handler(request *restful.Request, response *restful.Response) {
+	if g.desprecated {
+		klog.Warning(fmt.Sprintf("This proxy group %s has deprecated", g.GroupName))
+	}
+
 	u := g.makeURL(request)
 
 	httpProxy := proxy.NewUpgradeAwareHandler(u, http.DefaultTransport, false, false, &errorResponder{})

--- a/pkg/kapis/kubeedge/v1alpha1/register.go
+++ b/pkg/kapis/kubeedge/v1alpha1/register.go
@@ -33,5 +33,7 @@ func AddToContainer(container *restful.Container, endpoint string) error {
 		return nil
 	}
 
+	proxy.SetProxyDesprecated()
+
 	return proxy.AddToContainer(container)
 }

--- a/pkg/simple/client/edgeruntime/options.go
+++ b/pkg/simple/client/edgeruntime/options.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 KubeSphere Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edgeruntime
+
+import (
+	"github.com/spf13/pflag"
+
+	"kubesphere.io/kubesphere/pkg/utils/reflectutils"
+)
+
+type Options struct {
+	Endpoint string `json:"endpoint" yaml:"endpoint"`
+}
+
+func NewEdgeRuntimeOptions() *Options {
+	return &Options{
+		Endpoint: "",
+	}
+}
+
+func (o *Options) ApplyTo(options *Options) {
+	reflectutils.Override(options, o)
+}
+
+func (o *Options) Validate() []error {
+	errs := []error{}
+
+	return errs
+}
+
+func (o *Options) AddFlags(fs *pflag.FlagSet, c *Options) {
+	fs.StringVar(&o.Endpoint, "edgeservice-endpoint", c.Endpoint,
+		"edgeservice endpoint for edgeruntime v1alpha1.")
+}


### PR DESCRIPTION
Signed-off-by: zhu733756 <zhu733756@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind feature
/kind api-change


### What this PR does / why we need it:

To support more edge frameworks as optional.  The former component kubeedge needs to be converted to EdgeRuntime. Also, the proxy service has a change:
```
edgeruntime:
      endpoint: http://edgeservice.kubeedge.svc/api/
```

See #https://github.com/kubesphere/ks-installer/pull/1829 for a detailed introduction.


### Special notes for reviewers:
```
None
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
KubeEdge proxy service changes to http://edgeservice.kubeedge.svc/api/
```

As for console, API group changes from kubeedge.kubesphere.io to edgeruntime.kubesphere.io, no other breaks.
