### PR TITLE
Remove scheme duplicate registration code

### DIFF
--- a/pkg/controller/storage/capability/capability_controller.go
+++ b/pkg/controller/storage/capability/capability_controller.go
@@ -25,22 +25,17 @@ import (
 	"strconv"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"k8s.io/apimachinery/pkg/labels"
-
 	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	storageinformersv1 "k8s.io/client-go/informers/storage/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	storageclient "k8s.io/client-go/kubernetes/typed/storage/v1"
 	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
-
-	crdscheme "kubesphere.io/kubesphere/pkg/client/clientset/versioned/scheme"
 )
 
 const (
@@ -66,9 +61,6 @@ func NewController(
 	storageClassInformer storageinformersv1.StorageClassInformer,
 	csiDriverInformer storageinformersv1.CSIDriverInformer,
 ) *StorageCapabilityController {
-
-	utilruntime.Must(crdscheme.AddToScheme(scheme.Scheme))
-
 	controller := &StorageCapabilityController{
 		storageClassClient:    storageClassClient,
 		storageClassLister:    storageClassInformer.Lister(),

--- a/pkg/controller/storage/snapshotclass/snapshotclass_controller.go
+++ b/pkg/controller/storage/snapshotclass/snapshotclass_controller.go
@@ -24,24 +24,20 @@ import (
 	"strconv"
 	"time"
 
-	storagev1 "k8s.io/api/storage/v1"
-
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	snapshotclient "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned/typed/volumesnapshot/v1"
 	snapinformers "github.com/kubernetes-csi/external-snapshotter/client/v4/informers/externalversions/volumesnapshot/v1"
 	snapshotlisters "github.com/kubernetes-csi/external-snapshotter/client/v4/listers/volumesnapshot/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	storageinformersv1 "k8s.io/client-go/informers/storage/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
-
-	crdscheme "kubesphere.io/kubesphere/pkg/client/clientset/versioned/scheme"
 )
 
 const annotationAllowSnapshot = "storageclass.kubesphere.io/allow-snapshot"
@@ -63,9 +59,6 @@ func NewController(
 	snapshotClassClient snapshotclient.VolumeSnapshotClassInterface,
 	snapshotClassInformer snapinformers.VolumeSnapshotClassInformer,
 ) *VolumeSnapshotClassController {
-
-	utilruntime.Must(crdscheme.AddToScheme(scheme.Scheme))
-
 	controller := &VolumeSnapshotClassController{
 		storageClassLister:     storageClassInformer.Lister(),
 		storageClassSynced:     storageClassInformer.Informer().HasSynced,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind cleanup

### What this PR does / why we need it:

There are three reasons:

1. If necessary, registration should be done uniformly
2. The following code has no practical effect, both controllers use typed clients, and the corresponding scheme is already registered.
3. It may conflict with the helm controller, causing a resource to be registered twice. I encountered this problem in QKCP development and debugging:

https://github.com/kubesphere/kubesphere/blob/b47736c50082a1b25d244602774711f8fd0d0295/pkg/controller/helm/helm_controller.go#L59-L61

```
2022-08-16T11:28:35.986294819+08:00 W0816 11:28:35.985896       1 client_config.go:615] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
2022-08-16T11:28:35.992301122+08:00 I0816 11:28:35.992059       1 server.go:207] setting up manager
2022-08-16T11:28:36.075632825+08:00 I0816 11:28:36.075390       1 deleg.go:130] controller-runtime/metrics “msg”=“metrics server is starting to listen”  “addr”=“:8080"
2022-08-16T11:28:36.078868666+08:00 W0816 11:28:36.078683       1 controllers.go:171] ks-controller-manager starts without ldap provided, it will not sync user into ldap
2022-08-16T11:28:36.088035281+08:00 I0816 11:28:36.087811       1 reconciler.go:140] controllers/Helm “msg”=“Watching resource”  “group”=“gateway.kubesphere.io” “kind”=“Nginx” “version”=“v1alpha1"
2022-08-16T11:28:36.088059952+08:00 I0816 11:28:36.087874       1 helm_controller.go:76] configured watch gvk gateway.kubesphere.io/v1alpha1, Kind=Nginx chartPath /var/helm-charts/ingress-nginx maxConcurrentReconciles 8 reconcilePeriod 1m0s
2022-08-16T11:28:36.088132140+08:00 I0816 11:28:36.088031       1 reconciler.go:140] controllers/Helm “msg”=“Watching resource”  “group”=“gateway.kubesphere.io” “kind”=“Gateway” “version”=“v1alpha1"
2022-08-16T11:28:36.088142134+08:00 I0816 11:28:36.088054       1 helm_controller.go:76] configured watch gvk gateway.kubesphere.io/v1alpha1, Kind=Gateway chartPath /var/helm-charts/gateway maxConcurrentReconciles 8 reconcilePeriod 1m0s
2022-08-16T11:28:36.142027893+08:00 panic: Double registration of different types for gateway.kubesphere.io/v1alpha1, Kind=Gateway: old=k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured, new=kubesphere.io/api/gateway/v1alpha1.Gateway in scheme “k8s.io/client-go/kubernetes/scheme/register.go:72”
2022-08-16T11:28:36.142115043+08:00
2022-08-16T11:28:36.142131878+08:00 goroutine 67 [running]:
2022-08-16T11:28:36.142143232+08:00 k8s.io/apimachinery/pkg/runtime.(*Scheme).AddKnownTypeWithName(0xc000241880, 0x31a610a, 0x15, 0x31860f1, 0x8, 0x2990661, 0x7, 0x3604d50, 0xc0005bec40)
2022-08-16T11:28:36.142154101+08:00 	/workspace/vendor/k8s.io/apimachinery/pkg/runtime/scheme.go:193 +0xe57
2022-08-16T11:28:36.142165036+08:00 k8s.io/apimachinery/pkg/runtime.(*Scheme).AddKnownTypes(0xc000241880, 0x31a610a, 0x15, 0x31860f1, 0x8, 0xc0003ac2e0, 0x2, 0x2)
2022-08-16T11:28:36.142174699+08:00 	/workspace/vendor/k8s.io/apimachinery/pkg/runtime/scheme.go:170 +0x245
2022-08-16T11:28:36.142184824+08:00 sigs.k8s.io/controller-runtime/pkg/scheme.(*Builder).Register.func1(0xc000241880, 0x0, 0x0)
2022-08-16T11:28:36.142194585+08:00 	/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/scheme/scheme.go:72 +0x76
2022-08-16T11:28:36.142307976+08:00 k8s.io/apimachinery/pkg/runtime.(*SchemeBuilder).AddToScheme(0x4ceb2a0, 0xc000241880, 0x0, 0x0)
2022-08-16T11:28:36.142368518+08:00 	/workspace/vendor/k8s.io/apimachinery/pkg/runtime/scheme_builder.go:29 +0x6d
2022-08-16T11:28:36.142384483+08:00 sigs.k8s.io/controller-runtime/pkg/scheme.(*Builder).AddToScheme(...)
2022-08-16T11:28:36.142394641+08:00 	/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/scheme/scheme.go:87
2022-08-16T11:28:36.142462694+08:00 k8s.io/apimachinery/pkg/runtime.(*SchemeBuilder).AddToScheme(0x4ce4de0, 0xc000241880, 0x1, 0xc000da15f8)
2022-08-16T11:28:36.142481277+08:00 	/workspace/vendor/k8s.io/apimachinery/pkg/runtime/scheme_builder.go:29 +0x6d
2022-08-16T11:28:36.142493620+08:00 kubesphere.io/kubesphere/pkg/controller/storage/capability.NewController(0x367bb18, 0xc00103ec60, 0x36031a8, 0xc0004d8c90, 0x3603158, 0xc0004d8ca8, 0xc0009df0e0)
2022-08-16T11:28:36.142504090+08:00 	/workspace/pkg/controller/storage/capability/capability_controller.go:70 +0x46
2022-08-16T11:28:36.142513990+08:00 kubesphere.io/kubesphere/cmd/controller-manager/app.addAllControllers(0x368e4e8, 0xc00081c1e0, 0x367d5b8, 0xc0006de2d0, 0x3676078, 0xc0006ac380, 0xc0006d96b0, 0xc0009df0e0, 0x0, 0x319b4b9)
2022-08-16T11:28:36.142576028+08:00 	/workspace/cmd/controller-manager/app/controllers.go:355 +0x3505
2022-08-16T11:28:36.142592372+08:00 kubesphere.io/kubesphere/cmd/controller-manager/app.run(0xc0006d96b0, 0x3655078, 0xc0006ae000, 0x0, 0x0)
2022-08-16T11:28:36.142605274+08:00 	/workspace/cmd/controller-manager/app/server.go:224 +0x7a8
2022-08-16T11:28:36.142617339+08:00 kubesphere.io/kubesphere/cmd/controller-manager/app.Run.func1(0xc0006d96b0, 0xc0008801d0, 0xc0006fa000)
2022-08-16T11:28:36.142635618+08:00 	/workspace/cmd/controller-manager/app/server.go:136 +0x45
2022-08-16T11:28:36.142642348+08:00 created by kubesphere.io/kubesphere/cmd/controller-manager/app.Run
2022-08-16T11:28:36.142648213+08:00 	/workspace/cmd/controller-manager/app/server.go:135 +0x135
```

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @wansir @benjaminhuo 