### PR TITLE
fix rulegroup typemeta miss

### DIFF
--- a/pkg/models/alerting/rulegroup.go
+++ b/pkg/models/alerting/rulegroup.go
@@ -102,6 +102,7 @@ func (o *ruleGroupOperator) listRuleGroups(ctx context.Context, namespace string
 	// copy status info of statusRuleGroups to matched rulegroups
 	var groups = make([]runtime.Object, len(resourceRuleGroups))
 	for i := range resourceRuleGroups {
+		setRuleGroupResourceTypeMeta(resourceRuleGroups[i])
 		g := &kapialertingv2beta1.RuleGroup{
 			RuleGroup: *resourceRuleGroups[i],
 			Status: kapialertingv2beta1.RuleGroupStatus{
@@ -295,6 +296,8 @@ func (o *ruleGroupOperator) GetRuleGroup(ctx context.Context, namespace, name st
 		return nil, err
 	}
 
+	setRuleGroupResourceTypeMeta(resourceRuleGroup)
+
 	ret := &kapialertingv2beta1.RuleGroup{
 		RuleGroup: *resourceRuleGroup,
 		Status: kapialertingv2beta1.RuleGroupStatus{
@@ -384,6 +387,7 @@ func (o *ruleGroupOperator) listClusterRuleGroups(ctx context.Context, selector 
 	// copy status info of statusRuleGroups to matched rulegroups
 	var groups = make([]runtime.Object, len(resourceRuleGroups))
 	for i := range resourceRuleGroups {
+		setRuleGroupResourceTypeMeta(resourceRuleGroups[i])
 		g := &kapialertingv2beta1.ClusterRuleGroup{
 			ClusterRuleGroup: *resourceRuleGroups[i],
 			Status: kapialertingv2beta1.RuleGroupStatus{
@@ -488,6 +492,8 @@ func (o *ruleGroupOperator) GetClusterRuleGroup(ctx context.Context, name string
 		return nil, err
 	}
 
+	setRuleGroupResourceTypeMeta(resourceRuleGroup)
+
 	ret := &kapialertingv2beta1.ClusterRuleGroup{
 		ClusterRuleGroup: *resourceRuleGroup,
 		Status: kapialertingv2beta1.RuleGroupStatus{
@@ -573,6 +579,7 @@ func (o *ruleGroupOperator) listGlobalRuleGroups(ctx context.Context, selector l
 	// copy status info of statusRuleGroups to matched rulegroups
 	var groups = make([]runtime.Object, len(resourceRuleGroups))
 	for i := range resourceRuleGroups {
+		setRuleGroupResourceTypeMeta(resourceRuleGroups[i])
 		g := &kapialertingv2beta1.GlobalRuleGroup{
 			GlobalRuleGroup: *resourceRuleGroups[i],
 			Status: kapialertingv2beta1.RuleGroupStatus{
@@ -731,6 +738,8 @@ func (o *ruleGroupOperator) GetGlobalRuleGroup(ctx context.Context, name string)
 		return nil, err
 	}
 
+	setRuleGroupResourceTypeMeta(resourceRuleGroup)
+
 	ret := &kapialertingv2beta1.GlobalRuleGroup{
 		GlobalRuleGroup: *resourceRuleGroup,
 		Status: kapialertingv2beta1.RuleGroupStatus{
@@ -888,4 +897,24 @@ var (
 type wrapAlert struct {
 	kapialertingv2beta1.Alert
 	runtime.Object
+}
+
+var (
+	apiVersion = alertingv2beta1.SchemeGroupVersion.String()
+)
+
+// set TypeMeta info because the objects getted by lister.List() and lister.Get() may have no TypeMeta
+// related issue: https://github.com/kubernetes/client-go/issues/541
+func setRuleGroupResourceTypeMeta(obj runtime.Object) {
+	switch o := obj.(type) {
+	case *alertingv2beta1.RuleGroup:
+		o.APIVersion = apiVersion
+		o.Kind = alertingv2beta1.ResourceKindRuleGroup
+	case *alertingv2beta1.ClusterRuleGroup:
+		o.APIVersion = apiVersion
+		o.Kind = alertingv2beta1.ResourceKindClusterRuleGroup
+	case *alertingv2beta1.GlobalRuleGroup:
+		o.APIVersion = apiVersion
+		o.Kind = alertingv2beta1.ResourceKindGlobalRuleGroup
+	}
 }

--- a/staging/src/kubesphere.io/api/alerting/v2beta1/rulegroup_types.go
+++ b/staging/src/kubesphere.io/api/alerting/v2beta1/rulegroup_types.go
@@ -25,6 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+const (
+	ResourceKindRuleGroup        = "RuleGroup"
+	ResourceKindClusterRuleGroup = "ClusterRuleGroup"
+	ResourceKindGlobalRuleGroup  = "GlobalRuleGroup"
+)
+
 // Duration is a valid time unit
 // Supported units: y, w, d, h, m, s, ms Examples: `30s`, `1m`, `1h20m15s`
 // +kubebuilder:validation:Pattern:="^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

set `apiVersion` and `kind` to objects which is return by client-go informer and may have no api Kind info 

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
