### PR TITLE
fix tcp match error

### DIFF
--- a/pkg/controller/virtualservice/virtualservice_controller.go
+++ b/pkg/controller/virtualservice/virtualservice_controller.go
@@ -537,7 +537,13 @@ func (v *VirtualServiceController) generateVirtualServiceSpec(strategy *servicem
 			}
 			if len(strategyTempSpec.Tcp) > 0 && !servicemesh.SupportHttpProtocol(port.Name) {
 				for _, tcp := range strategyTempSpec.Tcp {
-					tcp.Match = []*apinetworkingv1alpha3.L4MatchAttributes{{Port: uint32(port.Port)}}
+					if len(tcp.Match) == 0 {
+						tcp.Match = []*apinetworkingv1alpha3.L4MatchAttributes{{Port: uint32(port.Port)}}
+					} else {
+						for _, match := range tcp.Match {
+							match.Port = uint32(port.Port)
+						}
+					}
 					for _, r := range tcp.Route {
 						r.Destination.Port = &apinetworkingv1alpha3.PortSelector{Number: uint32(port.Port)}
 					}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?


/kind bug

### What this PR does / why we need it:
The tcp match  has several kind, such as port, sourceLabels, gateway, destinationSubnets . We should not just put one port match element in the L4MatchAttributes match array, this may overwrite the original match element, and  cause an error.
So I modify the code ,like the above http match code , just insert the port match in every match element to fix this problem.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
None

### release-note



### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
