### PR TITLE
Fix the "index out of range" issue when sort metrics

### DIFF
--- a/pkg/models/monitoring/sort_page.go
+++ b/pkg/models/monitoring/sort_page.go
@@ -120,8 +120,10 @@ func (raw *Metrics) Sort(target, order, identifier string) *Metrics {
 				// Record ordinals in the final result
 				v, ok := mv.Metadata[identifier]
 				if ok && v != "" {
-					resourceOrdinal[v] = ordinal
-					ordinal++
+					if _, ok1 := resourceOrdinal[v]; !ok1 {
+						resourceOrdinal[v] = ordinal
+						ordinal++
+					}
 				}
 			}
 		}

--- a/pkg/models/monitoring/sort_page.go
+++ b/pkg/models/monitoring/sort_page.go
@@ -120,7 +120,7 @@ func (raw *Metrics) Sort(target, order, identifier string) *Metrics {
 				// Record ordinals in the final result
 				v, ok := mv.Metadata[identifier]
 				if ok && v != "" {
-					if _, ok1 := resourceOrdinal[v]; !ok1 {
+					if _, ok := resourceOrdinal[v]; !ok {
 						resourceOrdinal[v] = ordinal
 						ordinal++
 					}


### PR DESCRIPTION
### What type of PR is this?
/kind bug


### What this PR does / why we need it:
The ks apiserver throwed panic when called the metrics api, and I add more output as following:

```
I0224 21:35:15.492743       1 sort_page.go:125] target: virtualmachine_cpu_usage  v[i-i2mtn2vb]=0
I0224 21:35:15.492807       1 sort_page.go:125] target: virtualmachine_cpu_usage  v[i-i2mtn2vb]=1
I0224 21:35:15.492822       1 sort_page.go:125] target: virtualmachine_cpu_usage  v[i-zs89s7ia]=2
I0224 21:35:15.492834       1 sort_page.go:125] target: virtualmachine_cpu_usage  v[i-29gkkq85]=3
I0224 21:35:15.492847       1 sort_page.go:125] target: virtualmachine_cpu_usage  v[i-zs89s7ia]=4
I0224 21:35:15.492867       1 sort_page.go:125] target: virtualmachine_cpu_usage  v[i-29gkkq85]=5
I0224 21:35:15.492883       1 sort_page.go:140] resourceSet: map[string]bool{"i-29gkkq85":true, "i-i2mtn2vb":true, "i-zs89s7ia":true}
I0224 21:35:15.492923       1 sort_page.go:156] resourceOrdinal: map[string]int{"i-29gkkq85":5, "i-i2mtn2vb":1, "i-zs89s7ia":4}
2022/02/24 21:35:15 http: panic serving 10.233.87.247:35516: runtime error: index out of range [4] with length 3
```

### Does this PR introduced a user-facing change?
```release-note
None
```
