### PR TITLE
Fix failed to cache resources if group version not found

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -412,7 +412,7 @@ func waitForCacheSync(discoveryClient discovery.DiscoveryInterface, sharedInform
 		if err != nil {
 			if errors.IsNotFound(err) {
 				klog.Warningf("group version %s not exists in the cluster", groupVersion)
-				return nil
+				continue
 			}
 			return fmt.Errorf("failed to fetch group version %s: %s", groupVersion, err)
 		}


### PR DESCRIPTION
### What type of PR is this?

/kind bug


### What this PR does / why we need it:

If some required CRDs are missing, the resource cache will fail to start.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```
