### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/pkg/apiserver/auditing/types.go
+++ b/pkg/apiserver/auditing/types.go
@@ -21,7 +21,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -116,7 +116,6 @@ func (a *auditing) K8sAuditingEnabled() bool {
 //		info.Verb = "post"
 //		info.Name = created.Name
 //	}
-//
 func (a *auditing) LogRequestObject(req *http.Request, info *request.RequestInfo) *auditv1alpha1.Event {
 
 	// Ignore the dryRun k8s request.
@@ -190,13 +189,13 @@ func (a *auditing) LogRequestObject(req *http.Request, info *request.RequestInfo
 	}
 
 	if a.needAnalyzeRequestBody(e, req) {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			klog.Error(err)
 			return e
 		}
 		_ = req.Body.Close()
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		req.Body = io.NopCloser(bytes.NewBuffer(body))
 
 		if e.Level.GreaterOrEqual(audit.LevelRequest) {
 			e.RequestObject = &runtime.Unknown{Raw: body}

--- a/pkg/apiserver/authentication/identityprovider/aliyunidaas/idaas.go
+++ b/pkg/apiserver/authentication/identityprovider/aliyunidaas/idaas.go
@@ -19,7 +19,7 @@ package aliyunidaas
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/mitchellh/mapstructure"
@@ -134,7 +134,7 @@ func (a *aliyunIDaaS) IdentityExchangeCallback(req *http.Request) (identityprovi
 		return nil, err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apiserver/authentication/identityprovider/github/github.go
+++ b/pkg/apiserver/authentication/identityprovider/github/github.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -190,7 +190,7 @@ func (g *github) IdentityExchangeCallback(req *http.Request) (identityprovider.I
 		return nil, err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apiserver/authentication/identityprovider/ldap/ldap.go
+++ b/pkg/apiserver/authentication/identityprovider/ldap/ldap.go
@@ -21,7 +21,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/go-ldap/ldap"
@@ -186,7 +186,7 @@ func (l *ldapProvider) newConn() (*ldap.Conn, error) {
 	var err error
 	// Load CA cert
 	if l.RootCA != "" {
-		if caCert, err = ioutil.ReadFile(l.RootCA); err != nil {
+		if caCert, err = os.ReadFile(l.RootCA); err != nil {
 			klog.Error(err)
 			return nil, err
 		}

--- a/pkg/apiserver/authentication/identityprovider/ldap/ldap_test.go
+++ b/pkg/apiserver/authentication/identityprovider/ldap/ldap_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ldap
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -74,7 +73,7 @@ func TestLdapProvider_Authenticate(t *testing.T) {
 	if configFile == "" {
 		t.Skip("Skipped")
 	}
-	options, err := ioutil.ReadFile(configFile)
+	options, err := os.ReadFile(configFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
+++ b/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"kubesphere.io/kubesphere/pkg/utils/sliceutil"
@@ -251,7 +251,7 @@ func (o *oidcProvider) IdentityExchangeCallback(req *http.Request) (identityprov
 			if err != nil {
 				return nil, fmt.Errorf("failed to fetch userinfo: %v", err)
 			}
-			data, err := ioutil.ReadAll(resp.Body)
+			data, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return nil, fmt.Errorf("failed to fetch userinfo: %v", err)
 			}

--- a/pkg/apiserver/authentication/token/issuer.go
+++ b/pkg/apiserver/authentication/token/issuer.go
@@ -25,7 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"gopkg.in/square/go-jose.v2"
@@ -264,7 +264,7 @@ func loadSignKey(options *authentication.Options) (*rsa.PrivateKey, string, erro
 	var err error
 
 	if options.OAuthOptions.SignKey != "" {
-		signKeyData, err = ioutil.ReadFile(options.OAuthOptions.SignKey)
+		signKeyData, err = os.ReadFile(options.OAuthOptions.SignKey)
 		if err != nil {
 			klog.Errorf("issuer: failed to read private key file %s: %v", options.OAuthOptions.SignKey, err)
 			return nil, "", err

--- a/pkg/apiserver/config/config_test.go
+++ b/pkg/apiserver/config/config_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -206,7 +205,7 @@ func saveTestConfig(t *testing.T, conf *Config) {
 	if err != nil {
 		t.Fatalf("error marshal config. %v", err)
 	}
-	err = ioutil.WriteFile(fmt.Sprintf("%s.yaml", defaultConfigurationName), content, 0640)
+	err = os.WriteFile(fmt.Sprintf("%s.yaml", defaultConfigurationName), content, 0640)
 	if err != nil {
 		t.Fatalf("error write configuration file, %v", err)
 	}

--- a/pkg/controller/cluster/helper.go
+++ b/pkg/controller/cluster/helper.go
@@ -17,7 +17,7 @@ limitations under the License.
 package cluster
 
 import (
-	"io/ioutil"
+	"os"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -35,7 +35,7 @@ func buildKubeconfigFromRestConfig(config *rest.Config) ([]byte, error) {
 	// generated kubeconfig will be used by cluster federation, CAFile is not
 	// accepted by kubefed, so we need read CAFile
 	if len(apiCluster.CertificateAuthorityData) == 0 && len(config.CAFile) != 0 {
-		caData, err := ioutil.ReadFile(config.CAFile)
+		caData, err := os.ReadFile(config.CAFile)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/helm/helm_controller_test.go
+++ b/pkg/controller/helm/helm_controller_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package helm
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -73,8 +73,8 @@ var _ = Context("Helm reconcier", func() {
 	Describe("Gateway", func() {
 		It("Should setup gateway helm reconcier", func() {
 			data := "- group: gateway.kubesphere.io\n  version: v1alpha1\n  kind: Gateway\n  chart: ../../../config/gateway\n"
-			f, _ := ioutil.TempFile("", "watch")
-			ioutil.WriteFile(f.Name(), []byte(data), 0)
+			f, _ := os.CreateTemp("", "watch")
+			os.WriteFile(f.Name(), []byte(data), 0)
 
 			mgr, err := ctrl.NewManager(cfg, ctrl.Options{MetricsBindAddress: "0"})
 			Expect(err).NotTo(HaveOccurred(), "failed to create a manager")

--- a/pkg/kapis/cluster/v1alpha1/handler.go
+++ b/pkg/kapis/cluster/v1alpha1/handler.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -423,10 +422,10 @@ func validateKubeSphereAPIServer(config *rest.Config) (*version.Info, error) {
 	}
 	defer response.Body.Close()
 
-	responseBytes, _ := ioutil.ReadAll(response.Body)
+	responseBytes, _ := io.ReadAll(response.Body)
 	responseBody := string(responseBytes)
 
-	response.Body = ioutil.NopCloser(bytes.NewBuffer(responseBytes))
+	response.Body = io.NopCloser(bytes.NewBuffer(responseBytes))
 
 	if response.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("invalid response: %s , please make sure %s.%s.svc of member cluster is up and running", KubeSphereApiServer, constants.KubeSphereNamespace, responseBody)

--- a/pkg/kapis/monitoring/v1alpha3/handler.go
+++ b/pkg/kapis/monitoring/v1alpha3/handler.go
@@ -21,7 +21,7 @@ package v1alpha3
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -364,7 +364,7 @@ func (h handler) handleGrafanaDashboardImport(req *restful.Request, resp *restfu
 
 			defer r.Body.Close()
 
-			c, err := ioutil.ReadAll(r.Body)
+			c, err := io.ReadAll(r.Body)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/kapis/network/v1alpha2/handler.go
+++ b/pkg/kapis/network/v1alpha2/handler.go
@@ -18,7 +18,7 @@ package v1alpha2
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -54,7 +54,7 @@ func (h *handler) getNamespaceTopology(request *restful.Request, response *restf
 		return
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		klog.Errorf("read response error : %v", err)
@@ -86,7 +86,7 @@ func (h *handler) getNamespaceNodeTopology(request *restful.Request, response *r
 		return
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		klog.Errorf("read response error : %v", err)

--- a/pkg/kapis/notification/v2beta2/handler.go
+++ b/pkg/kapis/notification/v2beta2/handler.go
@@ -16,7 +16,7 @@
 package v2beta2
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/emicklei/go-restful"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -131,7 +131,7 @@ func (h *handler) PatchResource(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	data, err := ioutil.ReadAll(req.Request.Body)
+	data, err := io.ReadAll(req.Request.Body)
 	if err != nil {
 		api.HandleBadRequest(resp, req, err)
 		return

--- a/pkg/kapis/openpitrix/v1/handler.go
+++ b/pkg/kapis/openpitrix/v1/handler.go
@@ -16,7 +16,7 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/url"
 	"strconv"
@@ -987,7 +987,7 @@ func (h *openpitrixHandler) CreateAttachment(req *restful.Request, resp *restful
 			api.HandleBadRequest(resp, nil, err)
 			return
 		}
-		data, _ := ioutil.ReadAll(f)
+		data, _ := io.ReadAll(f)
 		f.Close()
 
 		att, err = h.openpitrix.CreateAttachment(data)

--- a/pkg/kapis/servicemesh/metrics/v1alpha2/handler.go
+++ b/pkg/kapis/servicemesh/metrics/v1alpha2/handler.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/emicklei/go-restful"
@@ -172,7 +172,7 @@ func (h *Handler) getData(response *restful.Response, url string) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 
 	if err != nil {
@@ -202,7 +202,7 @@ func (h *Handler) getJaegerData(response *restful.Response, url string) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 
 	if err != nil {

--- a/pkg/models/devops/devops.go
+++ b/pkg/models/devops/devops.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sort"
 	"strings"
@@ -306,7 +305,7 @@ func (d devopsOperator) ListPipelineObj(projectName string, filterFunc PipelineF
 	return api.ListResult{TotalItems: len(result), Items: items}, nil
 }
 
-//credentialobj in crd
+// credentialobj in crd
 func (d devopsOperator) CreateCredentialObj(projectName string, secret *v1.Secret) (*v1.Secret, error) {
 	projectObj, err := d.ksInformers.Devops().V1alpha3().DevOpsProjects().Lister().Get(projectName)
 	if err != nil {
@@ -837,7 +836,7 @@ func (d devopsOperator) GetOrgRepo(scmId, organizationId string, req *http.Reque
 // CreateSCMServers creates a Bitbucket server config item in Jenkins configuration if there's no same API address exist
 func (d devopsOperator) CreateSCMServers(scmId string, req *http.Request) (*devops.SCMServer, error) {
 
-	requestBody, err := ioutil.ReadAll(req.Body)
+	requestBody, err := io.ReadAll(req.Body)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
@@ -861,7 +860,7 @@ func (d devopsOperator) CreateSCMServers(scmId string, req *http.Request) (*devo
 			return &server, nil
 		}
 	}
-	req.Body = ioutil.NopCloser(bytes.NewReader(requestBody))
+	req.Body = io.NopCloser(bytes.NewReader(requestBody))
 
 	req.Method = http.MethodPost
 	resBody, err := d.devopsClient.CreateSCMServers(scmId, convertToHttpParameters(req))
@@ -977,7 +976,7 @@ func getInputReqBody(reqBody io.ReadCloser) (newReqBody io.ReadCloser, err error
 		Abort      bool                             `json:"abort,omitempty" description:"abort or not"`
 	}
 
-	Body, err := ioutil.ReadAll(reqBody)
+	Body, err := io.ReadAll(reqBody)
 	if err != nil {
 		klog.Error(err)
 		return nil, err
@@ -1002,7 +1001,7 @@ func getInputReqBody(reqBody io.ReadCloser) (newReqBody io.ReadCloser, err error
 func parseBody(body io.Reader) (newReqBody io.ReadCloser) {
 	rc, ok := body.(io.ReadCloser)
 	if !ok && body != nil {
-		rc = ioutil.NopCloser(body)
+		rc = io.NopCloser(body)
 	}
 	return rc
 }

--- a/pkg/models/kubeconfig/kubeconfig.go
+++ b/pkg/models/kubeconfig/kubeconfig.go
@@ -23,7 +23,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -102,7 +102,7 @@ func (o *operator) CreateKubeConfig(user *iamv1alpha2.User) error {
 	if len(o.config.CAData) > 0 {
 		ca = o.config.CAData
 	} else {
-		ca, err = ioutil.ReadFile(inClusterCAFilePath)
+		ca, err = os.ReadFile(inClusterCAFilePath)
 		if err != nil {
 			klog.Errorln(err)
 			return err

--- a/pkg/models/monitoring/sort_page_test.go
+++ b/pkg/models/monitoring/sort_page_test.go
@@ -18,8 +18,8 @@ package monitoring
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -161,7 +161,7 @@ func jsonFromFile(sourceFile, expectedFile string) (*Metrics, *Metrics, error) {
 	sourceJson := &Metrics{}
 	expectedJson := &Metrics{}
 
-	json, err := ioutil.ReadFile(fmt.Sprintf("./testdata/%s", sourceFile))
+	json, err := os.ReadFile(fmt.Sprintf("./testdata/%s", sourceFile))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -170,7 +170,7 @@ func jsonFromFile(sourceFile, expectedFile string) (*Metrics, *Metrics, error) {
 		return nil, nil, err
 	}
 
-	json, err = ioutil.ReadFile(fmt.Sprintf("./testdata/%s", expectedFile))
+	json, err = os.ReadFile(fmt.Sprintf("./testdata/%s", expectedFile))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/models/notification/notification.go
+++ b/pkg/models/notification/notification.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 
@@ -524,7 +523,7 @@ func (o *operator) Verify(request *restful.Request, response *restful.Response) 
 		return
 	}
 
-	reqBody, err := ioutil.ReadAll(request.Request.Body)
+	reqBody, err := io.ReadAll(request.Request.Body)
 	if err != nil {
 		klog.Error(err)
 		_ = response.WriteHeaderAndEntity(http.StatusBadRequest, err)

--- a/pkg/models/registries/registry_client.go
+++ b/pkg/models/registries/registry_client.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -179,7 +178,7 @@ func GetRespBody(resp *http.Response) ([]byte, error) {
 	} else {
 		reader = resp.Body
 	}
-	resBody, err := ioutil.ReadAll(reader)
+	resBody, err := io.ReadAll(reader)
 	if err != nil {
 		log.Error(err)
 		return nil, err

--- a/pkg/models/routers/routers.go
+++ b/pkg/models/routers/routers.go
@@ -19,7 +19,7 @@ package routers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -170,7 +170,7 @@ func (c *routerOperator) getRouterService(namespace string) (*corev1.Service, er
 // Load all resource yamls
 func loadYamls() ([]string, error) {
 	var yamls []string
-	files, err := ioutil.ReadDir(ingressControllerFolder)
+	files, err := os.ReadDir(ingressControllerFolder)
 	if err != nil {
 		klog.Warning(err)
 		return nil, err
@@ -180,7 +180,7 @@ func loadYamls() ([]string, error) {
 		if file.IsDir() || !strings.HasSuffix(file.Name(), ".yaml") {
 			continue
 		}
-		content, err := ioutil.ReadFile(ingressControllerFolder + "/" + file.Name())
+		content, err := os.ReadFile(ingressControllerFolder + "/" + file.Name())
 
 		if err != nil {
 			klog.Error(err)

--- a/pkg/simple/client/devops/fake/fakedevops.go
+++ b/pkg/simple/client/devops/fake/fakedevops.go
@@ -18,7 +18,7 @@ package fake
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -113,7 +113,7 @@ func (d *Devops) DeleteDevOpsProject(projectId string) error {
 				Header: http.Header{
 					"Foo": []string{"Bar"},
 				},
-				Body: ioutil.NopCloser(strings.NewReader("foo")), // shouldn't be used
+				Body: io.NopCloser(strings.NewReader("foo")), // shouldn't be used
 			},
 			Message: "",
 		}
@@ -136,7 +136,7 @@ func (d *Devops) GetDevOpsProject(projectId string) (string, error) {
 				Header: http.Header{
 					"Foo": []string{"Bar"},
 				},
-				Body: ioutil.NopCloser(strings.NewReader("foo")), // shouldn't be used
+				Body: io.NopCloser(strings.NewReader("foo")), // shouldn't be used
 				Request: &http.Request{
 					Method: "",
 					URL: &url.URL{
@@ -211,7 +211,7 @@ func (d *Devops) SubmitInputStep(projectName, pipelineName, runId, nodeId, stepI
 	return nil, nil
 }
 
-//BranchPipelinne operator interface
+// BranchPipelinne operator interface
 func (d *Devops) GetBranchPipeline(projectName, pipelineName, branchName string, httpParameters *devops.HttpParameters) (*devops.BranchPipeline, error) {
 	return nil, nil
 }
@@ -283,7 +283,7 @@ func (d *Devops) Validate(scmId string, httpParameters *devops.HttpParameters) (
 	return nil, nil
 }
 
-//Webhook operator interface
+// Webhook operator interface
 func (d *Devops) GetNotifyCommit(httpParameters *devops.HttpParameters) ([]byte, error) {
 	return nil, nil
 }
@@ -327,7 +327,7 @@ func (d *Devops) UpdateCredentialInProject(projectId string, credential *v1.Secr
 				Header: http.Header{
 					"Foo": []string{"Bar"},
 				},
-				Body: ioutil.NopCloser(strings.NewReader("foo")), // shouldn't be used
+				Body: io.NopCloser(strings.NewReader("foo")), // shouldn't be used
 				Request: &http.Request{
 					Method: "",
 					URL: &url.URL{
@@ -365,7 +365,7 @@ func (d *Devops) GetCredentialInProject(projectId, id string) (*devops.Credentia
 				Header: http.Header{
 					"Foo": []string{"Bar"},
 				},
-				Body: ioutil.NopCloser(strings.NewReader("foo")), // shouldn't be used
+				Body: io.NopCloser(strings.NewReader("foo")), // shouldn't be used
 				Request: &http.Request{
 					Method: "",
 					URL: &url.URL{
@@ -404,7 +404,7 @@ func (d *Devops) DeleteCredentialInProject(projectId, id string) (string, error)
 				Header: http.Header{
 					"Foo": []string{"Bar"},
 				},
-				Body: ioutil.NopCloser(strings.NewReader("foo")), // shouldn't be used
+				Body: io.NopCloser(strings.NewReader("foo")), // shouldn't be used
 				Request: &http.Request{
 					Method: "",
 					URL: &url.URL{
@@ -460,7 +460,7 @@ func (d *Devops) DeleteProjectPipeline(projectId string, pipelineId string) (str
 				Header: http.Header{
 					"Foo": []string{"Bar"},
 				},
-				Body: ioutil.NopCloser(strings.NewReader("foo")), // shouldn't be used
+				Body: io.NopCloser(strings.NewReader("foo")), // shouldn't be used
 				Request: &http.Request{
 					Method: "",
 					URL: &url.URL{
@@ -498,7 +498,7 @@ func (d *Devops) UpdateProjectPipeline(projectId string, pipeline *devopsv1alpha
 				Header: http.Header{
 					"Foo": []string{"Bar"},
 				},
-				Body: ioutil.NopCloser(strings.NewReader("foo")), // shouldn't be used
+				Body: io.NopCloser(strings.NewReader("foo")), // shouldn't be used
 				Request: &http.Request{
 					Method: "",
 					URL: &url.URL{
@@ -536,7 +536,7 @@ func (d *Devops) GetProjectPipelineConfig(projectId, pipelineId string) (*devops
 				Header: http.Header{
 					"Foo": []string{"Bar"},
 				},
-				Body: ioutil.NopCloser(strings.NewReader("foo")), // shouldn't be used
+				Body: io.NopCloser(strings.NewReader("foo")), // shouldn't be used
 				Request: &http.Request{
 					Method: "",
 					URL: &url.URL{

--- a/pkg/simple/client/devops/jenkins/jenkins.go
+++ b/pkg/simple/client/devops/jenkins/jenkins.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -849,7 +848,7 @@ func (j *Jenkins) CheckCron(projectName string, httpParameters *devops.HttpParam
 
 	reader = httpParameters.Body
 	//nolint:ineffassign,staticcheck
-	cronData, err := ioutil.ReadAll(reader)
+	cronData, err := io.ReadAll(reader)
 	err = json.Unmarshal(cronData, cron)
 	if err != nil {
 		klog.Error(err)

--- a/pkg/simple/client/devops/jenkins/request.go
+++ b/pkg/simple/client/devops/jenkins/request.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -185,7 +184,8 @@ func (r *Requester) SetClient(client *http.Client) *Requester {
 	return r
 }
 
-//Add auth on redirect if required.
+// Add auth on redirect if required.
+//
 //nolint:unused
 func (r *Requester) redirectPolicyFunc(req *http.Request, via []*http.Request) error {
 	if r.BasicAuth != nil {
@@ -448,7 +448,7 @@ func (r *Requester) DoPostForm(ar *APIRequest, responseStruct interface{}, form 
 func (r *Requester) ReadRawResponse(response *http.Response, responseStruct interface{}) (*http.Response, error) {
 	defer response.Body.Close()
 
-	content, err := ioutil.ReadAll(response.Body)
+	content, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -478,7 +478,7 @@ func CheckResponse(r *http.Response) error {
 	}
 	defer r.Body.Close()
 	errorResponse := &devops.ErrorResponse{Response: r}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err == nil && data != nil {
 		errorResponse.Body = data
 		errorResponse.Message = string(data)

--- a/pkg/simple/client/devops/jenkins/utils.go
+++ b/pkg/simple/client/devops/jenkins/utils.go
@@ -18,7 +18,6 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -64,7 +63,7 @@ func getRespBody(resp *http.Response) ([]byte, error) {
 	} else {
 		reader = resp.Body
 	}
-	resBody, err := ioutil.ReadAll(reader)
+	resBody, err := io.ReadAll(reader)
 	if err != nil {
 		klog.Error(err)
 		return nil, err

--- a/pkg/simple/client/es/client_test.go
+++ b/pkg/simple/client/es/client_test.go
@@ -18,9 +18,9 @@ package es
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -158,7 +158,7 @@ func TestOpensearchClient_Search(t *testing.T) {
 func mockElasticsearchService(pattern, fakeResp string, fakeCode int) *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc(pattern, func(res http.ResponseWriter, req *http.Request) {
-		b, _ := ioutil.ReadFile(fmt.Sprintf("./testdata/%s", fakeResp))
+		b, _ := os.ReadFile(fmt.Sprintf("./testdata/%s", fakeResp))
 		res.WriteHeader(fakeCode)
 		res.Write(b)
 	})
@@ -166,7 +166,7 @@ func mockElasticsearchService(pattern, fakeResp string, fakeCode int) *httptest.
 }
 
 func JsonFromFile(expectedFile string, expectedJsonPtr interface{}) error {
-	json, err := ioutil.ReadFile(fmt.Sprintf("./testdata/%s", expectedFile))
+	json, err := os.ReadFile(fmt.Sprintf("./testdata/%s", expectedFile))
 	if err != nil {
 		return err
 	}

--- a/pkg/simple/client/es/versions/opensearchv1/opensearchv1.go
+++ b/pkg/simple/client/es/versions/opensearchv1/opensearchv1.go
@@ -22,7 +22,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -81,7 +81,7 @@ func (o *OpenSearch) Search(indices string, body []byte, scroll bool) ([]byte, e
 		return nil, parseError(response)
 	}
 
-	return ioutil.ReadAll(response.Body)
+	return io.ReadAll(response.Body)
 }
 
 func (o *OpenSearch) Scroll(id string) ([]byte, error) {
@@ -98,7 +98,7 @@ func (o *OpenSearch) Scroll(id string) ([]byte, error) {
 		return nil, parseError(response)
 	}
 
-	return ioutil.ReadAll(response.Body)
+	return io.ReadAll(response.Body)
 }
 
 func (o *OpenSearch) ClearScroll(scrollId string) {

--- a/pkg/simple/client/es/versions/opensearchv2/opensearchv2.go
+++ b/pkg/simple/client/es/versions/opensearchv2/opensearchv2.go
@@ -22,7 +22,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -81,7 +81,7 @@ func (o *OpenSearch) Search(indices string, body []byte, scroll bool) ([]byte, e
 		return nil, parseError(response)
 	}
 
-	return ioutil.ReadAll(response.Body)
+	return io.ReadAll(response.Body)
 }
 
 func (o *OpenSearch) Scroll(id string) ([]byte, error) {
@@ -98,7 +98,7 @@ func (o *OpenSearch) Scroll(id string) ([]byte, error) {
 		return nil, parseError(response)
 	}
 
-	return ioutil.ReadAll(response.Body)
+	return io.ReadAll(response.Body)
 }
 
 func (o *OpenSearch) ClearScroll(scrollId string) {

--- a/pkg/simple/client/es/versions/v5/v5.go
+++ b/pkg/simple/client/es/versions/v5/v5.go
@@ -22,7 +22,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -81,7 +81,7 @@ func (e *Elastic) Search(indices string, body []byte, scroll bool) ([]byte, erro
 		return nil, parseError(response)
 	}
 
-	return ioutil.ReadAll(response.Body)
+	return io.ReadAll(response.Body)
 }
 
 func (e *Elastic) Scroll(id string) ([]byte, error) {
@@ -98,7 +98,7 @@ func (e *Elastic) Scroll(id string) ([]byte, error) {
 		return nil, parseError(response)
 	}
 
-	return ioutil.ReadAll(response.Body)
+	return io.ReadAll(response.Body)
 }
 
 func (e *Elastic) ClearScroll(scrollId string) {

--- a/pkg/simple/client/es/versions/v6/v6.go
+++ b/pkg/simple/client/es/versions/v6/v6.go
@@ -22,7 +22,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -81,7 +81,7 @@ func (e *Elastic) Search(indices string, body []byte, scroll bool) ([]byte, erro
 		return nil, parseError(response)
 	}
 
-	return ioutil.ReadAll(response.Body)
+	return io.ReadAll(response.Body)
 }
 
 func (e *Elastic) Scroll(id string) ([]byte, error) {
@@ -98,7 +98,7 @@ func (e *Elastic) Scroll(id string) ([]byte, error) {
 		return nil, parseError(response)
 	}
 
-	return ioutil.ReadAll(response.Body)
+	return io.ReadAll(response.Body)
 }
 
 func (e *Elastic) ClearScroll(scrollId string) {

--- a/pkg/simple/client/es/versions/v7/v7.go
+++ b/pkg/simple/client/es/versions/v7/v7.go
@@ -22,7 +22,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -82,7 +82,7 @@ func (e *Elastic) Search(indices string, body []byte, scroll bool) ([]byte, erro
 		return nil, parseError(response)
 	}
 
-	return ioutil.ReadAll(response.Body)
+	return io.ReadAll(response.Body)
 }
 
 func (e *Elastic) Scroll(id string) ([]byte, error) {
@@ -99,7 +99,7 @@ func (e *Elastic) Scroll(id string) ([]byte, error) {
 		return nil, parseError(response)
 	}
 
-	b, err := ioutil.ReadAll(response.Body)
+	b, err := io.ReadAll(response.Body)
 	return b, err
 }
 

--- a/pkg/simple/client/kiali/client.go
+++ b/pkg/simple/client/kiali/client.go
@@ -19,7 +19,7 @@ package kiali
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -109,7 +109,7 @@ func (c *Client) authenticate() (*TokenResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/simple/client/kiali/client_test.go
+++ b/pkg/simple/client/kiali/client_test.go
@@ -19,7 +19,7 @@ package kiali
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -70,7 +70,7 @@ func TestClient_Get(t *testing.T) {
 			args: args{url: "http://kiali.istio-system.svc"},
 			wantResp: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("fake"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("fake"))),
 			},
 			wantErr: false,
 		},
@@ -89,7 +89,7 @@ func TestClient_Get(t *testing.T) {
 			args: args{url: "http://kiali.istio-system.svc"},
 			wantResp: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("fake"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("fake"))),
 			},
 			wantErr: false,
 		},
@@ -108,7 +108,7 @@ func TestClient_Get(t *testing.T) {
 			args: args{url: "http://kiali.istio-system.svc"},
 			wantResp: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("fake"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("fake"))),
 			},
 			wantErr: false,
 		},

--- a/pkg/simple/client/kiali/mock_client.go
+++ b/pkg/simple/client/kiali/mock_client.go
@@ -2,7 +2,7 @@ package kiali
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -15,13 +15,13 @@ type MockClient struct {
 func (c *MockClient) Do(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(c.RequestResult))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(c.RequestResult))),
 	}, nil
 }
 
 func (c *MockClient) PostForm(url string, data url.Values) (resp *http.Response, err error) {
 	return &http.Response{
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewReader(c.TokenResult)),
+		Body:       io.NopCloser(bytes.NewReader(c.TokenResult)),
 	}, nil
 }

--- a/pkg/simple/client/logging/elasticsearch/elasticsearch_test.go
+++ b/pkg/simple/client/logging/elasticsearch/elasticsearch_test.go
@@ -18,9 +18,9 @@ package elasticsearch
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -274,7 +274,7 @@ func TestParseToQueryPart(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 
-			expected, err := ioutil.ReadFile(fmt.Sprintf("./testdata/%s", test.expected))
+			expected, err := os.ReadFile(fmt.Sprintf("./testdata/%s", test.expected))
 			if err != nil {
 				t.Fatalf("read expected error, %s", err.Error())
 			}
@@ -290,7 +290,7 @@ func TestParseToQueryPart(t *testing.T) {
 func mockElasticsearchService(pattern, fakeResp string, fakeCode int) *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc(pattern, func(res http.ResponseWriter, req *http.Request) {
-		b, _ := ioutil.ReadFile(fmt.Sprintf("./testdata/%s", fakeResp))
+		b, _ := os.ReadFile(fmt.Sprintf("./testdata/%s", fakeResp))
 		res.WriteHeader(fakeCode)
 		_, _ = res.Write(b)
 	})
@@ -298,7 +298,7 @@ func mockElasticsearchService(pattern, fakeResp string, fakeCode int) *httptest.
 }
 
 func JsonFromFile(expectedFile string, expectedJsonPtr interface{}) error {
-	json, err := ioutil.ReadFile(fmt.Sprintf("./testdata/%s", expectedFile))
+	json, err := os.ReadFile(fmt.Sprintf("./testdata/%s", expectedFile))
 	if err != nil {
 		return err
 	}

--- a/pkg/simple/client/monitoring/metricsserver/metricsserver_test.go
+++ b/pkg/simple/client/monitoring/metricsserver/metricsserver_test.go
@@ -2,10 +2,9 @@ package metricsserver
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
-
-	"io/ioutil"
 
 	"github.com/google/go-cmp/cmp"
 	jsoniter "github.com/json-iterator/go"
@@ -514,7 +513,7 @@ func TestGetNamedMetricsOverTime(t *testing.T) {
 }
 
 func jsonFromFile(expectedFile string, expectedJsonPtr interface{}) error {
-	json, err := ioutil.ReadFile(fmt.Sprintf("./testdata/%s", expectedFile))
+	json, err := os.ReadFile(fmt.Sprintf("./testdata/%s", expectedFile))
 	if err != nil {
 		return err
 	}

--- a/pkg/simple/client/monitoring/prometheus/prometheus_test.go
+++ b/pkg/simple/client/monitoring/prometheus/prometheus_test.go
@@ -18,9 +18,9 @@ package prometheus
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -176,14 +176,14 @@ func TestGetMetricLabelSet(t *testing.T) {
 func mockPrometheusService(pattern, fakeResp string) *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc(pattern, func(res http.ResponseWriter, req *http.Request) {
-		b, _ := ioutil.ReadFile(fmt.Sprintf("./testdata/%s", fakeResp))
+		b, _ := os.ReadFile(fmt.Sprintf("./testdata/%s", fakeResp))
 		res.Write(b)
 	})
 	return httptest.NewServer(mux)
 }
 
 func jsonFromFile(expectedFile string, expectedJsonPtr interface{}) error {
-	json, err := ioutil.ReadFile(fmt.Sprintf("./testdata/%s", expectedFile))
+	json, err := os.ReadFile(fmt.Sprintf("./testdata/%s", expectedFile))
 	if err != nil {
 		return err
 	}

--- a/pkg/simple/client/openpitrix/helmrepoindex/repo_index.go
+++ b/pkg/simple/client/openpitrix/helmrepoindex/repo_index.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -275,7 +274,7 @@ func ByteArrayToSavedIndex(data []byte) (*SavedIndex, error) {
 		return nil, err
 	}
 	r.Close()
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 
 	if err != nil && err != io.EOF {
 		return nil, err

--- a/pkg/simple/client/openpitrix/helmwrapper/helm_wrapper_test.go
+++ b/pkg/simple/client/openpitrix/helmwrapper/helm_wrapper_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package helmwrapper
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -42,7 +41,7 @@ func TestHelmInstall(t *testing.T) {
 
 func TempDir(t *testing.T) string {
 	t.Helper()
-	d, err := ioutil.TempDir("", "kubesphere")
+	d, err := os.MkdirTemp("", "kubesphere")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +65,7 @@ func GenerateChartData(t *testing.T, name string) string {
 	if err != nil {
 		t.Fatalf("Error creating chart for test: %v", err)
 	}
-	charData, err := ioutil.ReadFile(filename)
+	charData, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatalf("Error loading chart data %v", err)
 	}

--- a/pkg/simple/client/s3/fake/fakes3.go
+++ b/pkg/simple/client/s3/fake/fakes3.go
@@ -19,7 +19,6 @@ package fake
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -66,7 +65,7 @@ func (s *FakeS3) Delete(key string) error {
 
 func (s *FakeS3) Read(key string) ([]byte, error) {
 	if o, ok := s.Storage[key]; ok && o.Body != nil {
-		data, err := ioutil.ReadAll(o.Body)
+		data, err := io.ReadAll(o.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/test/testing.go
+++ b/pkg/test/testing.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -107,7 +107,7 @@ func (t *TestCtx) Setup(yamlPath string, crdPath string, schemes ...AddToSchemeF
 	if err != nil {
 		return err
 	}
-	bytes, err := ioutil.ReadFile(yamlPath)
+	bytes, err := os.ReadFile(yamlPath)
 	if err != nil {
 		klog.Errorln("Failed to read yaml file")
 		return err

--- a/staging/src/kubesphere.io/api/servicemesh/v1alpha2/strategy_types_test.go
+++ b/staging/src/kubesphere.io/api/servicemesh/v1alpha2/strategy_types_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package v1alpha2
 
 import (
-	"io/ioutil"
 	"log"
+	"os"
 	"testing"
 
 	apinetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
@@ -89,7 +89,7 @@ func TestStrategyRead(t *testing.T) {
 	//g := gomega.NewGomegaWithT(t)
 
 	var str []byte
-	file, err := ioutil.ReadFile("/Users/zry/go/src/kubesphere.io/kubesphere/config/samples/servicemesh_v1alpha2_strategy.yaml")
+	file, err := os.ReadFile("/Users/zry/go/src/kubesphere.io/kubesphere/config/samples/servicemesh_v1alpha2_strategy.yaml")
 	if err == nil {
 		obj, _, _ := scheme.Codecs.UniversalDeserializer().Decode(file, nil, &Strategy{})
 		switch obj.(type) {

--- a/tools/cmd/crd-doc-gen/main.go
+++ b/tools/cmd/crd-doc-gen/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -198,7 +197,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = ioutil.WriteFile(output, []byte(spec), 0644)
+	err = os.WriteFile(output, []byte(spec), 0644)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tools/cmd/doc-gen/main.go
+++ b/tools/cmd/doc-gen/main.go
@@ -20,8 +20,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	restfulspec "github.com/emicklei/go-restful-openapi"
 	"github.com/go-openapi/loads"
@@ -255,7 +255,7 @@ func generateSwaggerJson() []byte {
 	})
 
 	data, _ := json.MarshalIndent(swagger, "", "  ")
-	err := ioutil.WriteFile(output, data, 0644)
+	err := os.WriteFile(output, data, 0644)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind cleanup

### What this PR does / why we need it:

The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`)
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

### Which issue(s) this PR fixes:


### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?

```release-note
None
```

### Additional documentation, usage docs, etc.:
