### PR TITLE
Set the name of the current cluster into the kubesphere-config configmap

### DIFF
--- a/cmd/controller-manager/app/controllers.go
+++ b/cmd/controller-manager/app/controllers.go
@@ -456,7 +456,9 @@ func addAllControllers(mgr manager.Manager, client k8s.Client, informerFactory i
 				kubesphereInformer.Cluster().V1alpha1().Clusters(),
 				client.KubeSphere().ClusterV1alpha1().Clusters(),
 				cmOptions.MultiClusterOptions.ClusterControllerResyncPeriod,
-				cmOptions.MultiClusterOptions.HostClusterName)
+				cmOptions.MultiClusterOptions.HostClusterName,
+				kubernetesInformer.Core().V1().ConfigMaps(),
+			)
 			addController(mgr, "cluster", clusterController)
 		}
 	}

--- a/pkg/apiserver/config/config.go
+++ b/pkg/apiserver/config/config.go
@@ -22,17 +22,17 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/klog"
-
 	"github.com/fsnotify/fsnotify"
-
-	"kubesphere.io/kubesphere/pkg/apiserver/authentication"
-	"kubesphere.io/kubesphere/pkg/apiserver/authorization"
-
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
 
 	networkv1alpha1 "kubesphere.io/api/network/v1alpha1"
 
+	"kubesphere.io/kubesphere/pkg/apiserver/authentication"
+	"kubesphere.io/kubesphere/pkg/apiserver/authorization"
+	"kubesphere.io/kubesphere/pkg/constants"
 	"kubesphere.io/kubesphere/pkg/models/terminal"
 	"kubesphere.io/kubesphere/pkg/simple/client/alerting"
 	"kubesphere.io/kubesphere/pkg/simple/client/auditing"
@@ -362,4 +362,18 @@ func (conf *Config) stripEmptyOptions() {
 	if conf.GPUOptions != nil && len(conf.GPUOptions.Kinds) == 0 {
 		conf.GPUOptions = nil
 	}
+}
+
+// GetFromConfigMap returns KubeSphere ruuning config by the given ConfigMap.
+func GetFromConfigMap(cm *corev1.ConfigMap) (*Config, error) {
+	c := &Config{}
+	value, ok := cm.Data[constants.KubeSphereConfigMapDataKey]
+	if !ok {
+		return nil, fmt.Errorf("failed to get configmap kubesphere.yaml value")
+	}
+
+	if err := yaml.Unmarshal([]byte(value), c); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal value from configmap. err: %s", err)
+	}
+	return c, nil
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -31,6 +31,8 @@ const (
 	IngressControllerNamespace    = KubeSphereControlNamespace
 	AdminUserName                 = "admin"
 	IngressControllerPrefix       = "kubesphere-router-"
+	KubeSphereConfigName          = "kubesphere-config"
+	KubeSphereConfigMapDataKey    = "kubesphere.yaml"
 
 	ClusterNameLabelKey               = "kubesphere.io/cluster"
 	NameLabelKey                      = "kubesphere.io/name"

--- a/pkg/kapis/cluster/v1alpha1/handler_test.go
+++ b/pkg/kapis/cluster/v1alpha1/handler_test.go
@@ -39,6 +39,7 @@ import (
 	"kubesphere.io/api/cluster/v1alpha1"
 
 	"kubesphere.io/kubesphere/pkg/client/clientset/versioned/fake"
+	"kubesphere.io/kubesphere/pkg/constants"
 	"kubesphere.io/kubesphere/pkg/informers"
 	"kubesphere.io/kubesphere/pkg/utils/k8sutil"
 )
@@ -112,16 +113,16 @@ authentication:
 
 var hostCm = &corev1.ConfigMap{
 	ObjectMeta: metav1.ObjectMeta{
-		Namespace: KubesphereNamespace,
-		Name:      KubeSphereConfigName,
+		Namespace: constants.KubeSphereNamespace,
+		Name:      constants.KubeSphereConfigName,
 	},
 	Data: hostMap,
 }
 
 var memberCm = &corev1.ConfigMap{
 	ObjectMeta: metav1.ObjectMeta{
-		Namespace: KubesphereNamespace,
-		Name:      KubeSphereConfigName,
+		Namespace: constants.KubeSphereNamespace,
+		Name:      constants.KubeSphereConfigName,
 	},
 	Data: memberMap,
 }
@@ -465,14 +466,14 @@ func addMemberClusterResource(targetCm *corev1.ConfigMap, t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: KubesphereNamespace}}, metav1.CreateOptions{})
+	_, err = c.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: constants.KubeSphereNamespace}}, metav1.CreateOptions{})
 	if err != nil && !errors.IsAlreadyExists(err) {
 		t.Fatal(err)
 	}
 
