### PR TITLE
Check the server url when updating the cluster

### DIFF
--- a/pkg/controller/cluster/cluster_controller.go
+++ b/pkg/controller/cluster/cluster_controller.go
@@ -179,7 +179,14 @@ func NewClusterController(
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			oldCluster := oldObj.(*clusterv1alpha1.Cluster)
 			newCluster := newObj.(*clusterv1alpha1.Cluster)
-			if !reflect.DeepEqual(oldCluster.Spec, newCluster.Spec) || newCluster.DeletionTimestamp != nil {
+
+			oldConfig, oldErr := clientcmd.Load(oldCluster.Spec.Connection.KubeConfig)
+			newConfig, newErr := clientcmd.Load(oldCluster.Spec.Connection.KubeConfig)
+			if oldErr != nil || newErr != nil {
+				return
+			}
+			if oldConfig.Clusters[oldConfig.CurrentContext].Server == newConfig.Clusters[newConfig.CurrentContext].Server ||
+				!reflect.DeepEqual(oldCluster.Spec, newCluster.Spec) || newCluster.DeletionTimestamp != nil {
 				c.enqueueCluster(newObj)
 			}
 		},


### PR DESCRIPTION
Signed-off-by: yzx <946666800@qq.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
Add one of the following kinds:
/kind feature


### What this PR does / why we need it:
When updating the cluster, check the server url to avoid heavy losses caused by copying wrong files


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

