### PR TITLE
Fix disabled status not work for OAuth

### DIFF
--- a/pkg/models/auth/oauth.go
+++ b/pkg/models/auth/oauth.go
@@ -91,6 +91,10 @@ func (o *oauthAuthenticator) Authenticate(_ context.Context, provider string, re
 	}
 
 	if user != nil {
+		if user.Status.State == iamv1alpha2.UserDisabled {
+			// state not active
+			return nil, "", AccountIsNotActiveError
+		}
 		return &authuser.DefaultInfo{Name: user.GetName()}, providerOptions.Name, nil
 	}
 


### PR DESCRIPTION
### What type of PR is this?

/kind bug


### What this PR does / why we need it:

The disabled user is still able to authenticate successfully via OAuth.

### Which issue(s) this PR fixes:

Fixes #4781

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
