### PR TITLE
remove unused port 8080

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,5 +14,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker build . --file build/ks-controller-manager/Dockerfile --tag ks-controller-manager:fix-2965
+    -
+      name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    -
+      name: Build and push
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        push: true
+        tags: kalavt/ks-controller-manager:latest
+        file: build/ks-controller-manager/Dockerfile
+

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file build/ks-controller-manager/Dockerfile --tag ks-controller-manager:fix-2965

--- a/build/ks-controller-manager/Dockerfile
+++ b/build/ks-controller-manager/Dockerfile
@@ -47,6 +47,6 @@ COPY --from=build_context /out/ /
 
 WORKDIR /
 
-EXPOSE 8443 8080
+EXPOSE 8443
 
 CMD ["sh"]

--- a/config/ks-core/templates/ks-controller-manager.yaml
+++ b/config/ks-core/templates/ks-controller-manager.yaml
@@ -40,8 +40,6 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: ks-controller-manager
         ports:
-        - containerPort: 8080
-          protocol: TCP
         - containerPort: 8443
           protocol: TCP
         resources:


### PR DESCRIPTION
### What type of PR is this?
/kind bug
/kind cleanup

### What this PR does / why we need it:
clean up code in ks-controller-manager, remove unused port 8080, enable KubeSphere work with "EKS, Calico, and node-local-dns installed"

### Which issue(s) this PR fixes:

Fixes 
https://github.com/kubesphere/console/issues/2965
https://github.com/kubesphere/ks-installer/issues/2103


### Special notes for reviewers:
```
while, it's not a really fix to above two issue.
but ks-controller-manager not really use port 8080, should be clean up. 
then the user running KubeSphere can set hostNetwork: true manually enable control panel communicate with ks-controller-manager.

currently, the useless port 8080 would conflict with cluster installed "node-local-dns" (it will occupied node 8080 port)
clean up this port will let user got chance work with "EKS, Calico, and node-local-dns installed" of cause, set hostNetwork: true in ks-controller-manager deployment manually.

```

### Does this PR introduced a user-facing change?
None

```release-note
clean up ks-controller-manager unused port 8080
```

### Additional documentation, usage docs, etc.:
```docs
None.
```
