### PR TITLE
Fix registry verification failed

### DIFF
--- a/pkg/models/registries/v2/secret_authenticator_test.go
+++ b/pkg/models/registries/v2/secret_authenticator_test.go
@@ -1,10 +1,16 @@
 package v2
 
 import (
-	"fmt"
-	"testing"
-
 	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -109,3 +115,58 @@ func TestAuthn(t *testing.T) {
 		})
 	}
 }
+
+var (
+	registryServer    *httptest.Server
+	tlsRegistryServer *httptest.Server
+)
+
+func TestRegistry(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Registry Test Suite")
+}
+
+var _ = BeforeSuite(func(done Done) {
+	// anonymous registry
+	fakeHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+	tlsRegistryServer = httptest.NewTLSServer(fakeHandler)
+	registryServer = httptest.NewServer(fakeHandler)
+	close(done)
+}, 30)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	gexec.KillAndWait(5 * time.Second)
+	registryServer.Close()
+	tlsRegistryServer.Close()
+})
+
+var _ = Describe("Registry", func() {
+	Context("Registry", func() {
+		It("skip TLS certification checks", func() {
+			secret := buildSecret(tlsRegistryServer.URL, "", "", true)
+			secretAuthenticator, err := NewSecretAuthenticator(secret)
+			Expect(err).Should(BeNil())
+			_, err = secretAuthenticator.Auth()
+			Expect(err).Should(BeNil())
+		})
+		It("self-signed certs are not trusted", func() {
+			secret := buildSecret(tlsRegistryServer.URL, "", "", false)
+			secretAuthenticator, err := NewSecretAuthenticator(secret)
+			Expect(err).Should(BeNil())
+			_, err = secretAuthenticator.Auth()
+			Expect(err).ShouldNot(BeNil())
+		})
+		It("insecure registry", func() {
+			// Loopback addr always be insecure, http scheme will be used.
+			secret := buildSecret(registryServer.URL, "", "", false)
+			secretAuthenticator, err := NewSecretAuthenticator(secret)
+			Expect(err).Should(BeNil())
+			_, err = secretAuthenticator.Auth()
+			Expect(err).Should(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:

Fix the registry verification API, `secret.kubesphere.io/force-insecure` does not work well.

### Which issue(s) this PR fixes:

Fixes #4647

### Does this PR introduced a user-facing change?

```release-note
None
```

### Additional documentation, usage docs, etc.:

```bash
$ curl -u admin:P@88w0rd 'http://localhost:9090/kapis/resources.kubesphere.io/v1alpha3/namespaces/test2/imageconfig?image=harbor.wansir.com%2Fnginx&secret=harbor'
Get "https://harbor.wansir.com/v2/": x509: certificate is valid for 57f23c30c67e52caf63aab57a5af804f.facb18832ab1cb1b92523ac1b6818d5d.traefik.default, not harbor.wansir.com

# hongming @ hc in ~ [14:25:43]
$ kubectl -n test2 annotate secret private-harbor2 secret.kubesphere.io/force-insecure=true
secret/private-harbor2 annotated

# hongming @ hc in ~ [14:25:59]
$ curl -u admin:P@88w0rd 'http://localhost:9090/kapis/resources.kubesphere.io/v1alpha3/namespaces/test2/imageconfig?image=harbor.wansir.com%2Fnginx&secret=harbor'
GET https://harbor.wansir.com/v2/: unexpected status code 404 Not Found: 404 page not found
# self-signed certs are verified, 404 caused by the fake harbor server.
```
