### PR TITLE
Update utils.go

### DIFF
--- a/pkg/models/alerting/rules/utils.go
+++ b/pkg/models/alerting/rules/utils.go
@@ -173,8 +173,13 @@ func GetAlertingRulesStatus(ruleNamespace string, ruleChunk *ResourceRuleChunk, 
 		if !strings.HasPrefix(fileShort, ruleNamespace+"-") {
 			continue
 		}
-		resourceRules, ok := ruleChunk.ResourceRulesMap[strings.TrimPrefix(fileShort, ruleNamespace+"-")]
-		if !ok {
+		var resourceRules *ResourceRuleCollection
+		for resourceName, rules := range ruleChunk.ResourceRulesMap {
+			if strings.Contains(strings.TrimPrefix(fileShort, ruleNamespace+"-"), resourceName) {
+				resourceRules = rules
+			}
+		}
+		if resourceRules == nil {
 			continue
 		}
 		if _, ok := resourceRules.GroupSet[group.Name]; !ok {

--- a/pkg/models/alerting/rules/utils.go
+++ b/pkg/models/alerting/rules/utils.go
@@ -244,7 +244,7 @@ out:
 		if !strings.HasPrefix(fileShort, ruleNamespace+"-") {
 			continue
 		}
-		if strings.TrimPrefix(fileShort, ruleNamespace+"-") != rule.ResourceName {
+		if !strings.Contains(strings.TrimPrefix(fileShort, ruleNamespace+"-"), rule.ResourceName) {
 			continue
 		}
 


### PR DESCRIPTION
All build alerting is not working

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
For buildin alerting rules, fileshort path has a postfix that will never match the rule resourcename. Therefore, all buildin alerting rules will not fire since no rule group is matched.  Following are logs for debugging:

E0330 16:17:15.056762       1 utils.go:247] GetAlertingRuleStatus fileshortkubesphere-monitoring-system-prometheus-k8s-rules-46d5900b-1045-4e1a-b4a0-f5e28d4f8972
E0330 16:17:15.056766       1 utils.go:252] GetAlertingRuleStatus resourcename prometheus-k8s-rules

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
