### PR TITLE
[release-3.3] controller/cluster: retry when updating the KubeFedCluster conflicted

### DIFF
--- a/pkg/controller/cluster/cluster_controller.go
+++ b/pkg/controller/cluster/cluster_controller.go
@@ -407,6 +407,11 @@ func (c *clusterController) syncCluster(key string) error {
 	} else { // join federation
 		_, err = c.joinFederation(clusterConfig, cluster.Name, cluster.Labels)
 		if err != nil {
+			if errors.IsConflict(err) {
+				klog.Warningf("update KubeFedCluster %s conflicted, retrying", cluster.Name)
+				return err
+			}
+
 			klog.Errorf("Failed to join federation for cluster %s, error %v", cluster.Name, err)
 
 			federationNotReadyCondition := clusterv1alpha1.ClusterCondition{

--- a/pkg/controller/cluster/join.go
+++ b/pkg/controller/cluster/join.go
@@ -34,6 +34,7 @@ import (
 	kubeclient "k8s.io/client-go/kubernetes"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fedapis "sigs.k8s.io/kubefed/pkg/apis"
@@ -199,25 +200,25 @@ func createKubeFedCluster(clusterConfig *rest.Config, client client.Client, join
 	case err == nil && errorOnExisting:
 		return nil, errors.Errorf("federated cluster %s already exists in host cluster", joiningClusterName)
 	case err == nil:
-		existingFedCluster.Spec = fedCluster.Spec
-		existingFedCluster.Labels = labels
-		err = client.Update(context.TODO(), existingFedCluster)
-		if err != nil {
+		if retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if err = client.Get(context.TODO(), key, existingFedCluster); err != nil {
+				return err
+			}
+			existingFedCluster.Spec = fedCluster.Spec
+			existingFedCluster.Labels = labels
+			return client.Update(context.TODO(), existingFedCluster)
+		}); retryErr != nil {
 			klog.V(2).Infof("Could not update federated cluster %s due to %v", fedCluster.Name, err)
 			return nil, err
 		}
 		return existingFedCluster, nil
 	default:
-
-		err = checkWorkspaces(clusterConfig, client, fedCluster)
-
-		if err != nil {
+		if err = checkWorkspaces(clusterConfig, client, fedCluster); err != nil {
 			klog.V(2).Infof("Validate federated cluster %s failed due to %v", fedCluster.Name, err)
 			return nil, err
 		}
 
-		err = client.Create(context.TODO(), fedCluster)
-		if err != nil {
+		if err = client.Create(context.TODO(), fedCluster); err != nil {
 			klog.V(2).Infof("Could not create federated cluster %s due to %v", fedCluster.Name, err)
 			return nil, err
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

cherry-pick of #5653 

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5654 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Retry when updating the KubeFedCluster conflicted.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @wansir 