### PR TITLE
fix: can not re-upgrade helm application in a failed state

### DIFF
--- a/pkg/controller/openpitrix/helmrelease/helm_release_controller.go
+++ b/pkg/controller/openpitrix/helmrelease/helm_release_controller.go
@@ -179,9 +179,16 @@ func (r *ReconcileHelmRelease) reconcile(instance *v1alpha1.HelmRelease) (reconc
 
 	var err error
 	switch instance.Status.State {
-	case v1alpha1.HelmStatusDeleting, v1alpha1.HelmStatusFailed:
+	case v1alpha1.HelmStatusDeleting:
 		// no operation
 		return reconcile.Result{}, nil
+	case v1alpha1.HelmStatusFailed:
+		// Release used to be failed, but instance.Status.Version not equal to instance.Spec.Version
+		if instance.Status.Version != instance.Spec.Version {
+			return r.createOrUpgradeHelmRelease(instance, true)
+		} else {
+			return reconcile.Result{}, nil
+		}
 	case v1alpha1.HelmStatusActive:
 		// Release used to be active, but instance.Status.Version not equal to instance.Spec.Version
 		if instance.Status.Version != instance.Spec.Version {

--- a/pkg/models/openpitrix/release.go
+++ b/pkg/models/openpitrix/release.go
@@ -102,7 +102,7 @@ func (c *releaseOperator) UpgradeApplication(request UpgradeClusterRequest) erro
 	}
 
 	switch oldRls.Status.State {
-	case v1alpha1.StateActive, v1alpha1.HelmStatusUpgraded, v1alpha1.HelmStatusCreated:
+	case v1alpha1.StateActive, v1alpha1.HelmStatusUpgraded, v1alpha1.HelmStatusCreated, v1alpha1.HelmStatusFailed:
 		// no operation
 	default:
 		return errors.New("can not upgrade application now")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug



### What this PR does / why we need it:

We should allow user to re-upgrade helm application after correcting manifest

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5525 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

Kubesphere Chinese Forum: <link>https://kubesphere.io/forum/d/5462-can-not-upgrade-application-now</link>

The bug has been existed for so long time, it's time to fix it.

