### PR TITLE
add label_matcher param to filter alerts

### DIFF
--- a/pkg/api/alerting/v2beta1/types.go
+++ b/pkg/api/alerting/v2beta1/types.go
@@ -35,6 +35,7 @@ const (
 	// for alert
 	FieldAlertLabelFilters = "label_filters"
 	FieldAlertActiveAt     = "activeAt"
+	FieldAlertLabelMatcher = "label_matcher"
 )
 
 var SortableFields = []string{

--- a/pkg/kapis/alerting/v2beta1/register.go
+++ b/pkg/kapis/alerting/v2beta1/register.go
@@ -66,6 +66,7 @@ func AddToContainer(container *restful.Container, informers informers.InformerFa
 		Param(ws.QueryParameter(query.ParameterOrderBy, "sort parameters, one of `activeAt`. e.g. orderBy=activeAt")).
 		Param(ws.QueryParameter(kapialertingv2beta1.FieldState, "state, one of `firing`, `pending`")).
 		Param(ws.QueryParameter(kapialertingv2beta1.FieldAlertLabelFilters, "label filters, concatenating multiple filters with commas, equal symbol for exact query, wave symbol for fuzzy query e.g. name~a").DataFormat("key=%s,key~%s")).
+		Param(ws.QueryParameter(kapialertingv2beta1.FieldAlertLabelMatcher, "label matcher to match alert labels, follow prometheus matcher format. e.g. `{label_name1=\"valueA\",label_name2=~\"valueB|valueC\"}`")).
 		Returns(http.StatusOK, kapi.StatusOK, kapi.ListResult{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.AlertingTag}))
 
@@ -96,6 +97,7 @@ func AddToContainer(container *restful.Container, informers informers.InformerFa
 		Param(ws.QueryParameter(query.ParameterOrderBy, "sort parameters, one of `activeAt`. e.g. orderBy=activeAt")).
 		Param(ws.QueryParameter(kapialertingv2beta1.FieldState, "state, one of `firing`, `pending`")).
 		Param(ws.QueryParameter(kapialertingv2beta1.FieldAlertLabelFilters, "label filters, concatenating multiple filters with commas, equal symbol for exact query, wave symbol for fuzzy query e.g. name~a").DataFormat("key=%s,key~%s")).
+		Param(ws.QueryParameter(kapialertingv2beta1.FieldAlertLabelMatcher, "label matcher to match alert labels, follow prometheus matcher format. e.g. `{label_name1=\"valueA\",label_name2=~\"valueB|valueC\"}`")).
 		Returns(http.StatusOK, kapi.StatusOK, kapi.ListResult{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.AlertingTag}))
 
@@ -120,13 +122,14 @@ func AddToContainer(container *restful.Container, informers informers.InformerFa
 
 	ws.Route(ws.GET("/globalalerts").
 		To(handler.handleListGlobalAlerts).
-		Doc("list the alerts of globalrulegroups in the cluster").
+		Doc("list the alerts of globalrulegroups").
 		Param(ws.QueryParameter(query.ParameterPage, "page").Required(false).DataFormat("page=%d").DefaultValue("page=1")).
 		Param(ws.QueryParameter(query.ParameterLimit, "limit").Required(false)).
 		Param(ws.QueryParameter(query.ParameterAscending, "sort parameters, e.g. reverse=true").Required(false).DefaultValue("ascending=false")).
 		Param(ws.QueryParameter(query.ParameterOrderBy, "sort parameters, one of `activeAt`. e.g. orderBy=activeAt")).
 		Param(ws.QueryParameter(kapialertingv2beta1.FieldState, "state, one of `firing`, `pending`")).
 		Param(ws.QueryParameter(kapialertingv2beta1.FieldAlertLabelFilters, "label filters, concatenating multiple filters with commas, equal symbol for exact query, wave symbol for fuzzy query e.g. name~a").DataFormat("key=%s,key~%s")).
+		Param(ws.QueryParameter(kapialertingv2beta1.FieldAlertLabelMatcher, "label matcher to match alert labels, follow prometheus matcher format. e.g. `{label_name1=\"valueA\",label_name2=~\"valueB|valueC\"}`")).
 		Param(ws.QueryParameter(kapialertingv2beta1.FieldBuiltin, "filter alerts, `true` for alerts from built-in rule groups and `false` for alerts from custom rule groups")).
 		Returns(http.StatusOK, kapi.StatusOK, kapi.ListResult{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.AlertingTag}))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature

<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

add `label_matcher` param to alerts api, which can provide more advanced filtering capability by prometheus label matcher grammar.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
a usage example is as follows:
```shell
curl -G  ks_apiserver_host_port/kapis/alerting.kubesphere.io/v2beta1/globalalerts --data-urlencode 'label_matcher={cluster=~"host|member1"}'
```