### PR TITLE
Fix: deepcopy before mutating shared objects

### DIFF
--- a/pkg/models/resources/v1alpha2/persistentvolumeclaim/persistentvolumeclaims.go
+++ b/pkg/models/resources/v1alpha2/persistentvolumeclaim/persistentvolumeclaims.go
@@ -123,6 +123,7 @@ func (s *persistentVolumeClaimSearcher) Search(namespace string, conditions *par
 
 	r := make([]interface{}, 0)
 	for _, i := range result {
+		i = i.DeepCopy()
 		inUse := s.countPods(i.Name, i.Namespace)
 		isSnapshotAllow := s.isSnapshotAllowed(i.GetAnnotations()["volume.beta.kubernetes.io/storage-provisioner"])
 		if i.Annotations == nil {

--- a/pkg/models/resources/v1alpha2/storageclass/storageclasses.go
+++ b/pkg/models/resources/v1alpha2/storageclass/storageclasses.go
@@ -91,6 +91,7 @@ func (s *storageClassesSearcher) Search(namespace string, conditions *params.Con
 
 	r := make([]interface{}, 0)
 	for _, i := range result {
+		i = i.DeepCopy()
 		count := s.countPersistentVolumeClaims(i.Name)
 		if i.Annotations == nil {
 			i.Annotations = make(map[string]string)

--- a/pkg/models/resources/v1alpha2/storageclass/storageclasses_test.go
+++ b/pkg/models/resources/v1alpha2/storageclass/storageclasses_test.go
@@ -22,7 +22,18 @@ var (
 		},
 	}
 
+	sc1Expected = &v1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sc1",
+			Annotations: map[string]string{
+				"kubesphere.io/pvc-count": "1",
+			},
+		},
+	}
+
 	scs = []interface{}{sc1}
+
+	scsExpected = []interface{}{sc1Expected}
 
 	pvc1 = &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
@@ -85,7 +96,7 @@ func TestSearch(t *testing.T) {
 			conditions:  &params.Conditions{},
 			orderBy:     "name",
 			reverse:     true,
-			expected:    scs,
+			expected:    scsExpected,
 			expectedErr: nil,
 		},
 	}

--- a/pkg/models/resources/v1alpha3/node/nodes_test.go
+++ b/pkg/models/resources/v1alpha3/node/nodes_test.go
@@ -145,8 +145,6 @@ func TestNodesGetterGet(t *testing.T) {
 	}
 	nodeGot := got.(*corev1.Node)
 
-	// ignore last-annotated-at annotation
-	delete(nodeGot.Annotations, nodeAnnotatedAt)
 	if diff := cmp.Diff(nodeGot.Annotations, expectedAnnotations); len(diff) != 0 {
 		t.Errorf("%T, diff(-got, +expected), %v", expectedAnnotations, nodeGot.Annotations)
 	}
@@ -170,7 +168,7 @@ func TestListNodes(t *testing.T) {
 			},
 			&api.ListResult{
 				Items: []interface{}{
-					node2,
+					node2Expected,
 				},
 				TotalItems: 1,
 			},
@@ -187,7 +185,7 @@ func TestListNodes(t *testing.T) {
 			},
 			&api.ListResult{
 				Items: []interface{}{
-					node1,
+					node1Expected,
 				},
 				TotalItems: 1,
 			},
@@ -204,7 +202,7 @@ func TestListNodes(t *testing.T) {
 			},
 			&api.ListResult{
 				Items: []interface{}{
-					node2,
+					node2Expected,
 				},
 				TotalItems: 1,
 			},
@@ -239,6 +237,17 @@ var (
 			Unschedulable: true,
 		},
 	}
+
+	node1Expected = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "node1",
+			Annotations: map[string]string{},
+		},
+		Spec: corev1.NodeSpec{
+			Unschedulable: true,
+		},
+	}
+
 	node2 = &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node2",
@@ -247,6 +256,17 @@ var (
 			Unschedulable: false,
 		},
 	}
+
+	node2Expected = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "node2",
+			Annotations: map[string]string{},
+		},
+		Spec: corev1.NodeSpec{
+			Unschedulable: false,
+		},
+	}
+
 	nodes = []*corev1.Node{node1, node2}
 )
 

