### PR TITLE
Set ready status to false when the cluster join federation failed

### DIFF
--- a/pkg/controller/cluster/cluster_controller.go
+++ b/pkg/controller/cluster/cluster_controller.go
@@ -421,6 +421,15 @@ func (c *clusterController) syncCluster(key string) error {
 				Message:            "Cluster can not join federation control plane",
 			}
 			c.updateClusterCondition(cluster, federationNotReadyCondition)
+			notReadyCondition := clusterv1alpha1.ClusterCondition{
+				Type:               clusterv1alpha1.ClusterReady,
+				Status:             v1.ConditionFalse,
+				LastUpdateTime:     metav1.Now(),
+				LastTransitionTime: metav1.Now(),
+				Reason:             err.Error(),
+				Message:            "Cluster is not available now",
+			}
+			c.updateClusterCondition(cluster, notReadyCondition)
 
 			_, err = c.ksClient.ClusterV1alpha1().Clusters().Update(context.TODO(), cluster, metav1.UpdateOptions{})
 			if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Currently, when a cluster is disconnected, we only update the `Federated` status, but not the `Ready` status, which causes the Ready status to remain true, this patch fixes this issue.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5125

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Set ready status to false when the cluster join federation failed.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @wansir 