### PR TITLE
Fix: Add workspaceTemplate defaulter webhook

### DIFF
--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
 
 	alertingv2beta1 "kubesphere.io/api/alerting/v2beta1"
+	tenantv1alpha2 "kubesphere.io/api/tenant/v1alpha2"
 
 	"kubesphere.io/kubesphere/cmd/controller-manager/app/options"
 	"kubesphere.io/kubesphere/pkg/apis"
@@ -264,6 +265,11 @@ func run(s *options.KubeSphereControllerManagerOptions, ctx context.Context) err
 	globalrulegroup := alertingv2beta1.GlobalRuleGroup{}
 	if err := globalrulegroup.SetupWebhookWithManager(mgr); err != nil {
 		klog.Fatalf("Unable to setup GlobalRuleGroup webhook: %v", err)
+	}
+
+	workspaceTemplate := tenantv1alpha2.WorkspaceTemplate{}
+	if err := workspaceTemplate.SetupWebhookWithManager(mgr); err != nil {
+		klog.Fatalf("Unable to setup WorkspaceTemplate webhook: %v", err)
 	}
 
 	klog.V(2).Info("registering metrics to the webhook server")

--- a/config/ks-core/templates/webhook.yaml
+++ b/config/ks-core/templates/webhook.yaml
@@ -160,7 +160,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   creationTimestamp: null
-  name: mutating-webhook-configuration
+  name: worksapcetemplate.tenant.kubesphere.io
 webhooks:
   - admissionReviewVersions:
       - v1

--- a/config/ks-core/templates/webhook.yaml
+++ b/config/ks-core/templates/webhook.yaml
@@ -154,3 +154,32 @@ webhooks:
           - persistentvolumeclaims
         scope: '*'
     sideEffects: None
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: mutating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      caBundle: {{ b64enc $ca.Cert | quote }}
+      service:
+        name: ks-controller-manager
+        namespace: {{ .Release.Namespace }}
+        path: /mutate-tenant-kubesphere-io-v1alpha2-workspacetemplate
+    failurePolicy: Fail
+    name: workspacetemplate.tenant.kubesphere.io
+    rules:
+      - apiGroups:
+          - tenant.kubesphere.io
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - workspacetemplates
+    sideEffects: None

--- a/staging/src/kubesphere.io/api/tenant/v1alpha2/workspacetemplate_webhook.go
+++ b/staging/src/kubesphere.io/api/tenant/v1alpha2/workspacetemplate_webhook.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"kubesphere.io/api/types/v1beta1"
+)
+
+// log is for logging in this package.
+var workspacetemplatelog = logf.Log.WithName("workspacetemplate-resource")
+
+func (r *WorkspaceTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+var _ webhook.Defaulter = &WorkspaceTemplate{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *WorkspaceTemplate) Default() {
+	workspacetemplatelog.Info("default", "name", r.Name)
+	r.removeDuplicatedClusters()
+}
+
+func (r *WorkspaceTemplate) removeDuplicatedClusters() {
+	clusters := r.Spec.Placement.Clusters
+	clusterSet := make(map[v1beta1.GenericClusterReference]bool)
+
+	for _, v := range clusters {
+		clusterSet[v] = true
+	}
+
+	if len(clusterSet) != len(clusters) {
+		newClusters := make([]v1beta1.GenericClusterReference, 0)
+		for k := range clusterSet {
+			newClusters = append(newClusters, k)
+		}
+		r.Spec.Placement.Clusters = newClusters
+	}
+}


### PR DESCRIPTION
Signed-off-by: Wenhao Zhou <wenhaozhou@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5354

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Adding the workspaceTemplate mutatingwebhook to remove duplicated clusters at workspacetemplate.spec.placement
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
