### PR TITLE
support ksv project label to initialize role when create ksv project

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -47,6 +47,7 @@ const (
 	CreatorAnnotationKey              = "kubesphere.io/creator"
 	UsernameLabelKey                  = "kubesphere.io/username"
 	DevOpsProjectLabelKey             = "kubesphere.io/devopsproject"
+	KsvProjectLabelKey                = "virtualization.kubesphere.io/enable"
 	KubefedManagedLabel               = "kubefed.io/managed"
 
 	UserNameHeader = "X-Token-Username"

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -154,7 +154,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	// Initialize roles for devops/project namespaces if created by kubesphere
 	_, hasDevOpsProjectLabel := namespace.Labels[constants.DevOpsProjectLabelKey]
-	if hasDevOpsProjectLabel || hasWorkspaceLabel {
+	_, hasKsvProjectLabel := namespace.Labels[constants.KsvProjectLabelKey]
+	if hasDevOpsProjectLabel || hasKsvProjectLabel || hasWorkspaceLabel {
 		if err := r.initRoles(rootCtx, logger, namespace); err != nil {
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
### What type of PR is this?
/kind feature


### What this PR does / why we need it:
Currently hope to deploy ks and ksv in a cluster, then ksv has removed project controller, and ksv project will be managed by ks project controller,  so ks project controller should support ksv project label to initialize role when create ksv project

### Which issue(s) this PR fixes:
Fixes #
