### PR TITLE
fix rulegroups to prometheusrules

### DIFF
--- a/pkg/controller/alerting/util.go
+++ b/pkg/controller/alerting/util.go
@@ -326,7 +326,7 @@ func makePrometheusRuleSpecs(rulegroups []*promresourcesv1.RuleGroup) ([]*promre
 
 	var (
 		pSpecs []*promresourcesv1.PrometheusRuleSpec
-		pSpec  promresourcesv1.PrometheusRuleSpec
+		pSpec  = &promresourcesv1.PrometheusRuleSpec{}
 		size   int
 	)
 
@@ -340,16 +340,16 @@ func makePrometheusRuleSpecs(rulegroups []*promresourcesv1.RuleGroup) ([]*promre
 		contentLen := len(string(content))
 		size += contentLen
 		if size > maxConfigMapDataSize*80/100 { // leave space for enforcing possiable label matchers into expr
-			pSpecs = append(pSpecs, &pSpec)
+			pSpecs = append(pSpecs, pSpec)
 			// reinit
 			size = contentLen
-			pSpec = promresourcesv1.PrometheusRuleSpec{}
+			pSpec = &promresourcesv1.PrometheusRuleSpec{}
 		}
 
 		pSpec.Groups = append(pSpec.Groups, *rulegroup)
 	}
 	if len(pSpec.Groups) > 0 {
-		pSpecs = append(pSpecs, &pSpec)
+		pSpecs = append(pSpecs, pSpec)
 	}
 
 	return pSpecs, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
fix overwrite of mulitple PrometheusRules generated from rulegroups
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
