### PR TITLE
Calculating the Number of Logs in opensearch

### DIFF
--- a/pkg/simple/client/es/versions/opensearchv1/opensearchv1.go
+++ b/pkg/simple/client/es/versions/opensearchv1/opensearchv1.go
@@ -64,6 +64,7 @@ func (o *OpenSearch) Search(indices string, body []byte, scroll bool) ([]byte, e
 	opts := []func(*opensearchapi.SearchRequest){
 		o.client.Search.WithContext(context.Background()),
 		o.client.Search.WithIndex(indices),
+		o.client.Search.WithRestTotalHitsAsInt(true),
 		o.client.Search.WithIgnoreUnavailable(true),
 		o.client.Search.WithBody(bytes.NewBuffer(body)),
 	}

--- a/pkg/simple/client/es/versions/opensearchv2/opensearchv2.go
+++ b/pkg/simple/client/es/versions/opensearchv2/opensearchv2.go
@@ -63,6 +63,7 @@ func New(address string, basicAuth bool, username, password, index string) (*Ope
 func (o *OpenSearch) Search(indices string, body []byte, scroll bool) ([]byte, error) {
 	opts := []func(*opensearchapi.SearchRequest){
 		o.client.Search.WithContext(context.Background()),
+		o.client.Search.WithRestTotalHitsAsInt(true),
 		o.client.Search.WithIndex(indices),
 		o.client.Search.WithIgnoreUnavailable(true),
 		o.client.Search.WithBody(bytes.NewBuffer(body)),


### PR DESCRIPTION
Signed-off-by: chengdehao <dehaocheng@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
