### PR TITLE
create default token for service account

### DIFF
--- a/pkg/controller/cluster/cluster_controller.go
+++ b/pkg/controller/cluster/cluster_controller.go
@@ -297,10 +297,10 @@ func (c *clusterController) resyncClusters() error {
 	}
 
 	for _, cluster := range clusters {
-		if err = c.syncCluster(cluster.Name); err != nil {
-			klog.Warningf("failed to sync cluster %s: %s", cluster.Name, err)
-		}
+		key, _ := cache.MetaNamespaceKeyFunc(cluster)
+		c.queue.Add(key)
 	}
+
 	return nil
 }
 

--- a/pkg/controller/cluster/join.go
+++ b/pkg/controller/cluster/join.go
@@ -18,6 +18,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"time"
 
@@ -268,7 +269,7 @@ func createAuthorizedServiceAccount(joiningClusterClientset kubeclient.Interface
 
 	klog.V(2).Infof("Creating service account in joining cluster: %s", joiningClusterName)
 
-	saName, err := createServiceAccount(joiningClusterClientset, namespace,
+	saName, err := createServiceAccountWithSecret(joiningClusterClientset, namespace,
 		joiningClusterName, hostClusterName, dryRun, errorOnExisting)
 	if err != nil {
 		klog.V(2).Infof("Error creating service account: %s in joining cluster: %s due to: %v",
@@ -320,31 +321,75 @@ func createAuthorizedServiceAccount(joiningClusterClientset kubeclient.Interface
 	return saName, nil
 }
 
-// createServiceAccount creates a service account in the cluster associated
+// createServiceAccountWithSecret creates a service account and secret in the cluster associated
 // with clusterClientset with credentials that will be used by the host cluster
 // to access its API server.
-func createServiceAccount(clusterClientset kubeclient.Interface, namespace,
+func createServiceAccountWithSecret(clusterClientset kubeclient.Interface, namespace,
 	joiningClusterName, hostClusterName string, dryRun, errorOnExisting bool) (string, error) {
 	saName := util.ClusterServiceAccountName(joiningClusterName, hostClusterName)
-	sa := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      saName,
-			Namespace: namespace,
-		},
-	}
 
 	if dryRun {
 		return saName, nil
 	}
 
-	// Create a new service account.
-	_, err := clusterClientset.CoreV1().ServiceAccounts(namespace).Create(context.Background(), sa, metav1.CreateOptions{})
-	switch {
-	case apierrors.IsAlreadyExists(err) && errorOnExisting:
-		klog.V(2).Infof("Service account %s/%s already exists in target cluster %s", namespace, saName, joiningClusterName)
+	ctx := context.Background()
+	sa, err := clusterClientset.CoreV1().ServiceAccounts(namespace).Get(ctx, saName, metav1.GetOptions{})
+
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			sa = &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      saName,
+					Namespace: namespace,
+				},
+			}
+			// We must create the sa first, then create the associated secret, and update the sa at last.
+			// Or the kube-controller-manager will delete the secret.
+			sa, err = clusterClientset.CoreV1().ServiceAccounts(namespace).Create(ctx, sa, metav1.CreateOptions{})
+			switch {
+			case apierrors.IsAlreadyExists(err) && errorOnExisting:
+				klog.V(2).Infof("Service account %s/%s already exists in target cluster %s", namespace, saName, joiningClusterName)
+				return "", err
+			case err != nil && !apierrors.IsAlreadyExists(err):
+				klog.V(2).Infof("Could not create service account %s/%s in target cluster %s due to: %v", namespace, saName, joiningClusterName, err)
+				return "", err
+			}
+		} else {
+			return "", err
+		}
+	}
+
+	if len(sa.Secrets) > 0 {
+		return saName, nil
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-token-", saName),
+			Namespace:    namespace,
+			Annotations: map[string]string{
+				corev1.ServiceAccountNameKey: saName,
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+
+	// After kubernetes v1.24, kube-controller-manger will not create the default secret for
+	// service account. http://kep.k8s.io/2800
+	// Create a default secret.
+	secret, err = clusterClientset.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
+
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		klog.V(2).Infof("Could not create secret for service account %s/%s in target cluster %s due to: %v", namespace, saName, joiningClusterName, err)
 		return "", err
-	case err != nil && !apierrors.IsAlreadyExists(err):
-		klog.V(2).Infof("Could not create service account %s/%s in target cluster %s due to: %v", namespace, saName, joiningClusterName, err)
+	}
+
+	// At last, update the service account.
+	sa.Secrets = append(sa.Secrets, corev1.ObjectReference{Name: secret.Name})
+	_, err = clusterClientset.CoreV1().ServiceAccounts(namespace).Update(ctx, sa, metav1.UpdateOptions{})
+	switch {
+	case err != nil:
+		klog.Infof("Could not update service account %s/%s in target cluster %s due to: %v", namespace, saName, joiningClusterName, err)
 		return "", err
 	default:
 		return saName, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
After kubernetes v1.24, kube-conteoller-manager will not create the default token for service account.
This pr will create a default token for cluster service account.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
#4934

### Special notes for reviewers:
```
NONE
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/cc @wansir 
/cc @zheng1 
/cc @iawia002 