### PR TITLE
chore: install goimports automatically

### DIFF
--- a/hack/verify-goimports.sh
+++ b/hack/verify-goimports.sh
@@ -18,14 +18,25 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-. "$(dirname "${BASH_SOURCE[0]}")/lib/init.sh"
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+source "${KUBE_ROOT}/hack/lib/util.sh"
 
-cd "${KUBE_ROOT}/hack" || exit 1
+kube::golang::verify_go_version
 
-if ! command -v goimports &> /dev/null
-then
-    echo "goimports could not be found on your machine, please install it first"
-    exit 1
+# Ensure that we find the binaries we build before anything else.
+export GOBIN="${KUBE_OUTPUT_BINPATH}"
+PATH="${GOBIN}:${PATH}"
+
+# Explicitly opt into go modules, even though we're inside a GOPATH directory
+export GO111MODULE=on
+
+if ! command -v goimports ; then
+# Install goimports
+  echo 'installing goimports'
+  pushd "${KUBE_ROOT}/hack/tools" >/dev/null
+    GO111MODULE=auto go install -mod=mod golang.org/x/tools/cmd/goimports@v0.7.0
+  popd >/dev/null
 fi
 
 cd "${KUBE_ROOT}" || exit 1
@@ -35,9 +46,9 @@ IFS=$'\n' read -r -d '' -a files < <( find . -type f -name '*.go' -not -path "./
 output=$(goimports -local kubesphere.io/kubesphere -l "${files[@]}")
 
 if [ "${output}" != "" ]; then
-    echo "The following files are not import formatted "
+    echo "The following files are not import formatted"
     printf '%s\n' "${output[@]}"
     echo "Please run the following command:"
-    echo "  make goimports"
+    echo "make goimports"
     exit 1
 fi

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -37,7 +37,7 @@ export GO111MODULE=on
 
 if ! command -v golangci-lint ; then
 # Install golangci-lint
-  echo 'installing golangci-lint '
+  echo 'installing golangci-lint'
   pushd "${KUBE_ROOT}/hack/tools" >/dev/null
     GO111MODULE=auto go install -mod=mod github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
   popd >/dev/null
@@ -53,7 +53,7 @@ function error_exit {
 }
 trap "error_exit" EXIT
 
-echo "running golangci-lint: REV=HEAD^ "
+echo "running golangci-lint: REV=HEAD^"
 golangci-lint run \
   --timeout 30m \
   --disable-all \


### PR DESCRIPTION
### What type of PR is this?

/kind cleanup

### What this PR does / why we need it:

Automatically install goimports upon executing `update-goimports.sh`.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```
