### PR TITLE
format error log

### DIFF
--- a/pkg/kapis/resources/v1alpha3/handler.go
+++ b/pkg/kapis/resources/v1alpha3/handler.go
@@ -65,7 +65,7 @@ func (h *Handler) handleGetResources(request *restful.Request, response *restful
 	}
 
 	if err != resourcev1alpha3.ErrResourceNotSupported {
-		klog.Error(err, resourceType)
+		klog.Errorf("%s, resource type: %s", err, resourceType)
 		api.HandleInternalError(response, nil, err)
 		return
 	}
@@ -99,7 +99,7 @@ func (h *Handler) handleListResources(request *restful.Request, response *restfu
 	}
 
 	if err != resourcev1alpha3.ErrResourceNotSupported {
-		klog.Error(err, resourceType)
+		klog.Errorf("%s, resource type: %s", err, resourceType)
 		api.HandleInternalError(response, request, err)
 		return
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind regression
-->
/kind flake

### What this PR does / why we need it:
Format error log.
There is no delimiter space between the output of parameters of `klog.Error(err1, err2)`.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @wansir 