### PR TITLE
call validate when config update coz apiserver restart

### DIFF
--- a/cmd/ks-apiserver/app/server.go
+++ b/cmd/ks-apiserver/app/server.go
@@ -118,6 +118,11 @@ func Run(s *options.ServerRunOptions, configCh <-chan apiserverconfig.Config, ct
 			s.Config = &cfg
 			ictx, cancelFunc = context.WithCancel(context.TODO())
 			go func() {
+				if errs := s.Validate(); len(errs) != 0 {
+					for _, err := range errs {
+						errCh <- err
+					}
+				}
 				if err := run(s, ictx); err != nil {
 					errCh <- err
 				}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
I made apiserver restart by adding keycloak-related configuration to clusterconfiguration. However, I found that the keycloak-related configuration was not read correctly as expected. This was because oidcProviderFactory.Create() was not called. I traced back the specific call chain: ServerRunOptions.Validate -> AuthenticationOptions.Validate -> identityprovider.SetupWithOptions -> factory.Create. Therefore, I added s.Validate() before run(s, ictx).

### Which issue(s) this PR fixes:
Fixes #


```release-note
Validate the configuration after reloading.
```



