### PR TITLE
[KS-OIDC] Remove special characters form sub OIDC standard claim

### DIFF
--- a/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
+++ b/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
@@ -116,7 +116,7 @@ type oidcIdentity struct {
 }
 
 func (o oidcIdentity) GetUserID() string {
-        return base64.RawURLEncoding.EncodeToString([]byte(o.Sub))
+	return base64.RawURLEncoding.EncodeToString([]byte(o.Sub))
 }
 
 func (o oidcIdentity) GetUsername() string {

--- a/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
+++ b/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-        "regexp"
 	"io/ioutil"
 	"net/http"
 
@@ -116,13 +115,7 @@ type oidcIdentity struct {
 }
 
 func (o oidcIdentity) GetUserID() string {
-         StartSubTrimmer := regexp.MustCompile("^[!@#$%^&*()_+\-=\[\]{};':\\|,.<>\/?\"]+")
-         EndSubTrimmer   := regexp.MustCompile("[!@#$%^&*()_+\-=\[\]{};':\\|,.<>\/?\"]+$")
-         // Trim the start
-         HeadSubTrimmed := StartSubTrimmer.ReplaceAllString(o.Sub,"0")
-         // Trim the end
-         TailSubTrimmed := EndSubTrimmer.ReplaceAllString(HeadSubTrimmed,"0")
-         return TailSubTrimmed
+         return base64.RawURLEncoding.EncodeToString([]byte(o.Sub))
 }
 
 func (o oidcIdentity) GetUsername() string {

--- a/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
+++ b/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
@@ -19,7 +19,8 @@ package oidc
 import (
 	"context"
 	"crypto/tls"
-	"encoding"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"

--- a/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
+++ b/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+        "regexp"
 	"io/ioutil"
 	"net/http"
 
@@ -115,7 +116,13 @@ type oidcIdentity struct {
 }
 
 func (o oidcIdentity) GetUserID() string {
-	return o.Sub
+         StartSubTrimmer := regexp.MustCompile("^[!@#$%^&*()_+\-=\[\]{};':\\|,.<>\/?\"]+")
+         EndSubTrimmer   := regexp.MustCompile("[!@#$%^&*()_+\-=\[\]{};':\\|,.<>\/?\"]+$")
+         // Trim the start
+         HeadSubTrimmed := StartSubTrimmer.ReplaceAllString(o.Sub,"0")
+         // Trim the end
+         TailSubTrimmed := EndSubTrimmer.ReplaceAllString(HeadSubTrimmed,"0")
+         return TailSubTrimmed
 }
 
 func (o oidcIdentity) GetUsername() string {

--- a/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
+++ b/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+        "encoding/base64"
 	"errors"
 	"fmt"
 	"io/ioutil"

--- a/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
+++ b/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
@@ -19,8 +19,7 @@ package oidc
 import (
 	"context"
 	"crypto/tls"
-	"encoding/json"
-        "encoding/base64"
+	"encoding"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -116,7 +115,7 @@ type oidcIdentity struct {
 }
 
 func (o oidcIdentity) GetUserID() string {
-         return base64.RawURLEncoding.EncodeToString([]byte(o.Sub))
+        return base64.RawURLEncoding.EncodeToString([]byte(o.Sub))
 }
 
 func (o oidcIdentity) GetUsername() string {

--- a/pkg/apiserver/authentication/identityprovider/oidc/oidc_test.go
+++ b/pkg/apiserver/authentication/identityprovider/oidc/oidc_test.go
@@ -198,7 +198,7 @@ var _ = Describe("OIDC", func() {
 			req := &http.Request{URL: url}
 			identity, err := provider.IdentityExchangeCallback(req)
 			Expect(err).Should(BeNil())
-			Expect(base64.URLEncoding.DecodeString(identity.GetUserID())).Should(Equal("110169484474386276334"))
+			Expect(string(base64.URLEncoding.DecodeString(identity.GetUserID()))).Should(Equal("110169484474386276334"))
 			Expect(identity.GetUsername()).Should(Equal("test"))
 			Expect(identity.GetEmail()).Should(Equal("test@kubesphere.io"))
 		})

--- a/pkg/apiserver/authentication/identityprovider/oidc/oidc_test.go
+++ b/pkg/apiserver/authentication/identityprovider/oidc/oidc_test.go
@@ -198,7 +198,7 @@ var _ = Describe("OIDC", func() {
 			req := &http.Request{URL: url}
 			identity, err := provider.IdentityExchangeCallback(req)
 			Expect(err).Should(BeNil())
-                        Expect(identity.GetUserID()).Should(Equal(base64.RawURLEncoding.EncodeToString([]byte("110169484474386276334"))))
+			Expect(identity.GetUserID()).Should(Equal(base64.RawURLEncoding.EncodeToString([]byte("110169484474386276334"))))
 			Expect(identity.GetUsername()).Should(Equal("test"))
 			Expect(identity.GetEmail()).Should(Equal("test@kubesphere.io"))
 		})

--- a/pkg/apiserver/authentication/identityprovider/oidc/oidc_test.go
+++ b/pkg/apiserver/authentication/identityprovider/oidc/oidc_test.go
@@ -198,7 +198,7 @@ var _ = Describe("OIDC", func() {
 			req := &http.Request{URL: url}
 			identity, err := provider.IdentityExchangeCallback(req)
 			Expect(err).Should(BeNil())
-			Expect(string(base64.URLEncoding.DecodeString(identity.GetUserID()))).Should(Equal("110169484474386276334"))
+                        Expect(identity.GetUserID()).Should(Equal(base64.RawURLEncoding.EncodeToString([]byte("110169484474386276334"))))
 			Expect(identity.GetUsername()).Should(Equal("test"))
 			Expect(identity.GetEmail()).Should(Equal("test@kubesphere.io"))
 		})

--- a/pkg/apiserver/authentication/identityprovider/oidc/oidc_test.go
+++ b/pkg/apiserver/authentication/identityprovider/oidc/oidc_test.go
@@ -198,7 +198,7 @@ var _ = Describe("OIDC", func() {
 			req := &http.Request{URL: url}
 			identity, err := provider.IdentityExchangeCallback(req)
 			Expect(err).Should(BeNil())
-			Expect(identity.GetUserID()).Should(Equal(base64.RawURLEncoding.EncodeToString([]byte("110169484474386276334")))
+			Expect(base64.URLEncoding.DecodeString(identity.GetUserID())).Should(Equal("110169484474386276334"))
 			Expect(identity.GetUsername()).Should(Equal("test"))
 			Expect(identity.GetEmail()).Should(Equal("test@kubesphere.io"))
 		})

--- a/pkg/apiserver/authentication/identityprovider/oidc/oidc_test.go
+++ b/pkg/apiserver/authentication/identityprovider/oidc/oidc_test.go
@@ -198,7 +198,7 @@ var _ = Describe("OIDC", func() {
 			req := &http.Request{URL: url}
 			identity, err := provider.IdentityExchangeCallback(req)
 			Expect(err).Should(BeNil())
-			Expect(identity.GetUserID()).Should(Equal("110169484474386276334"))
+			Expect(identity.GetUserID()).Should(Equal(base64.RawURLEncoding.EncodeToString([]byte("110169484474386276334")))
 			Expect(identity.GetUsername()).Should(Equal("test"))
 			Expect(identity.GetEmail()).Should(Equal("test@kubesphere.io"))
 		})


### PR DESCRIPTION
#### Issue
Users cannot login using an OIDC identity provider.

#### Kubesphere version
3.2.1

#### Error Message
Logs form ks-apiserver 
```json
{
  code: 422,
  statusText: 'Unprocessable Entity',
  message: `User.iam.kubesphere.io "{UNLUCKY-USER}" is invalid: metadata.labels: Invalid value: "{UNLUCK-USER_OIDC_SUB-StartOrEnd-Special-Char}": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')\n`
}
```

#### Cause
The standard claim **sub** in OIDC specs https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims is used as label ``` iam.kubesphere.io/origin-uid ```  in  https://github.com/kubesphere/kubesphere/blob/master/pkg/models/auth/authenticator.go#L82  , for the case OIDC as identity  provided referenced in https://github.com/kubesphere/kubesphere/blob/master/pkg/apiserver/authentication/identityprovider/oidc/oidc.go#L118

Kubernetes  doesn't allow special characters in start and end of labels value as for https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set

#### Proposed Workaround  
Since is OIDC claim cannot  be substituted  by another claim , the proposed  solution is to replace any special characters at start or end with **0**

#### Solution
Replace the label ``` iam.kubesphere.io/origin-uid ```  with  unique generated UID  based on combining OIDC claims while respecting Kubernetes  labels standards.  
