### PR TITLE
fix: Account password settings can have no capital letters

### DIFF
--- a/config/crds/iam.kubesphere.io_users.yaml
+++ b/config/crds/iam.kubesphere.io_users.yaml
@@ -58,6 +58,9 @@ spec:
                 type: string
               password:
                 description: password will be encrypted by mutating admission webhook
+                maxLength: 64
+                minLength: 6
+                pattern: ^(.*[a-z].*[A-Z].*[0-9].*)$|^(.*[a-z].*[0-9].*[A-Z].*)$|^(.*[A-Z].*[a-z].*[0-9].*)$|^(.*[A-Z].*[0-9].*[a-z].*)$|^(.*[0-9].*[a-z].*[A-Z].*)$|^(.*[0-9].*[A-Z].*[a-z].*)$|^(\$2[ayb]\$.{56})$
                 type: string
             required:
             - email

--- a/staging/src/kubesphere.io/api/iam/v1alpha2/types.go
+++ b/staging/src/kubesphere.io/api/iam/v1alpha2/types.go
@@ -124,7 +124,20 @@ type UserSpec struct {
 	DisplayName string `json:"displayName,omitempty"`
 	// +optional
 	Groups []string `json:"groups,omitempty"`
+
 	// password will be encrypted by mutating admission webhook
+	// +kubebuilder:validation:MinLength=6
+	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:Pattern=`^(.*[a-z].*[A-Z].*[0-9].*)$|^(.*[a-z].*[0-9].*[A-Z].*)$|^(.*[A-Z].*[a-z].*[0-9].*)$|^(.*[A-Z].*[0-9].*[a-z].*)$|^(.*[0-9].*[a-z].*[A-Z].*)$|^(.*[0-9].*[A-Z].*[a-z].*)$|^(\$2[ayb]\$.{56})$`
+	// Password pattern is tricky here.
+	// The rule is simple: length between [6,64], at least one uppercase letter, one lowercase letter, one digit.
+	// The regexp in console(javascript) is quite straightforward: ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^]{6,64}$
+	// But in Go, we don't have ?= (back tracking) capability in regexp (also in CRD validation pattern)
+	// So we adopted an alternative scheme to achieve.
+	// Use 6 different regexp to combine to achieve the same effect.
+	// These six schemes enumerate the arrangement of numbers, uppercase letters, and lowercase letters
+	// that appear for the first time.
+	// Last but not least, the bcrypt string is also included to match the encrypted password. ^(\$2[ayb]\$.{56})$
 	EncryptedPassword string `json:"password,omitempty"`
 }
 

--- a/staging/src/kubesphere.io/api/iam/v1alpha2/types.go
+++ b/staging/src/kubesphere.io/api/iam/v1alpha2/types.go
@@ -135,8 +135,13 @@ type UserSpec struct {
 	// But in Go, we don't have ?= (back tracking) capability in regexp (also in CRD validation pattern)
 	// So we adopted an alternative scheme to achieve.
 	// Use 6 different regexp to combine to achieve the same effect.
-	// These six schemes enumerate the arrangement of numbers, uppercase letters, and lowercase letters
-	// that appear for the first time.
+	// These six schemes enumerate the arrangement of numbers, uppercase letters, and lowercase letters that appear for the first time.
+	// - ^(.*[a-z].*[A-Z].*[0-9].*)$ stands for lowercase letter comes first, then followed by an uppercase letter, then a digit.
+	// - ^(.*[a-z].*[0-9].*[A-Z].*)$ stands for lowercase letter comes first, then followed by a digit, then an uppercase leeter.
+	// - ^(.*[A-Z].*[a-z].*[0-9].*)$ ...
+	// - ^(.*[A-Z].*[0-9].*[a-z].*)$ ...
+	// - ^(.*[0-9].*[a-z].*[A-Z].*)$ ...
+	// - ^(.*[0-9].*[A-Z].*[a-z].*)$ ...
 	// Last but not least, the bcrypt string is also included to match the encrypted password. ^(\$2[ayb]\$.{56})$
 	EncryptedPassword string `json:"password,omitempty"`
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4242

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Enable user password pattern checking. (as same as the console does)
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Valid password(as same as the console) should contains:
- at least one capital letter,
- at least one small letter,
- at least one digit.
- and length is between 6 and 64.

This rule is written in kubesphere/console password pattern:
export const PATTERN_PASSWORD = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^]{6,64}$/

Use CRD validation pattern to implement this.

Password pattern is tricky here.
The regexp in console(javascript) is quite straightforward: ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^]{6,64}$
But in Go, we don't have ?= (back tracking) capability in regexp (also in CRD validation pattern)

So we have to adopted an alternative scheme to achieve.
We use 6 different regexp to combine to achieve the same effect.

These six schemes enumerate the arrangement of numbers, uppercase letters, and lowercase letters that appear for the first time.

- ^(.*[a-z].*[A-Z].*[0-9].*)$ stands for lowercase letter comes first, then followed by an uppercase letter, then a digit.
- ^(.*[a-z].*[0-9].*[A-Z].*)$ stands for lowercase letter comes first, then followed by a digit, then an uppercase leeter.
- ^(.*[A-Z].*[a-z].*[0-9].*)$
- ^(.*[A-Z].*[0-9].*[a-z].*)$
- ^(.*[0-9].*[a-z].*[A-Z].*)$
- ^(.*[0-9].*[A-Z].*[a-z].*)$

Last but not least, the bcrypt string is also included to match the encrypted password. ^(\$2[ayb]\$.{56})$
```
