### PR TITLE
Add update cluster kubeconfig API

### DIFF
--- a/pkg/api/cluster/v1alpha1/types.go
+++ b/pkg/api/cluster/v1alpha1/types.go
@@ -1,0 +1,5 @@
+package v1alpha1
+
+type UpdateClusterRequest struct {
+	KubeConfig []byte `json:"kubeconfig"`
+}

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	rt "runtime"
+	"strconv"
 	"time"
 
 	"kubesphere.io/kubesphere/pkg/utils/iputil"
@@ -33,8 +34,6 @@ import (
 	"kubesphere.io/api/notification/v2beta1"
 
 	openpitrixv2alpha1 "kubesphere.io/kubesphere/pkg/kapis/openpitrix/v2alpha1"
-
-	"strconv"
 
 	"github.com/emicklei/go-restful"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -228,6 +227,7 @@ func (s *APIServer) installKubeSphereAPIs() {
 		s.KubernetesClient.KubeSphere(), s.EventsClient, s.LoggingClient, s.AuditingClient, amOperator, rbacAuthorizer, s.MonitoringClient, s.RuntimeCache, s.Config.MeteringOptions))
 	urlruntime.Must(terminalv1alpha2.AddToContainer(s.container, s.KubernetesClient.Kubernetes(), rbacAuthorizer, s.KubernetesClient.Config()))
 	urlruntime.Must(clusterkapisv1alpha1.AddToContainer(s.container,
+		s.KubernetesClient.KubeSphere(),
 		s.InformerFactory.KubernetesSharedInformerFactory(),
 		s.InformerFactory.KubeSphereSharedInformerFactory(),
 		s.Config.MultiClusterOptions.ProxyPublishService,

--- a/pkg/kapis/cluster/v1alpha1/handler_test.go
+++ b/pkg/kapis/cluster/v1alpha1/handler_test.go
@@ -252,7 +252,7 @@ func TestGeranteAgentDeployment(t *testing.T) {
 	for _, testCase := range testCases {
 
 		t.Run(testCase.description, func(t *testing.T) {
-			h := newHandler(informersFactory.KubernetesSharedInformerFactory(),
+			h := newHandler(ksclient, informersFactory.KubernetesSharedInformerFactory(),
 				informersFactory.KubeSphereSharedInformerFactory(),
 				proxyService,
 				"",
@@ -333,7 +333,7 @@ func TestValidateKubeConfig(t *testing.T) {
 	informersFactory.KubernetesSharedInformerFactory().Core().V1().Services().Informer().GetIndexer().Add(service)
 	informersFactory.KubeSphereSharedInformerFactory().Cluster().V1alpha1().Clusters().Informer().GetIndexer().Add(cluster)
 
-	h := newHandler(informersFactory.KubernetesSharedInformerFactory(),
+	h := newHandler(ksclient, informersFactory.KubernetesSharedInformerFactory(),
 		informersFactory.KubeSphereSharedInformerFactory(),
 		proxyService,
 		"",
@@ -409,7 +409,7 @@ func TestValidateMemberClusterConfiguration(t *testing.T) {
 	informersFactory.KubeSphereSharedInformerFactory().Cluster().V1alpha1().Clusters().Informer().GetIndexer().Add(cluster)
 	informersFactory.KubernetesSharedInformerFactory().Core().V1().ConfigMaps().Informer().GetIndexer().Add(hostCm)
 
-	h := newHandler(informersFactory.KubernetesSharedInformerFactory(),
+	h := newHandler(ksclient, informersFactory.KubernetesSharedInformerFactory(),
 		informersFactory.KubeSphereSharedInformerFactory(),
 		proxyService,
 		"",

--- a/tools/cmd/doc-gen/main.go
+++ b/tools/cmd/doc-gen/main.go
@@ -118,7 +118,7 @@ func generateSwaggerJson() []byte {
 	informerFactory := informers.NewNullInformerFactory()
 
 	urlruntime.Must(oauth.AddToContainer(container, nil, nil, nil, nil, nil, nil))
-	urlruntime.Must(clusterkapisv1alpha1.AddToContainer(container, informerFactory.KubernetesSharedInformerFactory(),
+	urlruntime.Must(clusterkapisv1alpha1.AddToContainer(container, clientsets.KubeSphere(), informerFactory.KubernetesSharedInformerFactory(),
 		informerFactory.KubeSphereSharedInformerFactory(), "", "", ""))
 	urlruntime.Must(devopsv1alpha2.AddToContainer(container, ""))
 	urlruntime.Must(devopsv1alpha3.AddToContainer(container, ""))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind feature

### What this PR does / why we need it:

Part of #4426

This patch adds a new API that allows users to update the member cluster's kubeconfig:

```
PUT /kapis/cluster.kubesphere.io/v1alpha1/clusters/{name}/kubeconfig

{
  "kubeconfig": "base64 encoded data"
}
```

This API will only allow to update member clusters that use direct mode, for member clusters that use proxy mode, we don't need to update the kubeconfig, if the certs expired, just restart the tower component in the host cluster, it will renew the cert.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:

The API to detect whether the cluster kubeconfig certificate has expired will be submitted in the next PR.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Add update cluster kubeconfig API.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @zryfish 