### PR TITLE
Add "snapshot-count" annotation for volumesnapshotClass

### DIFF
--- a/pkg/models/resources/v1alpha3/volumesnapshotclass/volumesnapshotclass.go
+++ b/pkg/models/resources/v1alpha3/volumesnapshotclass/volumesnapshotclass.go
@@ -17,7 +17,10 @@ limitations under the License.
 package volumesnapshotclass
 
 import (
+	"strconv"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/labels"
 
 	v1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	"github.com/kubernetes-csi/external-snapshotter/client/v4/informers/externalversions"
@@ -53,6 +56,11 @@ func (v *volumeSnapshotClassGetter) List(namespace string, query *query.Query) (
 
 	var result []runtime.Object
 	for _, snapshotClass := range all {
+		count := v.countVolumeSnapshots(snapshotClass.Name)
+		if snapshotClass.Annotations == nil {
+			snapshotClass.Annotations = make(map[string]string)
+		}
+		snapshotClass.Annotations["kubesphere.io/snapshot-count"] = strconv.Itoa(count)
 		result = append(result, snapshotClass)
 	}
 
@@ -85,4 +93,19 @@ func (v *volumeSnapshotClassGetter) filter(object runtime.Object, filter query.F
 	default:
 		return v1alpha3.DefaultObjectMetaFilter(snapshotClass.ObjectMeta, filter)
 	}
+}
+
+func (v *volumeSnapshotClassGetter) countVolumeSnapshots(name string) int {
+	snapshots, err := v.informers.Snapshot().V1().VolumeSnapshots().Lister().VolumeSnapshots("").List(labels.Everything())
+	if err != nil {
+		return 0
+	}
+	var count int
+
+	for _, snapshot := range snapshots {
+		if snapshot.Spec.VolumeSnapshotClassName != nil && *snapshot.Spec.VolumeSnapshotClassName == name {
+			count++
+		}
+	}
+	return count
 }

--- a/pkg/models/resources/v1alpha3/volumesnapshotclass/volumesnapshotclass.go
+++ b/pkg/models/resources/v1alpha3/volumesnapshotclass/volumesnapshotclass.go
@@ -97,7 +97,7 @@ func (v *volumeSnapshotClassGetter) filter(object runtime.Object, filter query.F
 }
 
 func (v *volumeSnapshotClassGetter) countVolumeSnapshots(name string) int {
-	snapshots, err := v.informers.Snapshot().V1().VolumeSnapshots().Lister().VolumeSnapshots("").List(labels.Everything())
+	snapshots, err := v.informers.Snapshot().V1().VolumeSnapshots().Lister().List(labels.Everything())
 	if err != nil {
 		return 0
 	}

--- a/pkg/models/resources/v1alpha3/volumesnapshotclass/volumesnapshotclass.go
+++ b/pkg/models/resources/v1alpha3/volumesnapshotclass/volumesnapshotclass.go
@@ -56,6 +56,7 @@ func (v *volumeSnapshotClassGetter) List(namespace string, query *query.Query) (
 
 	var result []runtime.Object
 	for _, snapshotClass := range all {
+		snapshotClass = snapshotClass.DeepCopy()
 		count := v.countVolumeSnapshots(snapshotClass.Name)
 		if snapshotClass.Annotations == nil {
 			snapshotClass.Annotations = make(map[string]string)

--- a/pkg/models/resources/v1alpha3/volumesnapshotclass/volumesnapshotclass_test.go
+++ b/pkg/models/resources/v1alpha3/volumesnapshotclass/volumesnapshotclass_test.go
@@ -72,6 +72,18 @@ func TestListVolumeSnapshotClass(t *testing.T) {
 	snapshotClass3.CreationTimestamp = v1.NewTime(snapshotClass1.CreationTimestamp.Add(time.Hour * 3))
 	snapshotClass3.DeletionPolicy = snapshotv1.VolumeSnapshotContentRetain
 
+	sc1Expected := snapshotClass1.DeepCopy()
+	sc1Expected.Annotations = make(map[string]string)
+	sc1Expected.Annotations["kubesphere.io/snapshot-count"] = "0"
+
+	sc2Expected := snapshotClass2.DeepCopy()
+	sc2Expected.Annotations = make(map[string]string)
+	sc2Expected.Annotations["kubesphere.io/snapshot-count"] = "0"
+
+	sc3Expected := snapshotClass3.DeepCopy()
+	sc3Expected.Annotations = make(map[string]string)
+	sc3Expected.Annotations["kubesphere.io/snapshot-count"] = "0"
+
 	volumeSnapshotClasses := []interface{}{snapshotClass1, snapshotClass2, snapshotClass3}
 
 	for _, s := range volumeSnapshotClasses {
@@ -86,7 +98,7 @@ func TestListVolumeSnapshotClass(t *testing.T) {
 			snapshotClassList, err := getter.List("", query1)
 			Expect(err).To(BeNil())
 			Expect(snapshotClassList.TotalItems).To(Equal(1))
-			Expect(snapshotClassList.Items[0]).To(Equal(snapshotClass1))
+			Expect(snapshotClassList.Items[0]).To(Equal(sc1Expected))
 		})
 
 		It("match driver", func() {
@@ -95,7 +107,7 @@ func TestListVolumeSnapshotClass(t *testing.T) {
 			snapshotClassList, err := getter.List("", query1)
 			Expect(err).To(BeNil())
 			Expect(snapshotClassList.TotalItems).To(Equal(1))
-			Expect(snapshotClassList.Items[0]).To(Equal(snapshotClass2))
+			Expect(snapshotClassList.Items[0]).To(Equal(sc2Expected))
 		})
 
 		It("match deletionPolicy", func() {
@@ -104,7 +116,7 @@ func TestListVolumeSnapshotClass(t *testing.T) {
 			snapshotClassList, err := getter.List("", query1)
 			Expect(err).To(BeNil())
 			Expect(snapshotClassList.TotalItems).To(Equal(1))
-			Expect(snapshotClassList.Items[0]).To(Equal(snapshotClass3))
+			Expect(snapshotClassList.Items[0]).To(Equal(sc3Expected))
 		})
 
 	})


### PR DESCRIPTION
Signed-off-by: f10atin9 <f10atin9@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
In the console, the snapshotclass list is required to display the number of snapshots.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
None
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
