### PR TITLE
Optimize the error message

### DIFF
--- a/pkg/simple/client/es/versions/error.go
+++ b/pkg/simple/client/es/versions/error.go
@@ -1,0 +1,19 @@
+package versions
+
+type Error struct {
+	Status  int           `json:"status"`
+	Details *ErrorDetails `json:"error,omitempty"`
+}
+
+type ErrorDetails struct {
+	Type         string                   `json:"type"`
+	Reason       string                   `json:"reason"`
+	ResourceType string                   `json:"resource.type,omitempty"`
+	ResourceId   string                   `json:"resource.id,omitempty"`
+	Index        string                   `json:"index,omitempty"`
+	Phase        string                   `json:"phase,omitempty"`
+	Grouped      bool                     `json:"grouped,omitempty"`
+	CausedBy     map[string]interface{}   `json:"caused_by,omitempty"`
+	RootCause    []*ErrorDetails          `json:"root_cause,omitempty"`
+	FailedShards []map[string]interface{} `json:"failed_shards,omitempty"`
+}

--- a/pkg/simple/client/es/versions/v5/v5.go
+++ b/pkg/simple/client/es/versions/v5/v5.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v5"
 	"github.com/elastic/go-elasticsearch/v5/esapi"
+
+	"kubesphere.io/kubesphere/pkg/simple/client/es/versions"
 )
 
 type Elastic struct {
@@ -112,12 +114,15 @@ func (e *Elastic) GetTotalHitCount(v interface{}) int64 {
 }
 
 func parseError(response *esapi.Response) error {
-	var e map[string]interface{}
+	var e versions.Error
 	if err := json.NewDecoder(response.Body).Decode(&e); err != nil {
 		return err
 	} else {
 		// Print the response status and error information.
-		e, _ := e["error"].(map[string]interface{})
-		return fmt.Errorf("type: %v, reason: %v", e["type"], e["reason"])
+		if len(e.Details.RootCause) != 0 {
+			return fmt.Errorf("type: %v, reason: %v", e.Details.Type, e.Details.RootCause[0].Reason)
+		} else {
+			return fmt.Errorf("type: %v, reason: %v", e.Details.Type, e.Details.Reason)
+		}
 	}
 }

--- a/pkg/simple/client/es/versions/v6/v6.go
+++ b/pkg/simple/client/es/versions/v6/v6.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v6"
 	"github.com/elastic/go-elasticsearch/v6/esapi"
+
+	"kubesphere.io/kubesphere/pkg/simple/client/es/versions"
 )
 
 type Elastic struct {
@@ -112,12 +114,15 @@ func (e *Elastic) GetTotalHitCount(v interface{}) int64 {
 }
 
 func parseError(response *esapi.Response) error {
-	var e map[string]interface{}
+	var e versions.Error
 	if err := json.NewDecoder(response.Body).Decode(&e); err != nil {
 		return err
 	} else {
 		// Print the response status and error information.
-		e, _ := e["error"].(map[string]interface{})
-		return fmt.Errorf("type: %v, reason: %v", e["type"], e["reason"])
+		if len(e.Details.RootCause) != 0 {
+			return fmt.Errorf("type: %v, reason: %v", e.Details.Type, e.Details.RootCause[0].Reason)
+		} else {
+			return fmt.Errorf("type: %v, reason: %v", e.Details.Type, e.Details.Reason)
+		}
 	}
 }

--- a/pkg/simple/client/es/versions/v7/v7.go
+++ b/pkg/simple/client/es/versions/v7/v7.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
+
+	"kubesphere.io/kubesphere/pkg/simple/client/es/versions"
 )
 
 type Elastic struct {
@@ -115,12 +117,15 @@ func (e *Elastic) GetTotalHitCount(v interface{}) int64 {
 }
 
 func parseError(response *esapi.Response) error {
-	var e map[string]interface{}
+	var e versions.Error
 	if err := json.NewDecoder(response.Body).Decode(&e); err != nil {
 		return err
 	} else {
 		// Print the response status and error information.
-		e, _ := e["error"].(map[string]interface{})
-		return fmt.Errorf("type: %v, reason: %v", e["type"], e["reason"])
+		if len(e.Details.RootCause) != 0 {
+			return fmt.Errorf("type: %v, reason: %v", e.Details.Type, e.Details.RootCause[0].Reason)
+		} else {
+			return fmt.Errorf("type: %v, reason: %v", e.Details.Type, e.Details.Reason)
+		}
 	}
 }

--- a/pkg/simple/client/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/simple/client/logging/elasticsearch/elasticsearch_test.go
@@ -133,7 +133,7 @@ func TestCountLogsByInterval(t *testing.T) {
 			fakeVersion: es.ElasticV7,
 			fakeResp:    "es7_count_logs_by_interval_400.json",
 			fakeCode:    http.StatusBadRequest,
-			expectedErr: "type: search_phase_execution_exception, reason: all shards failed",
+			expectedErr: "type: search_phase_execution_exception, reason: Unable to parse interval [30m0s]",
 		},
 		{
 			fakeVersion: es.ElasticV7,


### PR DESCRIPTION
Signed-off-by: chengdehao <dehaocheng@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
Users often locate information based on errors. In the current ks-apiserver the error messages in elasticsearch are also handled. ks-apiserver returns error messages in `es.reason`, but the error messages may not be specific enough to pinpoint the error message. So now we returns `error.root_casue[0].reason` information.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubesphere/kubesphere/issues/4603

### Special notes for reviewers:
I have introduced the elasticsearch package to wrap the error messages.Please see https://pkg.go.dev/github.com/olivere/elastic/v7#Error . Also in testing it was found that the return message from elasticsearch may not have information about `error.root_casue[0]` in it. So the error message was judged so that the error message obtained was not empty.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
