### PR TITLE
Sync the expiration time of kubeconfig cert file of the cluster

### DIFF
--- a/pkg/kapis/cluster/v1alpha1/handler.go
+++ b/pkg/kapis/cluster/v1alpha1/handler.go
@@ -41,8 +41,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-
 	"kubesphere.io/api/cluster/v1alpha1"
 
 	"kubesphere.io/kubesphere/pkg/api"
@@ -51,6 +49,7 @@ import (
 	kubesphere "kubesphere.io/kubesphere/pkg/client/clientset/versioned"
 	"kubesphere.io/kubesphere/pkg/client/informers/externalversions"
 	clusterlister "kubesphere.io/kubesphere/pkg/client/listers/cluster/v1alpha1"
+	"kubesphere.io/kubesphere/pkg/utils/k8sutil"
 	"kubesphere.io/kubesphere/pkg/version"
 )
 
@@ -286,7 +285,7 @@ func (h *handler) updateKubeConfig(request *restful.Request, response *restful.R
 		api.HandleBadRequest(response, request, fmt.Errorf("cluster kubeconfig MUST NOT be empty"))
 		return
 	}
-	config, err := loadKubeConfigFromBytes(req.KubeConfig)
+	config, err := k8sutil.LoadKubeConfigFromBytes(req.KubeConfig)
 	if err != nil {
 		api.HandleBadRequest(response, request, err)
 		return
@@ -363,7 +362,7 @@ func (h *handler) validateCluster(request *restful.Request, response *restful.Re
 
 // validateKubeConfig takes base64 encoded kubeconfig and check its validity
 func (h *handler) validateKubeConfig(kubeconfig []byte) error {
-	config, err := loadKubeConfigFromBytes(kubeconfig)
+	config, err := k8sutil.LoadKubeConfigFromBytes(kubeconfig)
 	if err != nil {
 		return err
 	}
@@ -393,20 +392,6 @@ func (h *handler) validateKubeConfig(kubeconfig []byte) error {
 	return err
 }
 
-func loadKubeConfigFromBytes(kubeconfig []byte) (*rest.Config, error) {
-	clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
-	if err != nil {
-		return nil, err
-	}
-
-	config, err := clientConfig.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	return config, nil
-}
-
 // validateKubeSphereAPIServer uses version api to check the accessibility
 // If kubesphere apiserver endpoint is not provided, use kube-apiserver proxy instead
 func validateKubeSphereAPIServer(ksEndpoint string, kubeconfig []byte) (*version.Info, error) {
@@ -426,7 +411,7 @@ func validateKubeSphereAPIServer(ksEndpoint string, kubeconfig []byte) (*version
 			return nil, err
 		}
 	} else {
-		config, err := loadKubeConfigFromBytes(kubeconfig)
+		config, err := k8sutil.LoadKubeConfigFromBytes(kubeconfig)
 		if err != nil {
 			return nil, err
 		}
@@ -485,7 +470,7 @@ func (h *handler) validateMemberClusterConfiguration(memberKubeconfig []byte) er
 
 // getMemberClusterConfig returns KubeSphere running config by the given member cluster kubeconfig
 func (h *handler) getMemberClusterConfig(kubeconfig []byte) (*config.Config, error) {
-	config, err := loadKubeConfigFromBytes(kubeconfig)
+	config, err := k8sutil.LoadKubeConfigFromBytes(kubeconfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kapis/cluster/v1alpha1/handler_test.go
+++ b/pkg/kapis/cluster/v1alpha1/handler_test.go
@@ -41,6 +41,7 @@ import (
 
 	"kubesphere.io/kubesphere/pkg/client/clientset/versioned/fake"
 	"kubesphere.io/kubesphere/pkg/informers"
+	"kubesphere.io/kubesphere/pkg/utils/k8sutil"
 	"kubesphere.io/kubesphere/pkg/version"
 )
 
@@ -339,7 +340,7 @@ func TestValidateKubeConfig(t *testing.T) {
 		"",
 		agentImage)
 
-	config, err := loadKubeConfigFromBytes([]byte(base64EncodedKubeConfig))
+	config, err := k8sutil.LoadKubeConfigFromBytes([]byte(base64EncodedKubeConfig))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -415,7 +416,7 @@ func TestValidateMemberClusterConfiguration(t *testing.T) {
 		"",
 		agentImage)
 
-	config, err := loadKubeConfigFromBytes([]byte(base64EncodedKubeConfig))
+	config, err := k8sutil.LoadKubeConfigFromBytes([]byte(base64EncodedKubeConfig))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/utils/k8sutil/k8sutil.go
+++ b/pkg/utils/k8sutil/k8sutil.go
@@ -18,6 +18,8 @@ package k8sutil
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	tenantv1alpha1 "kubesphere.io/api/tenant/v1alpha1"
 	tenantv1alpha2 "kubesphere.io/api/tenant/v1alpha2"
@@ -54,4 +56,19 @@ func GetWorkspaceOwnerName(ownerReferences []metav1.OwnerReference) string {
 		}
 	}
 	return ""
+}
+
+// LoadKubeConfigFromBytes parses the kubeconfig yaml data to the rest.Config struct.
+func LoadKubeConfigFromBytes(kubeconfig []byte) (*rest.Config, error) {
+	clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
 }

--- a/staging/src/kubesphere.io/api/cluster/v1alpha1/cluster_types.go
+++ b/staging/src/kubesphere.io/api/cluster/v1alpha1/cluster_types.go
@@ -121,6 +121,9 @@ const (
 
 	// Openpitrix runtime is created
 	ClusterOpenPitrixRuntimeReady ClusterConditionType = "OpenPitrixRuntimeReady"
+
+	// ClusterKubeConfigCertExpiresInSevenDays indicates that the cluster certificate is about to expire.
+	ClusterKubeConfigCertExpiresInSevenDays ClusterConditionType = "KubeConfigCertExpiresInSevenDays"
 )
 
 type ClusterCondition struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind feature

### What this PR does / why we need it:

Part of #4426

This patch adds a new status condition `KubeConfigCertExpiresInSevenDays` for a cluster:

```yaml
status:
  conditions:
  - lastTransitionTime: "2022-01-05T08:46:14Z"
    lastUpdateTime: "2022-01-05T08:46:14Z"
    message: 2022-10-25 08:24:09 +0000 UTC
    reason: KubeConfigCertExpiresInSevenDays
    status: "False"
    type: KubeConfigCertExpiresInSevenDays
  - lastTransitionTime: "2022-01-05T08:51:47Z"
    lastUpdateTime: "2022-01-05T08:51:47Z"
    message: Cluster has joined federation control plane successfully
    status: "True"
    type: Federated
  - lastTransitionTime: "2022-01-05T08:51:47Z"
    lastUpdateTime: "2022-01-05T08:51:47Z"
    message: Cluster is available now
    reason: Ready
    status: "True"
    type: Ready
```

The front end can determine whether the cluster certificate is about to expire based on the `KubeConfigCertExpiresInSevenDays` condition status, and time in `message` is the expiration time, we can show the certificate expiration note on the page.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Sync the expiration time of kubeconfig cert file of the cluster.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @zryfish 