--- a/pkg/models/resources/v1alpha3/persistentvolumeclaim/persistentvolumeclaim.go
+++ b/pkg/models/resources/v1alpha3/persistentvolumeclaim/persistentvolumeclaim.go
@@ -53,6 +53,8 @@ func (p *persistentVolumeClaimGetter) Get(namespace, name string) (runtime.Objec
 	if err != nil {
 		return pvc, err
 	}
+	// we should never mutate the shared objects from informers
+	pvc = pvc.DeepCopy()
 	p.annotatePVC(pvc)
 	return pvc, nil
 }
@@ -65,6 +67,7 @@ func (p *persistentVolumeClaimGetter) List(namespace string, query *query.Query)
 
 	var result []runtime.Object
 	for _, pvc := range all {
+		pvc = pvc.DeepCopy()
 		p.annotatePVC(pvc)
 		result = append(result, pvc)
 	}

--- a/pkg/models/resources/v1alpha3/persistentvolumeclaim/persistentvolumeclaim_test.go
+++ b/pkg/models/resources/v1alpha3/persistentvolumeclaim/persistentvolumeclaim_test.go
@@ -37,7 +37,7 @@ var (
 	testStorageClassName = "test-csi"
 )
 
-func TestListPods(t *testing.T) {
+func TestListPVCs(t *testing.T) {
 	tests := []struct {
 		description string
 		namespace   string
@@ -58,7 +58,7 @@ func TestListPods(t *testing.T) {
 				Filters:   map[query.Field]query.Value{query.FieldNamespace: query.Value("default")},
 			},
 			&api.ListResult{
-				Items:      []interface{}{pvc3, pvc2, pvc1},
+				Items:      []interface{}{pvc3Expected, pvc2Expected, pvc1Expected},
 				TotalItems: len(persistentVolumeClaims),
 			},
 			nil,
@@ -79,7 +79,7 @@ func TestListPods(t *testing.T) {
 				},
 			},
 			&api.ListResult{
-				Items:      []interface{}{pvc1},
+				Items:      []interface{}{pvc1Expected},
 				TotalItems: 1,
 			},
 			nil,
@@ -100,7 +100,7 @@ func TestListPods(t *testing.T) {
 				},
 			},
 			&api.ListResult{
-				Items:      []interface{}{pvcGet2},
+				Items:      []interface{}{pvc2Expected},
 				TotalItems: 1,
 			},
 			nil,
@@ -121,7 +121,7 @@ func TestListPods(t *testing.T) {
 				},
 			},
 			&api.ListResult{
-				Items:      []interface{}{pvcGet3},
+				Items:      []interface{}{pvc3Expected},
 				TotalItems: 1,
 			},
 			nil,
@@ -154,6 +154,21 @@ var (
 			Phase: corev1.ClaimPending,
 		},
 	}
+
+	pvc1Expected = &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotationInUse:         "false",
+				annotationAllowSnapshot: "false",
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimPending,
+		},
+	}
+
 	pvc2 = &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pvc-2",
@@ -167,7 +182,7 @@ var (
 		},
 	}
 
-	pvcGet2 = &corev1.PersistentVolumeClaim{
+	pvc2Expected = &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pvc-2",
 			Namespace: "default",
@@ -189,7 +204,7 @@ var (
 		},
 	}
 
-	pvcGet3 = &corev1.PersistentVolumeClaim{
+	pvc3Expected = &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pvc-3",
 			Namespace: "default",


### PR DESCRIPTION
Signed-off-by: dkeven <keven@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug


### What this PR does / why we need it:

Do a `DeepCopy()` before modifying shared objects from the informers to avoid mutaing the shared objects & avoid 
panic caused by concurrent map reading and writing.

Refer: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/controllers.md

```
Never mutate original objects! Caches are shared across controllers, this means that if you mutate your "copy" (actually a reference or shallow copy) of an object, you'll mess up other controllers (not just your own).

The most common point of failure is making a shallow copy, then mutating a map, like Annotations. Use api.Scheme.Copy to make a deep copy.
```

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubesphere/kubesphere/issues/4357

Fixes https://github.com/kubesphere/kubesphere/issues/3469

See also https://kubesphere.com.cn/forum/d/6466-fatal-error-concurrent-map-writes

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```
