### PR TITLE
fix: ks-apiserver panic error: ServiceAccount's Secret index out of r…

### DIFF
--- a/pkg/kapis/servicemesh/metrics/v1alpha2/handler.go
+++ b/pkg/kapis/servicemesh/metrics/v1alpha2/handler.go
@@ -48,15 +48,17 @@ func NewHandler(o *servicemesh.Options, client kubernetes.Interface, cache cache
 	if o != nil && o.KialiQueryHost != "" {
 		sa, err := client.CoreV1().ServiceAccounts(KubesphereNamespace).Get(context.TODO(), KubeSphereServiceAccount, metav1.GetOptions{})
 		if err == nil {
-			secret, err := client.CoreV1().Secrets(KubesphereNamespace).Get(context.TODO(), sa.Secrets[0].Name, metav1.GetOptions{})
-			if err == nil {
-				return &Handler{
-					opt: o,
-					client: kiali.NewDefaultClient(
-						cache,
-						string(secret.Data["token"]),
-						o.KialiQueryHost,
-					),
+			if len(sa.Secrets) > 0 {
+				secret, err := client.CoreV1().Secrets(KubesphereNamespace).Get(context.TODO(), sa.Secrets[0].Name, metav1.GetOptions{})
+				if err == nil {
+					return &Handler{
+						opt: o,
+						client: kiali.NewDefaultClient(
+							cache,
+							string(secret.Data["token"]),
+							o.KialiQueryHost,
+						),
+					}
 				}
 			}
 			klog.Warningf("get ServiceAccount's Secret failed %v", err)


### PR DESCRIPTION
…ange

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5427

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fixed Runtime Error: index out of range (o] when the process of ks-apiserver starts
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
