### PR TITLE
controller/cluster: retry when updating the KubeFedCluster conflicted

### DIFF
--- a/pkg/controller/cluster/cluster_controller.go
+++ b/pkg/controller/cluster/cluster_controller.go
@@ -411,6 +411,11 @@ func (c *clusterController) syncCluster(key string) error {
 	} else { // join federation
 		_, err = c.joinFederation(clusterConfig, cluster.Name, cluster.Labels)
 		if err != nil {
+			if errors.IsConflict(err) {
+				klog.Warningf("update KubeFedCluster %s conflicted, retrying", cluster.Name)
+				return err
+			}
+
 			klog.Errorf("Failed to join federation for cluster %s, error %v", cluster.Name, err)
 
 			federationNotReadyCondition := clusterv1alpha1.ClusterCondition{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

[The patch](https://github.com/kubesphere/kubesphere/pull/5130) considers the failure of the join federation operation as an indicator of the cluster not being ready. However, this judgment is incomplete as it fails to consider cases of conflicting updates. In instances of conflicting updates, retrying is necessary instead of treating it as a signal of the cluster not being ready. 

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubesphere/kubesphere/pull/5130


### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Retry when updating the KubeFedCluster conflicted.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @wansir 