### PR TITLE
Check the cluster ID (kube-system UID) when updating the cluster

### DIFF
--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -39,6 +39,7 @@ import (
 	"kubesphere.io/kubesphere/cmd/controller-manager/app/options"
 	"kubesphere.io/kubesphere/pkg/apis"
 	controllerconfig "kubesphere.io/kubesphere/pkg/apiserver/config"
+	"kubesphere.io/kubesphere/pkg/controller/cluster"
 	"kubesphere.io/kubesphere/pkg/controller/network/webhooks"
 	"kubesphere.io/kubesphere/pkg/controller/quota"
 	"kubesphere.io/kubesphere/pkg/controller/user"
@@ -237,6 +238,9 @@ func run(s *options.KubeSphereControllerManagerOptions, ctx context.Context) err
 	hookServer := mgr.GetWebhookServer()
 
 	klog.V(2).Info("registering webhooks to the webhook server")
+	if s.IsControllerEnabled("cluster") && s.MultiClusterOptions.Enable {
+		hookServer.Register("/validate-cluster-kubesphere-io-v1alpha1", &webhook.Admission{Handler: &cluster.ValidatingHandler{Client: mgr.GetClient()}})
+	}
 	hookServer.Register("/validate-email-iam-kubesphere-io-v1alpha2", &webhook.Admission{Handler: &user.EmailValidator{Client: mgr.GetClient()}})
 	hookServer.Register("/validate-network-kubesphere-io-v1alpha1", &webhook.Admission{Handler: &webhooks.ValidatingHandler{C: mgr.GetClient()}})
 	hookServer.Register("/mutate-network-kubesphere-io-v1alpha1", &webhook.Admission{Handler: &webhooks.MutatingHandler{C: mgr.GetClient()}})

--- a/pkg/controller/cluster/cluster_webhook.go
+++ b/pkg/controller/cluster/cluster_webhook.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2020 The KubeSphere Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+
+	v1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	clusterv1alpha1 "kubesphere.io/api/cluster/v1alpha1"
+)
+
+type ValidatingHandler struct {
+	Client  client.Client
+	decoder *admission.Decoder
+}
+
+var _ admission.DecoderInjector = &ValidatingHandler{}
+
+// InjectDecoder injects the decoder into a ValidatingHandler.
+func (h *ValidatingHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+// Handle handles admission requests.
+func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+
+	if req.Operation != v1.Update {
+		return admission.Allowed("")
+	}
+
+	newCluster := &clusterv1alpha1.Cluster{}
+	err := h.decoder.DecodeRaw(req.Object, newCluster)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	oldCluster := &clusterv1alpha1.Cluster{}
+	err = h.decoder.DecodeRaw(req.OldObject, oldCluster)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if reflect.DeepEqual(oldCluster.Spec, newCluster.Spec) {
+		return admission.Allowed("")
+	}
+
+	clusterConfig, err := clientcmd.RESTConfigFromKubeConfig(newCluster.Spec.Connection.KubeConfig)
+	if err != nil {
+		return admission.Denied(fmt.Sprintf("failed to load cluster config for %s: %s", newCluster.Name, err))
+	}
+
+	clusterClient, err := kubernetes.NewForConfig(clusterConfig)
+	if err != nil {
+		return admission.Denied(err.Error())
+	}
+	kubeSystem, err := clusterClient.CoreV1().Namespaces().Get(ctx, metav1.NamespaceSystem, metav1.GetOptions{})
+	if err != nil {
+		return admission.Denied(err.Error())
+	}
+
+	if oldCluster.Status.UID != kubeSystem.UID {
+		return admission.Denied("this kubeconfig corresponds to a different cluster than the previous one, you need to make sure that kubeconfig is not from another cluster")
+	}
+
+	return admission.Allowed("")
+}

--- a/pkg/controller/cluster/cluster_webhook.go
+++ b/pkg/controller/cluster/cluster_webhook.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"reflect"
 
 	v1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,10 +61,6 @@ func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) a
 	err = h.decoder.DecodeRaw(req.OldObject, oldCluster)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
-	}
-
-	if reflect.DeepEqual(oldCluster.Spec, newCluster.Spec) {
-		return admission.Allowed("")
 	}
 
 	clusterConfig, err := clientcmd.RESTConfigFromKubeConfig(newCluster.Spec.Connection.KubeConfig)


### PR DESCRIPTION
Signed-off-by: yzx <946666800@qq.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature


### What this PR does / why we need it:
When manual updating the cluster crd resource, check the cluster ID (kube-system UID)  to avoid heavy losses caused by copying wrong files.Because kubefed automatically performs a lot of irreversible operations

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

This also requires adding a validatingwebhookconfiguration,like
```yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
  annotations:
    meta.helm.sh/release-name: ks-core
    meta.helm.sh/release-namespace: kubesphere-system
  labels:
    app.kubernetes.io/managed-by: Helm
  name: cluster.kubesphere.io
webhooks:
- admissionReviewVersions:
  - v1beta1
  clientConfig:
    caBundle: <data>
    service:
      name: ks-controller-manager
      namespace: kubesphere-system
      path: /validate-cluster-kubesphere-io-v1alpha1
      port: 443
  failurePolicy: Fail
  matchPolicy: Exact
  name: validating-cluster.kubesphere.io
  namespaceSelector:
    matchExpressions:
    - key: control-plane
      operator: DoesNotExist
  objectSelector: {}
  rules:
  - apiGroups:
    - cluster.kubesphere.io
    apiVersions:
    - v1alpha1
    operations:
    - UPDATE
    resources:
    - clusters
    scope: '*'
  sideEffects: None
  timeoutSeconds: 30
```

I also submitted it in ks-installer https://github.com/kubesphere/ks-installer/pull/2131

