### PR TITLE
Use batch/v1 instead of batch/v1beta1

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -104,7 +104,7 @@ var SupportedGroupVersionResources = map[ClientType][]schema.GroupVersionResourc
 		{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses"},
 
 		{Group: "batch", Version: "v1", Resource: "jobs"},
-		{Group: "batch", Version: "v1beta1", Resource: "cronjobs"},
+		{Group: "batch", Version: "v1", Resource: "cronjobs"},
 
 		{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
 

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/emicklei/go-restful"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -472,7 +471,7 @@ func (s *APIServer) waitForResourceSync(ctx context.Context) error {
 		{Group: "batch", Version: "v1"}: {
 			"jobs",
 		},
-		{Group: "batch", Version: "v1beta1"}: {
+		{Group: "batch", Version: "v1"}: {
 			"cronjobs",
 		},
 		{Group: "networking.k8s.io", Version: "v1"}: {

--- a/pkg/models/quotas/quotas.go
+++ b/pkg/models/quotas/quotas.go
@@ -49,7 +49,7 @@ var supportedResources = map[string]schema.GroupVersionResource{
 	persistentvolumeclaimsKey: {Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
 	ingressKey:                {Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
 	jobsKey:                   {Group: "batch", Version: "v1", Resource: "jobs"},
-	cronJobsKey:               {Group: "batch", Version: "v1beta1", Resource: "cronjobs"},
+	cronJobsKey:               {Group: "batch", Version: "v1", Resource: "cronjobs"},
 	s2iBuilders:               {Group: "devops.kubesphere.io", Version: "v1alpha1", Resource: "s2ibuilders"},
 }
 


### PR DESCRIPTION
### What type of PR is this?

/kind api-change


### What this PR does / why we need it:

Use batch/v1 instead of batch/v1beta1, for more details: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/issues/issues/700

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
batch/v1beta1 is no longer supported
```