### PR TITLE
limit rule count per group

### DIFF
--- a/staging/src/kubesphere.io/api/alerting/v2beta1/rulegroup_webhook.go
+++ b/staging/src/kubesphere.io/api/alerting/v2beta1/rulegroup_webhook.go
@@ -33,7 +33,10 @@ import (
 
 var rulegrouplog = logf.Log.WithName("rulegroup")
 
-const RuleLabelKeyRuleId = "rule_id"
+const (
+	RuleLabelKeyRuleId   = "rule_id"
+	MaxRuleCountPerGroup = 40
+)
 
 func (r *RuleGroup) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
@@ -87,6 +90,10 @@ func (r *RuleGroup) ValidateDelete() error {
 func (r *RuleGroup) Validate() error {
 	log := rulegrouplog.WithValues("name", r.Namespace+"/"+r.Name)
 	log.Info("validate")
+
+	if len(r.Spec.Rules) > MaxRuleCountPerGroup {
+		return fmt.Errorf("the rule group has %d rules, exceeding the max count (%d)", len(r.Spec.Rules), MaxRuleCountPerGroup)
+	}
 
 	var rules []Rule
 	for _, r := range r.Spec.Rules {
@@ -210,6 +217,10 @@ func (r *ClusterRuleGroup) Validate() error {
 	log := clusterrulegrouplog.WithValues("name", r.Name)
 	log.Info("validate")
 
+	if len(r.Spec.Rules) > MaxRuleCountPerGroup {
+		return fmt.Errorf("the rule group has %d rules, exceeding the max count (%d)", len(r.Spec.Rules), MaxRuleCountPerGroup)
+	}
+
 	var rules []Rule
 	for _, r := range r.Spec.Rules {
 		rules = append(rules, r.Rule)
@@ -306,6 +317,10 @@ func (r *GlobalRuleGroup) ValidateDelete() error {
 func (r *GlobalRuleGroup) Validate() error {
 	log := globalrulegrouplog.WithValues("name", r.Name)
 	log.Info("validate")
+
+	if len(r.Spec.Rules) > MaxRuleCountPerGroup {
+		return fmt.Errorf("the rule group has %d rules, exceeding the max count (%d)", len(r.Spec.Rules), MaxRuleCountPerGroup)
+	}
 
 	var rules []Rule
 	for _, r := range r.Spec.Rules {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

limit the rules count in one rule group to avoid slow evaluation

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
