### PR TITLE
Bump publishing bot go version to 1.18.9

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -22,6 +22,7 @@ rules:
       branch: master
       dir: staging/src/kubesphere.io/api
     name: master
+    go: 1.18.9
 
   smoke-test: |
     # assumes GO111MODULE=on
@@ -35,3 +36,4 @@ rules:
       branch: master
       dir: staging/src/kubesphere.io/utils
     name: master
+    go: 1.18.9


### PR DESCRIPTION
### What type of PR is this?

/kind flake

### What this PR does / why we need it:

Bump publishing bot go version to 1.18.9

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```