-	_, err = c.CoreV1().ConfigMaps(KubesphereNamespace).Create(context.Background(), targetCm, metav1.CreateOptions{})
+	_, err = c.CoreV1().ConfigMaps(constants.KubeSphereNamespace).Create(context.Background(), targetCm, metav1.CreateOptions{})
 	if err != nil && errors.IsAlreadyExists(err) {
-		_, err = c.CoreV1().ConfigMaps(KubesphereNamespace).Update(context.Background(), targetCm, metav1.UpdateOptions{})
+		_, err = c.CoreV1().ConfigMaps(constants.KubeSphereNamespace).Update(context.Background(), targetCm, metav1.UpdateOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -486,7 +487,7 @@ func addMemberClusterResource(targetCm *corev1.ConfigMap, t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.AppsV1().Deployments(KubesphereNamespace).Create(context.Background(), &deploy, metav1.CreateOptions{})
+	_, err = c.AppsV1().Deployments(constants.KubeSphereNamespace).Create(context.Background(), &deploy, metav1.CreateOptions{})
 	if err != nil && !errors.IsAlreadyExists(err) {
 		t.Fatal(err)
 	}

--- a/pkg/simple/client/multicluster/options.go
+++ b/pkg/simple/client/multicluster/options.go
@@ -53,6 +53,10 @@ type Options struct {
 
 	// HostClusterName is the name of the control plane cluster, default set to host.
 	HostClusterName string `json:"hostClusterName,omitempty" yaml:"hostClusterName,omitempty"`
+
+	// ClusterName is the name of the current cluster,
+	// this value will be set by the cluster-controller and stored in the kubesphere-config configmap.
+	ClusterName string `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
 }
 
 // NewOptions returns a default nil options


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind feature

### What this PR does / why we need it:

See #4672 for background info, after this patch, the cluster name will be added into the `kubesphere-config` configmap:

before:

```yaml
data:
  kubesphere.yaml: |
    authentication:
      authenticateRateLimiterMaxTries: 10
      authenticateRateLimiterDuration: 10m0s
      loginHistoryRetentionPeriod: 168h
      maximumClockSkew: 10s
      multipleLogin: True
      kubectlImage: kubesphere/kubectl:v1.21.0
      jwtSecret: "LvHOc5ATkJy8amuW0NVZU6jNPrYG2qlj"
      oauthOptions:
        clients:
        - name: kubesphere
          secret: kubesphere
          redirectURIs:
          - '*'
    network:
      ippoolType: none
    openpitrix:
      s3:
        endpoint: http://minio.kubesphere-system.svc:9000
        region: us-east-1
        disableSSL: True
        forcePathStyle: True
        accessKeyID: openpitrixminioaccesskey
        secretAccessKey: openpitrixminiosecretkey
        bucket: app-store
    multicluster:
      enable: true
      agentImage: kubesphere/tower:v0.2.0
      proxyPublishService: tower.kubesphere-system.svc
      proxyPublishAddress: http://103.61.38.60:30361
    monitoring:
      endpoint: http://prometheus-operated.kubesphere-monitoring-system.svc:9090
      enableGPUMonitoring: false
    gpu:
      kinds:
      - resourceName: nvidia.com/gpu
        resourceType: GPU
        default: True
    notification:
      endpoint: http://notification-manager-svc.kubesphere-monitoring-system.svc:19093
    logging:
      host: http://elasticsearch-logging-data.kubesphere-logging-system.svc:9200
      indexPrefix: ks-logstash-log
    alerting:
      prometheusEndpoint: http://prometheus-operated.kubesphere-monitoring-system.svc:9090
      thanosRulerEndpoint: http://thanos-ruler-operated.kubesphere-monitoring-system.svc:10902
      thanosRuleResourceLabels: thanosruler=thanos-ruler,role=thanos-alerting-rules
    gateway:
      watchesPath: /var/helm-charts/watches.yaml
      namespace: kubesphere-controls-system
```

after:

```yaml
data:
  kubesphere.yaml: |
    authentication:
      authenticateRateLimiterMaxTries: 10
      authenticateRateLimiterDuration: 10m0s
      maximumClockSkew: 10s
      loginHistoryRetentionPeriod: 168h0m0s
      loginHistoryMaximumEntries: 0
      multipleLogin: true
      jwtSecret: LvHOc5ATkJy8amuW0NVZU6jNPrYG2qlj
      oauthOptions:
        clients:
        - name: kubesphere
          secret: kubesphere
          redirectURIs:
          - '*'
        accessTokenMaxAge: 0s
        accessTokenInactivityTimeout: 0s
      kubectlImage: kubesphere/kubectl:v1.21.0
    network:
      ippoolType: none
    openpitrix:
      s3:
        endpoint: http://minio.kubesphere-system.svc:9000
        region: us-east-1
        disableSSL: true
        forcePathStyle: true
        accessKeyID: openpitrixminioaccesskey
        secretAccessKey: openpitrixminiosecretkey
        bucket: app-store
    multicluster:
      enable: true
      proxyPublishService: tower.kubesphere-system.svc
      proxyPublishAddress: http://103.61.38.60:30361
      agentImage: kubesphere/tower:v0.2.0
      clusterName: host
    monitoring:
      endpoint: http://prometheus-operated.kubesphere-monitoring-system.svc:9090
    gpu:
      kinds:
      - resourceName: nvidia.com/gpu
        resourceType: GPU
        default: true
    notification:
      endpoint: http://notification-manager-svc.kubesphere-monitoring-system.svc:19093
    logging:
      host: http://elasticsearch-logging-data.kubesphere-logging-system.svc:9200
      basicAuth: false
      username: ""
      password: ""
      indexPrefix: ks-logstash-log
      version: ""
    alerting:
      endpoint: ""
      prometheusEndpoint: http://prometheus-operated.kubesphere-monitoring-system.svc:9090
      thanosRulerEndpoint: http://thanos-ruler-operated.kubesphere-monitoring-system.svc:10902
      thanosRuleResourceLabels: thanosruler=thanos-ruler,role=thanos-alerting-rules
    gateway:
      watchesPath: /var/helm-charts/watches.yaml
      namespace: kubesphere-controls-system
```

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
close #4672

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Set the name of the current cluster into the kubesphere-config configmap.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @zryfish @wanjunlei 