### PR TITLE
Use the kube-system UID to identify if the member cluster already exists

### DIFF
--- a/api/ks-openapi-spec/swagger.json
+++ b/api/ks-openapi-spec/swagger.json
@@ -21081,10 +21081,10 @@
     },
     "v1alpha2.Node": {
       "required": [
-        "rank",
+        "labelMinor",
         "id",
         "label",
-        "labelMinor",
+        "rank",
         "controls"
       ],
       "properties": {
@@ -21192,10 +21192,10 @@
     },
     "v1alpha2.NodeSummary": {
       "required": [
-        "labelMinor",
-        "rank",
         "id",
-        "label"
+        "label",
+        "labelMinor",
+        "rank"
       ],
       "properties": {
         "adjacency": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -10770,6 +10770,10 @@
           "description": "Region is the name of the region in which all of the nodes in the cluster exist.  e.g. 'us-east1'.",
           "type": "string"
         },
+        "uid": {
+          "description": "UID is the kube-system namespace UID of the cluster, which represents the unique ID of the cluster.",
+          "type": "string"
+        },
         "zones": {
           "description": "Zones are the names of availability zones in which the nodes of the cluster exist, e.g. 'us-east1-a'.",
           "type": "array",

--- a/config/crds/cluster.kubesphere.io_clusters.yaml
+++ b/config/crds/cluster.kubesphere.io_clusters.yaml
@@ -167,6 +167,10 @@ spec:
                 description: Region is the name of the region in which all of the
                   nodes in the cluster exist.  e.g. 'us-east1'.
                 type: string
+              uid:
+                description: UID is the kube-system namespace UID of the cluster,
+                  which represents the unique ID of the cluster.
+                type: string
               zones:
                 description: Zones are the names of availability zones in which the
                   nodes of the cluster exist, e.g. 'us-east1-a'.

--- a/staging/src/kubesphere.io/api/cluster/v1alpha1/cluster_types.go
+++ b/staging/src/kubesphere.io/api/cluster/v1alpha1/cluster_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -168,6 +169,9 @@ type ClusterStatus struct {
 	// every amount of time, like 5 minutes.
 	// +optional
 	Configz map[string]bool `json:"configz,omitempty"`
+
+	// UID is the kube-system namespace UID of the cluster, which represents the unique ID of the cluster.
+	UID types.UID `json:"uid,omitempty"`
 }
 
 // +genclient

--- a/staging/src/kubesphere.io/api/cluster/v1alpha1/openapi_generated.go
+++ b/staging/src/kubesphere.io/api/cluster/v1alpha1/openapi_generated.go
@@ -14439,6 +14439,13 @@ func schema_kubesphereio_api_cluster_v1alpha1_ClusterStatus(ref common.Reference
 							},
 						},
 					},
+					"uid": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UID is the kube-system namespace UID of the cluster, which represents the unique ID of the cluster.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

See background info and our previous discussion at #4625, We now use the UID of the target cluster's `kube-system` namespace as the unique identifier of the cluster to determine if the cluster already exists.

<img width="386" alt="Screen Shot 2022-01-27 at 11 35 03 AM" src="https://user-images.githubusercontent.com/9134003/151287461-b8f8867c-5504-456b-b53e-5ac51d9095c3.png">

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4625

### Special notes for reviewers:

This PR also does some code cleanup work, reducing a lot of unnecessary config parsing and client creation.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @zryfish 