### PR TITLE
Add "readyToUse" filter field for volumesnapshotcontent

### DIFF
--- a/pkg/models/resources/v1alpha3/volumesnapshotcontent/volumesnapshotcontent.go
+++ b/pkg/models/resources/v1alpha3/volumesnapshotcontent/volumesnapshotcontent.go
@@ -1,6 +1,7 @@
 package volumesnapshotcontent
 
 import (
+	"strconv"
 	"strings"
 
 	v1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
@@ -17,6 +18,7 @@ const (
 	volumeSnapshotClassName = "volumeSnapshotClassName"
 	volumeSnapshotName      = "volumeSnapshotName"
 	volumeSnapshotNameSpace = "volumeSnapshotNamespace"
+	readyToUse              = "readyToUse"
 )
 
 type volumesnapshotcontentGetter struct {
@@ -70,6 +72,8 @@ func (v *volumesnapshotcontentGetter) filter(object runtime.Object, filter query
 		return strings.EqualFold(snapshotcontent.Spec.VolumeSnapshotRef.Name, string(filter.Value))
 	case volumeSnapshotNameSpace:
 		return strings.EqualFold(snapshotcontent.Spec.VolumeSnapshotRef.Namespace, string(filter.Value))
+	case readyToUse:
+		return strings.EqualFold(strconv.FormatBool(*snapshotcontent.Status.ReadyToUse), string(filter.Value))
 	default:
 		return v1alpha3.DefaultObjectMetaFilter(snapshotcontent.ObjectMeta, filter)
 	}


### PR DESCRIPTION
Signed-off-by: f10atin9 <f10atin9@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

### What this PR does / why we need it:
After adding this, the console can filter the volumesnapshotcontent by the ReadyToUse field.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
#4596 
### Special notes for reviewers:
```
None
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
