### PR TITLE
Fix: restricted users cannot activate manually

### DIFF
--- a/pkg/controller/user/user_controller.go
+++ b/pkg/controller/user/user_controller.go
@@ -530,7 +530,9 @@ func (r *Reconciler) syncUserStatus(ctx context.Context, user *iamv1alpha2.User)
 	now := time.Now()
 	failedLoginAttempts := 0
 	for _, loginRecord := range records.Items {
+		afterStateTransition := user.Status.LastTransitionTime == nil || loginRecord.CreationTimestamp.After(user.Status.LastTransitionTime.Time)
 		if !loginRecord.Spec.Success &&
+			afterStateTransition &&
 			loginRecord.CreationTimestamp.Add(r.AuthenticationOptions.AuthenticateRateLimiterDuration).After(now) {
 			failedLoginAttempts++
 		}

--- a/pkg/controller/user/user_controller_test.go
+++ b/pkg/controller/user/user_controller_test.go
@@ -68,9 +68,11 @@ func TestDoNothing(t *testing.T) {
 	for i := 0; i < authenticateOptions.AuthenticateRateLimiterMaxTries+1; i++ {
 		loginRecord := iamv1alpha2.LoginRecord{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:              fmt.Sprintf("%s-%d", user.Name, i),
-				Labels:            map[string]string{iamv1alpha2.UserReferenceLabel: user.Name},
-				CreationTimestamp: metav1.Now(),
+				Name:   fmt.Sprintf("%s-%d", user.Name, i),
+				Labels: map[string]string{iamv1alpha2.UserReferenceLabel: user.Name},
+				// Ensure that the failed login record created after the user status change to active,
+				// otherwise, the failed login attempts will not be counted.
+				CreationTimestamp: metav1.NewTime(time.Now().Add(time.Minute)),
 			},
 			Spec: iamv1alpha2.LoginRecordSpec{
 				Success: false,


### PR DESCRIPTION
### What type of PR is this?

/kind bug


### What this PR does / why we need it:

Restricted users(AuthLimitExceeded) cannot activate manually, all of the failed attempts will be counted after the User state changes to active, and the user state will change back to limited until restrict timeout.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4857

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
