### PR TITLE
Fix wrong params naming in openpitrix

### DIFF
--- a/pkg/kapis/openpitrix/v1/handler.go
+++ b/pkg/kapis/openpitrix/v1/handler.go
@@ -767,13 +767,12 @@ func (h *openpitrixHandler) UpgradeApplication(req *restful.Request, resp *restf
 	}
 
 	upgradeClusterRequest.Namespace = namespace
-	upgradeClusterRequest.ClusterId = applicationId
 	user, _ := request.UserFrom(req.Request.Context())
 	if user != nil {
 		upgradeClusterRequest.Username = user.GetName()
 	}
 
-	err = h.openpitrix.UpgradeApplication(upgradeClusterRequest)
+	err = h.openpitrix.UpgradeApplication(upgradeClusterRequest, applicationId)
 	if err != nil {
 		klog.Errorln(err)
 		api.HandleInternalError(resp, nil, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
Add one of the following kinds:
/kind bug


Optionally add one or more of the following kinds if applicable:
/kind api-change


### What this PR does / why we need it:
In the following issue, I found the applicationId in openpitrix api is misunderstanding.
https://github.com/kubesphere/kubesphere/issues/5602
In the API, the "applicationId" parameter is actually the name of the helmRelease, but it uses "applicationId" as the parameter name, as shown in the following figure.

<img width="455" alt="image" src="https://user-images.githubusercontent.com/13819034/236389209-d3b5a053-77e5-489c-b986-570fa6c57171.png">


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubesphere/kubesphere/issues/5602

### Special notes for reviewers:

This PR will cause changes to the OpenAPI, so we need to be cautious. Additionally, the commit only made changes to the upgrade API, while in reality, the get API and others also need modification. I would like to confirm the opinions of the members. Is it necessary to make these changes?


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
