### PR TITLE
Remove the incorrect custom MarshalJSON method to avoid infinite recursion

### DIFF
--- a/pkg/simple/client/cache/cache.go
+++ b/pkg/simple/client/cache/cache.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cache
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -53,12 +52,6 @@ type Interface interface {
 // DynamicOptions the options of the cache. For redis, options key can be  "host", "port", "db", "password".
 // For InMemoryCache, options key can be "cleanupperiod"
 type DynamicOptions map[string]interface{}
-
-func (o DynamicOptions) MarshalJSON() ([]byte, error) {
-
-	data, err := json.Marshal(o)
-	return data, err
-}
 
 func RegisterCacheFactory(factory CacheFactory) {
 	cacheFactories[factory.Type()] = factory


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

This incorrect custom `MarshalJSON` method would cause a recursion hell during JSON serialization of the `Config` object, leading to program crashes:

```
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc021e80370 stack=[0xc021e80000, 0xc041e80000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x2f4b666?, 0x4d8cc60?})
	/usr/local/go/src/runtime/panic.go:1047 +0x5d fp=0xc000087e10 sp=0xc000087de0 pc=0x439e5d
runtime.newstack()
	/usr/local/go/src/runtime/stack.go:1103 +0x5cc fp=0xc000087fc8 sp=0xc000087e10 pc=0x45412c
runtime.morestack()
	/usr/local/go/src/runtime/asm_amd64.s:570 +0x8b fp=0xc000087fd0 sp=0xc000087fc8 pc=0x46bf6b

goroutine 771 [running]:
runtime.nilinterhash(0xc021e80410?, 0x30201817?)
	/usr/local/go/src/runtime/alg.go:117 +0xf5 fp=0xc021e80380 sp=0xc021e80378 pc=0x404015
runtime.mapaccess2(0x2aa9fe0, 0xc00072e120, 0x0?)
	/usr/local/go/src/runtime/map.go:478 +0x7e fp=0xc021e803c0 sp=0xc021e80380 pc=0x40eebe
sync.(*Map).Load(0x4eca1c0, {0x2ed87a0, 0x2b7a560})
	/usr/local/go/src/sync/map.go:112 +0xb7 fp=0xc021e80430 sp=0xc021e803c0 pc=0x483357
encoding/json.typeEncoder({0x3400400?, 0x2b7a560})
	/usr/local/go/src/encoding/json/encode.go:381 +0x4c fp=0xc021e80480 sp=0xc021e80430 pc=0x7e3f4c
encoding/json.valueEncoder({0x2b7a560?, 0xc0001212f0?, 0x80?})
	/usr/local/go/src/encoding/json/encode.go:377 +0x4a fp=0xc021e804a8 sp=0xc021e80480 pc=0x7e3eaa
encoding/json.(*encodeState).reflectValue(0x0?, {0x2b7a560?, 0xc0001212f0?, 0x40dc27?}, {0x78?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:359 +0x4a fp=0xc021e80508 sp=0xc021e804a8 pc=0x7e3dca
encoding/json.(*encodeState).marshal(0x40a7ed?, {0x2b7a560?, 0xc0001212f0?}, {0xd0?, 0x5?})
	/usr/local/go/src/encoding/json/encode.go:331 +0xfa fp=0xc021e80580 sp=0xc021e80508 pc=0x7e397a
encoding/json.Marshal({0x2b7a560, 0xc0001212f0})
	/usr/local/go/src/encoding/json/encode.go:160 +0x45 fp=0xc021e805e0 sp=0xc021e80580 pc=0x7e3005
kubesphere.io/kubesphere/pkg/simple/client/cache.DynamicOptions.MarshalJSON(0x2b7a560?)
	/workspace/pkg/simple/client/cache/cache.go:59 +0x25 fp=0xc021e80600 sp=0xc021e805e0 pc=0x17b4e25
encoding/json.marshalerEncoder(0xc00b6c1180, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0xa0?, 0xf1?})
	/usr/local/go/src/encoding/json/encode.go:478 +0xbe fp=0xc021e80688 sp=0xc021e80600 pc=0x7e471e
encoding/json.condAddrEncoder.encode({0x3072010?, 0x3072060?}, 0xc021e806f8?, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x0?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:961 +0x67 fp=0xc021e806c0 sp=0xc021e80688 pc=0x7e85e7
encoding/json.condAddrEncoder.encode-fm(0x2b7a560?, {0x2b7a560?, 0xc0001212f0?, 0x30?}, {0x8?, 0xa1?})
	<autogenerated>:1 +0x58 fp=0xc021e80708 sp=0xc021e806c0 pc=0x7f1278
encoding/json.(*encodeState).reflectValue(0x0?, {0x2b7a560?, 0xc0001212f0?, 0x40dc27?}, {0x78?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:359 +0x78 fp=0xc021e80768 sp=0xc021e80708 pc=0x7e3df8
encoding/json.(*encodeState).marshal(0x40a7ed?, {0x2b7a560?, 0xc0001212f0?}, {0x30?, 0x8?})
	/usr/local/go/src/encoding/json/encode.go:331 +0xfa fp=0xc021e807e0 sp=0xc021e80768 pc=0x7e397a
encoding/json.Marshal({0x2b7a560, 0xc0001212f0})
	/usr/local/go/src/encoding/json/encode.go:160 +0x45 fp=0xc021e80840 sp=0xc021e807e0 pc=0x7e3005
kubesphere.io/kubesphere/pkg/simple/client/cache.DynamicOptions.MarshalJSON(0x2b7a560?)
	/workspace/pkg/simple/client/cache/cache.go:59 +0x25 fp=0xc021e80860 sp=0xc021e80840 pc=0x17b4e25
encoding/json.marshalerEncoder(0xc00b6c1100, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x70?, 0xf1?})
	/usr/local/go/src/encoding/json/encode.go:478 +0xbe fp=0xc021e808e8 sp=0xc021e80860 pc=0x7e471e
encoding/json.condAddrEncoder.encode({0x3072010?, 0x3072060?}, 0xc021e80958?, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x0?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:961 +0x67 fp=0xc021e80920 sp=0xc021e808e8 pc=0x7e85e7
encoding/json.condAddrEncoder.encode-fm(0x2b7a560?, {0x2b7a560?, 0xc0001212f0?, 0x30?}, {0x8?, 0xa1?})
	<autogenerated>:1 +0x58 fp=0xc021e80968 sp=0xc021e80920 pc=0x7f1278
encoding/json.(*encodeState).reflectValue(0x0?, {0x2b7a560?, 0xc0001212f0?, 0x40dc27?}, {0x78?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:359 +0x78 fp=0xc021e809c8 sp=0xc021e80968 pc=0x7e3df8
encoding/json.(*encodeState).marshal(0x40a7ed?, {0x2b7a560?, 0xc0001212f0?}, {0x90?, 0xa?})
	/usr/local/go/src/encoding/json/encode.go:331 +0xfa fp=0xc021e80a40 sp=0xc021e809c8 pc=0x7e397a
encoding/json.Marshal({0x2b7a560, 0xc0001212f0})
	/usr/local/go/src/encoding/json/encode.go:160 +0x45 fp=0xc021e80aa0 sp=0xc021e80a40 pc=0x7e3005
kubesphere.io/kubesphere/pkg/simple/client/cache.DynamicOptions.MarshalJSON(0x2b7a560?)
	/workspace/pkg/simple/client/cache/cache.go:59 +0x25 fp=0xc021e80ac0 sp=0xc021e80aa0 pc=0x17b4e25
encoding/json.marshalerEncoder(0xc00b6c1080, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x40?, 0xf1?})
	/usr/local/go/src/encoding/json/encode.go:478 +0xbe fp=0xc021e80b48 sp=0xc021e80ac0 pc=0x7e471e
encoding/json.condAddrEncoder.encode({0x3072010?, 0x3072060?}, 0xc021e80bb8?, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x0?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:961 +0x67 fp=0xc021e80b80 sp=0xc021e80b48 pc=0x7e85e7
encoding/json.condAddrEncoder.encode-fm(0x2b7a560?, {0x2b7a560?, 0xc0001212f0?, 0x30?}, {0x8?, 0xa1?})
	<autogenerated>:1 +0x58 fp=0xc021e80bc8 sp=0xc021e80b80 pc=0x7f1278
encoding/json.(*encodeState).reflectValue(0x0?, {0x2b7a560?, 0xc0001212f0?, 0x40dc27?}, {0x78?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:359 +0x78 fp=0xc021e80c28 sp=0xc021e80bc8 pc=0x7e3df8
encoding/json.(*encodeState).marshal(0x40a7ed?, {0x2b7a560?, 0xc0001212f0?}, {0xf0?, 0xc?})
	/usr/local/go/src/encoding/json/encode.go:331 +0xfa fp=0xc021e80ca0 sp=0xc021e80c28 pc=0x7e397a
encoding/json.Marshal({0x2b7a560, 0xc0001212f0})
	/usr/local/go/src/encoding/json/encode.go:160 +0x45 fp=0xc021e80d00 sp=0xc021e80ca0 pc=0x7e3005
kubesphere.io/kubesphere/pkg/simple/client/cache.DynamicOptions.MarshalJSON(0x2b7a560?)
	/workspace/pkg/simple/client/cache/cache.go:59 +0x25 fp=0xc021e80d20 sp=0xc021e80d00 pc=0x17b4e25
encoding/json.marshalerEncoder(0xc00b6c1000, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x10?, 0xf1?})
	/usr/local/go/src/encoding/json/encode.go:478 +0xbe fp=0xc021e80da8 sp=0xc021e80d20 pc=0x7e471e
encoding/json.condAddrEncoder.encode({0x3072010?, 0x3072060?}, 0xc021e80e18?, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x0?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:961 +0x67 fp=0xc021e80de0 sp=0xc021e80da8 pc=0x7e85e7
encoding/json.condAddrEncoder.encode-fm(0x2b7a560?, {0x2b7a560?, 0xc0001212f0?, 0x30?}, {0x8?, 0xa1?})
	<autogenerated>:1 +0x58 fp=0xc021e80e28 sp=0xc021e80de0 pc=0x7f1278
encoding/json.(*encodeState).reflectValue(0x0?, {0x2b7a560?, 0xc0001212f0?, 0x40dc27?}, {0x78?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:359 +0x78 fp=0xc021e80e88 sp=0xc021e80e28 pc=0x7e3df8
encoding/json.(*encodeState).marshal(0x40a7ed?, {0x2b7a560?, 0xc0001212f0?}, {0x50?, 0xf?})
	/usr/local/go/src/encoding/json/encode.go:331 +0xfa fp=0xc021e80f00 sp=0xc021e80e88 pc=0x7e397a
encoding/json.Marshal({0x2b7a560, 0xc0001212f0})
	/usr/local/go/src/encoding/json/encode.go:160 +0x45 fp=0xc021e80f60 sp=0xc021e80f00 pc=0x7e3005
kubesphere.io/kubesphere/pkg/simple/client/cache.DynamicOptions.MarshalJSON(0x2b7a560?)
	/workspace/pkg/simple/client/cache/cache.go:59 +0x25 fp=0xc021e80f80 sp=0xc021e80f60 pc=0x17b4e25
encoding/json.marshalerEncoder(0xc00b6c0f80, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0xe0?, 0xf0?})
	/usr/local/go/src/encoding/json/encode.go:478 +0xbe fp=0xc021e81008 sp=0xc021e80f80 pc=0x7e471e
encoding/json.condAddrEncoder.encode({0x3072010?, 0x3072060?}, 0xc021e81078?, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x0?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:961 +0x67 fp=0xc021e81040 sp=0xc021e81008 pc=0x7e85e7
encoding/json.condAddrEncoder.encode-fm(0x2b7a560?, {0x2b7a560?, 0xc0001212f0?, 0x30?}, {0x8?, 0xa1?})
	<autogenerated>:1 +0x58 fp=0xc021e81088 sp=0xc021e81040 pc=0x7f1278
encoding/json.(*encodeState).reflectValue(0x0?, {0x2b7a560?, 0xc0001212f0?, 0x40dc27?}, {0x78?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:359 +0x78 fp=0xc021e810e8 sp=0xc021e81088 pc=0x7e3df8
encoding/json.(*encodeState).marshal(0x40a7ed?, {0x2b7a560?, 0xc0001212f0?}, {0xb0?, 0x11?})
	/usr/local/go/src/encoding/json/encode.go:331 +0xfa fp=0xc021e81160 sp=0xc021e810e8 pc=0x7e397a
encoding/json.Marshal({0x2b7a560, 0xc0001212f0})
	/usr/local/go/src/encoding/json/encode.go:160 +0x45 fp=0xc021e811c0 sp=0xc021e81160 pc=0x7e3005
kubesphere.io/kubesphere/pkg/simple/client/cache.DynamicOptions.MarshalJSON(0x2b7a560?)
	/workspace/pkg/simple/client/cache/cache.go:59 +0x25 fp=0xc021e811e0 sp=0xc021e811c0 pc=0x17b4e25
encoding/json.marshalerEncoder(0xc00b6c0f00, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0xb0?, 0xf0?})
	/usr/local/go/src/encoding/json/encode.go:478 +0xbe fp=0xc021e81268 sp=0xc021e811e0 pc=0x7e471e
encoding/json.condAddrEncoder.encode({0x3072010?, 0x3072060?}, 0xc021e812d8?, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x0?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:961 +0x67 fp=0xc021e812a0 sp=0xc021e81268 pc=0x7e85e7
encoding/json.condAddrEncoder.encode-fm(0x2b7a560?, {0x2b7a560?, 0xc0001212f0?, 0x30?}, {0x8?, 0xa1?})
	<autogenerated>:1 +0x58 fp=0xc021e812e8 sp=0xc021e812a0 pc=0x7f1278
encoding/json.(*encodeState).reflectValue(0x0?, {0x2b7a560?, 0xc0001212f0?, 0x40dc27?}, {0x78?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:359 +0x78 fp=0xc021e81348 sp=0xc021e812e8 pc=0x7e3df8
encoding/json.(*encodeState).marshal(0x40a7ed?, {0x2b7a560?, 0xc0001212f0?}, {0x10?, 0x14?})
	/usr/local/go/src/encoding/json/encode.go:331 +0xfa fp=0xc021e813c0 sp=0xc021e81348 pc=0x7e397a
encoding/json.Marshal({0x2b7a560, 0xc0001212f0})
	/usr/local/go/src/encoding/json/encode.go:160 +0x45 fp=0xc021e81420 sp=0xc021e813c0 pc=0x7e3005
kubesphere.io/kubesphere/pkg/simple/client/cache.DynamicOptions.MarshalJSON(0x2b7a560?)
	/workspace/pkg/simple/client/cache/cache.go:59 +0x25 fp=0xc021e81440 sp=0xc021e81420 pc=0x17b4e25
encoding/json.marshalerEncoder(0xc00b6c0e80, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x80?, 0xf0?})
	/usr/local/go/src/encoding/json/encode.go:478 +0xbe fp=0xc021e814c8 sp=0xc021e81440 pc=0x7e471e
encoding/json.condAddrEncoder.encode({0x3072010?, 0x3072060?}, 0xc021e81538?, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x0?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:961 +0x67 fp=0xc021e81500 sp=0xc021e814c8 pc=0x7e85e7
encoding/json.condAddrEncoder.encode-fm(0x2b7a560?, {0x2b7a560?, 0xc0001212f0?, 0x30?}, {0x8?, 0xa1?})
	<autogenerated>:1 +0x58 fp=0xc021e81548 sp=0xc021e81500 pc=0x7f1278
encoding/json.(*encodeState).reflectValue(0x0?, {0x2b7a560?, 0xc0001212f0?, 0x40dc27?}, {0x78?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:359 +0x78 fp=0xc021e815a8 sp=0xc021e81548 pc=0x7e3df8
encoding/json.(*encodeState).marshal(0x40a7ed?, {0x2b7a560?, 0xc0001212f0?}, {0x70?, 0x16?})
	/usr/local/go/src/encoding/json/encode.go:331 +0xfa fp=0xc021e81620 sp=0xc021e815a8 pc=0x7e397a
encoding/json.Marshal({0x2b7a560, 0xc0001212f0})
	/usr/local/go/src/encoding/json/encode.go:160 +0x45 fp=0xc021e81680 sp=0xc021e81620 pc=0x7e3005
kubesphere.io/kubesphere/pkg/simple/client/cache.DynamicOptions.MarshalJSON(0x2b7a560?)
	/workspace/pkg/simple/client/cache/cache.go:59 +0x25 fp=0xc021e816a0 sp=0xc021e81680 pc=0x17b4e25
encoding/json.marshalerEncoder(0xc00b6c0e00, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x50?, 0xf0?})
	/usr/local/go/src/encoding/json/encode.go:478 +0xbe fp=0xc021e81728 sp=0xc021e816a0 pc=0x7e471e
encoding/json.condAddrEncoder.encode({0x3072010?, 0x3072060?}, 0xc021e81798?, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x0?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:961 +0x67 fp=0xc021e81760 sp=0xc021e81728 pc=0x7e85e7
encoding/json.condAddrEncoder.encode-fm(0x2b7a560?, {0x2b7a560?, 0xc0001212f0?, 0x30?}, {0x8?, 0xa1?})
	<autogenerated>:1 +0x58 fp=0xc021e817a8 sp=0xc021e81760 pc=0x7f1278
encoding/json.(*encodeState).reflectValue(0x0?, {0x2b7a560?, 0xc0001212f0?, 0x40dc27?}, {0x78?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:359 +0x78 fp=0xc021e81808 sp=0xc021e817a8 pc=0x7e3df8
encoding/json.(*encodeState).marshal(0x40a7ed?, {0x2b7a560?, 0xc0001212f0?}, {0xd0?, 0x18?})
	/usr/local/go/src/encoding/json/encode.go:331 +0xfa fp=0xc021e81880 sp=0xc021e81808 pc=0x7e397a
encoding/json.Marshal({0x2b7a560, 0xc0001212f0})
	/usr/local/go/src/encoding/json/encode.go:160 +0x45 fp=0xc021e818e0 sp=0xc021e81880 pc=0x7e3005
kubesphere.io/kubesphere/pkg/simple/client/cache.DynamicOptions.MarshalJSON(0x2b7a560?)
	/workspace/pkg/simple/client/cache/cache.go:59 +0x25 fp=0xc021e81900 sp=0xc021e818e0 pc=0x17b4e25
encoding/json.marshalerEncoder(0xc00b6c0d80, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x20?, 0xf0?})
	/usr/local/go/src/encoding/json/encode.go:478 +0xbe fp=0xc021e81988 sp=0xc021e81900 pc=0x7e471e
encoding/json.condAddrEncoder.encode({0x3072010?, 0x3072060?}, 0xc021e819f8?, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x0?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:961 +0x67 fp=0xc021e819c0 sp=0xc021e81988 pc=0x7e85e7
encoding/json.condAddrEncoder.encode-fm(0x2b7a560?, {0x2b7a560?, 0xc0001212f0?, 0x30?}, {0x8?, 0xa1?})
	<autogenerated>:1 +0x58 fp=0xc021e81a08 sp=0xc021e819c0 pc=0x7f1278
encoding/json.(*encodeState).reflectValue(0x0?, {0x2b7a560?, 0xc0001212f0?, 0x40dc27?}, {0x78?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:359 +0x78 fp=0xc021e81a68 sp=0xc021e81a08 pc=0x7e3df8
encoding/json.(*encodeState).marshal(0x40a7ed?, {0x2b7a560?, 0xc0001212f0?}, {0x30?, 0x1b?})
	/usr/local/go/src/encoding/json/encode.go:331 +0xfa fp=0xc021e81ae0 sp=0xc021e81a68 pc=0x7e397a
encoding/json.Marshal({0x2b7a560, 0xc0001212f0})
	/usr/local/go/src/encoding/json/encode.go:160 +0x45 fp=0xc021e81b40 sp=0xc021e81ae0 pc=0x7e3005
kubesphere.io/kubesphere/pkg/simple/client/cache.DynamicOptions.MarshalJSON(0x2b7a560?)
	/workspace/pkg/simple/client/cache/cache.go:59 +0x25 fp=0xc021e81b60 sp=0xc021e81b40 pc=0x17b4e25
encoding/json.marshalerEncoder(0xc00b6c0d00, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0xf0?, 0xef?})
	/usr/local/go/src/encoding/json/encode.go:478 +0xbe fp=0xc021e81be8 sp=0xc021e81b60 pc=0x7e471e
encoding/json.condAddrEncoder.encode({0x3072010?, 0x3072060?}, 0xc021e81c58?, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x0?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:961 +0x67 fp=0xc021e81c20 sp=0xc021e81be8 pc=0x7e85e7
encoding/json.condAddrEncoder.encode-fm(0x2b7a560?, {0x2b7a560?, 0xc0001212f0?, 0x30?}, {0x8?, 0xa1?})
	<autogenerated>:1 +0x58 fp=0xc021e81c68 sp=0xc021e81c20 pc=0x7f1278
encoding/json.(*encodeState).reflectValue(0x0?, {0x2b7a560?, 0xc0001212f0?, 0x40dc27?}, {0x78?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:359 +0x78 fp=0xc021e81cc8 sp=0xc021e81c68 pc=0x7e3df8
encoding/json.(*encodeState).marshal(0x40a7ed?, {0x2b7a560?, 0xc0001212f0?}, {0x90?, 0x1d?})
	/usr/local/go/src/encoding/json/encode.go:331 +0xfa fp=0xc021e81d40 sp=0xc021e81cc8 pc=0x7e397a
encoding/json.Marshal({0x2b7a560, 0xc0001212f0})
	/usr/local/go/src/encoding/json/encode.go:160 +0x45 fp=0xc021e81da0 sp=0xc021e81d40 pc=0x7e3005
kubesphere.io/kubesphere/pkg/simple/client/cache.DynamicOptions.MarshalJSON(0x2b7a560?)
	/workspace/pkg/simple/client/cache/cache.go:59 +0x25 fp=0xc021e81dc0 sp=0xc021e81da0 pc=0x17b4e25
encoding/json.marshalerEncoder(0xc00b6c0c80, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0xc0?, 0xef?})
	/usr/local/go/src/encoding/json/encode.go:478 +0xbe fp=0xc021e81e48 sp=0xc021e81dc0 pc=0x7e471e
encoding/json.condAddrEncoder.encode({0x3072010?, 0x3072060?}, 0xc021e81eb8?, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x0?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:961 +0x67 fp=0xc021e81e80 sp=0xc021e81e48 pc=0x7e85e7
encoding/json.condAddrEncoder.encode-fm(0x2b7a560?, {0x2b7a560?, 0xc0001212f0?, 0x30?}, {0x8?, 0xa1?})
	<autogenerated>:1 +0x58 fp=0xc021e81ec8 sp=0xc021e81e80 pc=0x7f1278
encoding/json.(*encodeState).reflectValue(0x0?, {0x2b7a560?, 0xc0001212f0?, 0x40dc27?}, {0x78?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:359 +0x78 fp=0xc021e81f28 sp=0xc021e81ec8 pc=0x7e3df8
encoding/json.(*encodeState).marshal(0x40a7ed?, {0x2b7a560?, 0xc0001212f0?}, {0xf0?, 0x1f?})
	/usr/local/go/src/encoding/json/encode.go:331 +0xfa fp=0xc021e81fa0 sp=0xc021e81f28 pc=0x7e397a
encoding/json.Marshal({0x2b7a560, 0xc0001212f0})
	/usr/local/go/src/encoding/json/encode.go:160 +0x45 fp=0xc021e82000 sp=0xc021e81fa0 pc=0x7e3005
kubesphere.io/kubesphere/pkg/simple/client/cache.DynamicOptions.MarshalJSON(0x2b7a560?)
	/workspace/pkg/simple/client/cache/cache.go:59 +0x25 fp=0xc021e82020 sp=0xc021e82000 pc=0x17b4e25
encoding/json.marshalerEncoder(0xc00b6c0c00, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x90?, 0xef?})
	/usr/local/go/src/encoding/json/encode.go:478 +0xbe fp=0xc021e820a8 sp=0xc021e82020 pc=0x7e471e
encoding/json.condAddrEncoder.encode({0x3072010?, 0x3072060?}, 0xc021e82118?, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x0?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:961 +0x67 fp=0xc021e820e0 sp=0xc021e820a8 pc=0x7e85e7
encoding/json.condAddrEncoder.encode-fm(0x2b7a560?, {0x2b7a560?, 0xc0001212f0?, 0x30?}, {0x8?, 0xa1?})
	<autogenerated>:1 +0x58 fp=0xc021e82128 sp=0xc021e820e0 pc=0x7f1278
encoding/json.(*encodeState).reflectValue(0x0?, {0x2b7a560?, 0xc0001212f0?, 0x40dc27?}, {0x78?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:359 +0x78 fp=0xc021e82188 sp=0xc021e82128 pc=0x7e3df8
encoding/json.(*encodeState).marshal(0x40a7ed?, {0x2b7a560?, 0xc0001212f0?}, {0x50?, 0x22?})
	/usr/local/go/src/encoding/json/encode.go:331 +0xfa fp=0xc021e82200 sp=0xc021e82188 pc=0x7e397a
encoding/json.Marshal({0x2b7a560, 0xc0001212f0})
	/usr/local/go/src/encoding/json/encode.go:160 +0x45 fp=0xc021e82260 sp=0xc021e82200 pc=0x7e3005
kubesphere.io/kubesphere/pkg/simple/client/cache.DynamicOptions.MarshalJSON(0x2b7a560?)
	/workspace/pkg/simple/client/cache/cache.go:59 +0x25 fp=0xc021e82280 sp=0xc021e82260 pc=0x17b4e25
encoding/json.marshalerEncoder(0xc00b6c0b80, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x60?, 0xef?})
	/usr/local/go/src/encoding/json/encode.go:478 +0xbe fp=0xc021e82308 sp=0xc021e82280 pc=0x7e471e
encoding/json.condAddrEncoder.encode({0x3072010?, 0x3072060?}, 0xc021e82378?, {0x2b7a560?, 0xc0001212f0?, 0x2b7a560?}, {0x0?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:961 +0x67 fp=0xc021e82340 sp=0xc021e82308 pc=0x7e85e7
encoding/json.condAddrEncoder.encode-fm(0x2b7a560?, {0x2b7a560?, 0xc0001212f0?, 0x30?}, {0x8?, 0xa1?})
	<autogenerated>:1 +0x58 fp=0xc021e82388 sp=0xc021e82340 pc=0x7f1278
encoding/json.(*encodeState).reflectValue(0x0?, {0x2b7a560?, 0xc0001212f0?, 0x40dc27?}, {0x78?, 0x0?})
	/usr/local/go/src/encoding/json/encode.go:359 +0x78 fp=0xc021e823e8 sp=0xc021e82388 pc=0x7e3df8
encoding/json.(*encodeState).marshal(0x40a7ed?, {0x2b7a560?, 0xc0001212f0?}, {0xb0?, 0x24?})
	/usr/local/go/src/encoding/json/encode.go:331 +0xfa fp=0xc021e82460 sp=0xc021e823e8 pc=0x7e397a
encoding/json.Marshal({0x2b7a560, 0xc0001212f0})
	/usr/local/go/src/encoding/json/encode.go:160 +0x45 fp=0xc021e824c0 sp=0xc021e82460 pc=0x7e3005
kubesphere.io/kubesphere/pkg/simple/client/cache.DynamicOptions.MarshalJSON(0x2b7a560?)
	/workspace/pkg/simple/client/cache/cache.go:59 +0x25 fp=0xc021e824e0 sp=0xc021e824c0 pc=0x17b4e25
...additional frames elided...
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:3102 +0x4db
```

Additionally, this custom method had no actual customization, making it unnecessary, so I simply deleted it.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @wansir 