### PR TITLE
fix: Function NewTerms in ES DSL builder: panic if the value is string

### DIFF
--- a/pkg/simple/client/es/query/builder.go
+++ b/pkg/simple/client/es/query/builder.go
@@ -460,8 +460,15 @@ func (m *Terms) IsValid() bool {
 
 func NewTerms(key string, val interface{}) *Terms {
 
-	if reflect.ValueOf(val).IsNil() {
+	if val == nil {
 		return nil
+	}
+
+	switch reflect.TypeOf(val).Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
+		if reflect.ValueOf(val).IsNil() {
+			return nil
+		}
 	}
 
 	return &Terms{

--- a/pkg/simple/client/es/query/builder_test.go
+++ b/pkg/simple/client/es/query/builder_test.go
@@ -1,0 +1,52 @@
+package query
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestNewTerms(t *testing.T) {
+	var tests = []struct {
+		fakeKey  string
+		fakeVal  interface{}
+		expected *Terms
+	}{
+		{
+			fakeKey: "key1",
+			fakeVal: "value",
+			expected: &Terms{
+				Terms: map[string]interface{}{
+					"key1": "value",
+				},
+			},
+		},
+		{
+			fakeKey: "key2",
+			fakeVal: 0.33,
+			expected: &Terms{
+				Terms: map[string]interface{}{
+					"key2": 0.33,
+				},
+			},
+		},
+		{
+			fakeKey: "key3",
+			fakeVal: []int32{1, 2, 3},
+			expected: &Terms{
+				Terms: map[string]interface{}{
+					"key3": []int32{1, 2, 3},
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			terms := NewTerms(test.fakeKey, test.fakeVal)
+			if !reflect.DeepEqual(terms, test.expected) {
+				t.Fatalf("NewTerms() got=%v, want %v", terms, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:
Fix the bug of NewTerms() in ES DSL builder: panic if the value is string

### Which issue(s) this PR fixes:
Fixes #5500 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
None
```

### Additional documentation, usage docs, etc.:
```docs

```
