### PR TITLE
Fix the tiny typo in ks-openapi-spec

### DIFF
--- a/api/ks-openapi-spec/swagger.json
+++ b/api/ks-openapi-spec/swagger.json
@@ -12711,7 +12711,7 @@
         "tags": [
           "Namespace"
         ],
-        "summary": "List the namespaces of the specified workspace for the current user",
+        "summary": "Create the namespaces of the specified workspace for the current user",
         "operationId": "CreateNamespace",
         "parameters": [
           {

--- a/pkg/kapis/tenant/v1alpha2/register.go
+++ b/pkg/kapis/tenant/v1alpha2/register.go
@@ -190,7 +190,7 @@ func AddToContainer(c *restful.Container, factory informers.InformerFactory, k8s
 	ws.Route(ws.POST("/workspaces/{workspace}/namespaces").
 		To(handler.CreateNamespace).
 		Param(ws.PathParameter("workspace", "workspace name")).
-		Doc("List the namespaces of the specified workspace for the current user").
+		Doc("Create the namespaces of the specified workspace for the current user").
 		Reads(corev1.Namespace{}).
 		Returns(http.StatusOK, api.StatusOK, corev1.Namespace{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.NamespaceTag}))


### PR DESCRIPTION
There is tiny typo in Create Namespace API.
So fix it quickly.

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
