### PR TITLE
refactor: remove usless options

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -40,14 +40,12 @@ import (
 	"kubesphere.io/kubesphere/pkg/simple/client/multicluster"
 	"kubesphere.io/kubesphere/pkg/simple/client/network"
 	"kubesphere.io/kubesphere/pkg/simple/client/openpitrix"
-	"kubesphere.io/kubesphere/pkg/simple/client/s3"
 	"kubesphere.io/kubesphere/pkg/simple/client/servicemesh"
 )
 
 type KubeSphereControllerManagerOptions struct {
 	KubernetesOptions     *k8s.KubernetesOptions
 	DevopsOptions         *jenkins.Options
-	S3Options             *s3.Options
 	AuthenticationOptions *authentication.Options
 	LdapOptions           *ldapclient.Options
 	OpenPitrixOptions     *openpitrix.Options
@@ -88,7 +86,6 @@ func NewKubeSphereControllerManagerOptions() *KubeSphereControllerManagerOptions
 	s := &KubeSphereControllerManagerOptions{
 		KubernetesOptions:     k8s.NewKubernetesOptions(),
 		DevopsOptions:         jenkins.NewDevopsOptions(),
-		S3Options:             s3.NewS3Options(),
 		LdapOptions:           ldapclient.NewOptions(),
 		OpenPitrixOptions:     openpitrix.NewOptions(),
 		NetworkOptions:        network.NewNetworkOptions(),
@@ -116,7 +113,6 @@ func (s *KubeSphereControllerManagerOptions) Flags(allControllerNameSelectors []
 
 	s.KubernetesOptions.AddFlags(fss.FlagSet("kubernetes"), s.KubernetesOptions)
 	s.DevopsOptions.AddFlags(fss.FlagSet("devops"), s.DevopsOptions)
-	s.S3Options.AddFlags(fss.FlagSet("s3"), s.S3Options)
 	s.AuthenticationOptions.AddFlags(fss.FlagSet("authentication"), s.AuthenticationOptions)
 	s.LdapOptions.AddFlags(fss.FlagSet("ldap"), s.LdapOptions)
 	s.OpenPitrixOptions.AddFlags(fss.FlagSet("openpitrix"), s.OpenPitrixOptions)
@@ -161,20 +157,19 @@ func (s *KubeSphereControllerManagerOptions) Flags(allControllerNameSelectors []
 }
 
 // Validate Options and Genetic Options
-func (o *KubeSphereControllerManagerOptions) Validate(allControllerNameSelectors []string) []error {
+func (s *KubeSphereControllerManagerOptions) Validate(allControllerNameSelectors []string) []error {
 	var errs []error
-	errs = append(errs, o.DevopsOptions.Validate()...)
-	errs = append(errs, o.KubernetesOptions.Validate()...)
-	errs = append(errs, o.S3Options.Validate()...)
-	errs = append(errs, o.OpenPitrixOptions.Validate()...)
-	errs = append(errs, o.NetworkOptions.Validate()...)
-	errs = append(errs, o.LdapOptions.Validate()...)
-	errs = append(errs, o.MultiClusterOptions.Validate()...)
-	errs = append(errs, o.AlertingOptions.Validate()...)
+	errs = append(errs, s.DevopsOptions.Validate()...)
+	errs = append(errs, s.KubernetesOptions.Validate()...)
+	errs = append(errs, s.OpenPitrixOptions.Validate()...)
+	errs = append(errs, s.NetworkOptions.Validate()...)
+	errs = append(errs, s.LdapOptions.Validate()...)
+	errs = append(errs, s.MultiClusterOptions.Validate()...)
+	errs = append(errs, s.AlertingOptions.Validate()...)
 
 	// genetic option: application-selector
-	if len(o.ApplicationSelector) != 0 {
-		_, err := labels.Parse(o.ApplicationSelector)
+	if len(s.ApplicationSelector) != 0 {
+		_, err := labels.Parse(s.ApplicationSelector)
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -182,7 +177,7 @@ func (o *KubeSphereControllerManagerOptions) Validate(allControllerNameSelectors
 
 	// genetic option: controllers, check all selectors are valid
 	allControllersNameSet := sets.New(allControllerNameSelectors...)
-	for _, selector := range o.ControllerGates {
+	for _, selector := range s.ControllerGates {
 		if selector == "*" {
 			continue
 		}
@@ -196,9 +191,9 @@ func (o *KubeSphereControllerManagerOptions) Validate(allControllerNameSelectors
 }
 
 // IsControllerEnabled check if a specified controller enabled or not.
-func (o *KubeSphereControllerManagerOptions) IsControllerEnabled(name string) bool {
+func (s *KubeSphereControllerManagerOptions) IsControllerEnabled(name string) bool {
 	hasStar := false
-	for _, ctrl := range o.ControllerGates {
+	for _, ctrl := range s.ControllerGates {
 		if ctrl == name {
 			return true
 		}
@@ -234,7 +229,6 @@ func (s *KubeSphereControllerManagerOptions) bindLeaderElectionFlags(l *leaderel
 func (s *KubeSphereControllerManagerOptions) MergeConfig(cfg *controllerconfig.Config) {
 	s.KubernetesOptions = cfg.KubernetesOptions
 	s.DevopsOptions = cfg.DevopsOptions
-	s.S3Options = cfg.S3Options
 	s.AuthenticationOptions = cfg.AuthenticationOptions
 	s.LdapOptions = cfg.LdapOptions
 	s.OpenPitrixOptions = cfg.OpenPitrixOptions

--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -44,7 +44,6 @@ import (
 	"kubesphere.io/kubesphere/pkg/controller/user"
 	"kubesphere.io/kubesphere/pkg/informers"
 	"kubesphere.io/kubesphere/pkg/simple/client/k8s"
-	"kubesphere.io/kubesphere/pkg/simple/client/s3"
 	"kubesphere.io/kubesphere/pkg/utils/metrics"
 	"kubesphere.io/kubesphere/pkg/utils/term"
 	"kubesphere.io/kubesphere/pkg/version"
@@ -58,7 +57,6 @@ func NewControllerManagerCommand() *cobra.Command {
 		s = &options.KubeSphereControllerManagerOptions{
 			KubernetesOptions:     conf.KubernetesOptions,
 			DevopsOptions:         conf.DevopsOptions,
-			S3Options:             conf.S3Options,
 			AuthenticationOptions: conf.AuthenticationOptions,
 			LdapOptions:           conf.LdapOptions,
 			OpenPitrixOptions:     conf.OpenPitrixOptions,
@@ -168,13 +166,6 @@ func run(s *options.KubeSphereControllerManagerOptions, ctx context.Context) err
 	if err != nil {
 		klog.Errorf("Failed to create kubernetes clientset %v", err)
 		return err
-	}
-
-	if s.S3Options != nil && len(s.S3Options.Endpoint) != 0 {
-		_, err = s3.NewS3Client(s.S3Options)
-		if err != nil {
-			return fmt.Errorf("failed to connect to s3, please check s3 service status, error: %v", err)
-		}
 	}
 
 	informerFactory := informers.NewInformerFactories(

--- a/cmd/ks-apiserver/apiserver.go
+++ b/cmd/ks-apiserver/apiserver.go
@@ -17,16 +17,15 @@ limitations under the License.
 package main
 
 import (
-	"log"
+	"os"
+
+	"k8s.io/component-base/cli"
 
 	"kubesphere.io/kubesphere/cmd/ks-apiserver/app"
 )
 
 func main() {
-
 	cmd := app.NewAPIServerCommand()
-
-	if err := cmd.Execute(); err != nil {
-		log.Fatalln(err)
-	}
+	code := cli.Run(cmd)
+	os.Exit(code)
 }

--- a/cmd/ks-apiserver/app/server.go
+++ b/cmd/ks-apiserver/app/server.go
@@ -56,7 +56,7 @@ cluster's shared state through which all other components interact.`,
 				return utilerrors.NewAggregate(errs)
 			}
 
-			if s.GOPSEnabled {
+			if s.DebugMode {
 				// Add agent to report additional information such as the current stack trace, Go version, memory stats, etc.
 				// Bind to a random port on address 127.0.0.1.
 				if err := agent.Listen(agent.Options{}); err != nil {

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -107,7 +107,6 @@ import (
 	"kubesphere.io/kubesphere/pkg/simple/client/k8s"
 	"kubesphere.io/kubesphere/pkg/simple/client/logging"
 	"kubesphere.io/kubesphere/pkg/simple/client/monitoring"
-	"kubesphere.io/kubesphere/pkg/simple/client/s3"
 	"kubesphere.io/kubesphere/pkg/simple/client/sonarqube"
 	"kubesphere.io/kubesphere/pkg/utils/clusterclient"
 	"kubesphere.io/kubesphere/pkg/utils/iputil"
@@ -145,8 +144,6 @@ type APIServer struct {
 	LoggingClient logging.Client
 
 	DevopsClient devops.Interface
-
-	S3Client s3.Interface
 
 	SonarClient sonarqube.SonarInterface
 

--- a/pkg/simple/client/cache/cache.go
+++ b/pkg/simple/client/cache/cache.go
@@ -39,13 +39,13 @@ type Interface interface {
 	// Set sets the value and living duration of the given key, zero duration means never expire
 	Set(key string, value string, duration time.Duration) error
 
-	// Del deletes the given key, no error returned if the key doesn't exists
+	// Del deletes the given key, no error returned if the key doesn't exist
 	Del(keys ...string) error
 
 	// Exists checks the existence of a give key
 	Exists(keys ...string) (bool, error)
 
-	// Expires updates object's expiration time, return err if key doesn't exist
+	// Expire updates object's expiration time, return err if key doesn't exist
 	Expire(key string, duration time.Duration) error
 }
 
@@ -58,6 +58,10 @@ func New(option *Options, stopCh <-chan struct{}) (Interface, error) {
 		err := fmt.Errorf("cache with type %s is not supported", option.Type)
 		klog.Error(err)
 		return nil, err
+	}
+
+	if option.Type == TypeInMemoryCache {
+		klog.Warning("In-memory cache will be used, this may cause data inconsistencies when running with multiple replicas.")
 	}
 
 	cache, err := cacheFactories[option.Type].Create(option.Options, stopCh)

--- a/pkg/simple/client/cache/inmemory_cache.go
+++ b/pkg/simple/client/cache/inmemory_cache.go
@@ -32,9 +32,7 @@ import (
 var ErrNoSuchKey = errors.New("no such key")
 
 const (
-	typeInMemoryCache = "InMemoryCache"
-	DefaultCacheType  = typeInMemoryCache
-
+	TypeInMemoryCache    = "InMemoryCache"
 	defaultCleanupPeriod = 2 * time.Hour
 )
 
@@ -176,12 +174,11 @@ type inMemoryCacheFactory struct {
 }
 
 func (sf *inMemoryCacheFactory) Type() string {
-	return typeInMemoryCache
+	return TypeInMemoryCache
 }
 
 func (sf *inMemoryCacheFactory) Create(options options.DynamicOptions, stopCh <-chan struct{}) (Interface, error) {
 	var sOptions InMemoryCacheOptions
-
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		DecodeHook:       mapstructure.StringToTimeDurationHookFunc(),
 		WeaklyTypedInput: true,

--- a/pkg/simple/client/cache/options.go
+++ b/pkg/simple/client/cache/options.go
@@ -31,7 +31,7 @@ type Options struct {
 // because redis is not required for some components
 func NewCacheOptions() *Options {
 	return &Options{
-		Type:    "",
+		Type:    TypeInMemoryCache,
 		Options: map[string]interface{}{},
 	}
 }

--- a/pkg/simple/client/s3/s3.go
+++ b/pkg/simple/client/s3/s3.go
@@ -22,6 +22,8 @@ import (
 	"math"
 	"time"
 
+	fakes3 "kubesphere.io/kubesphere/pkg/simple/client/s3/fake"
+
 	"code.cloudfoundry.org/bytefmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -44,6 +46,8 @@ const (
 	MinConcurrency = 5
 	// MaxConcurrency is the maximum concurrency to limit the goroutines.
 	MaxConcurrency = 128
+
+	fakeS3Host = "FAKE"
 )
 
 // calculateConcurrency calculates the concurrency for better performance,
@@ -120,6 +124,10 @@ func (s *Client) Delete(key string) error {
 }
 
 func NewS3Client(options *Options) (Interface, error) {
+	if options.Endpoint == fakeS3Host {
+		return fakes3.NewFakeS3(), nil
+	}
+
 	cred := credentials.NewStaticCredentials(options.AccessKeyID, options.SecretAccessKey, options.SessionToken)
 
 	config := aws.Config{

--- a/vendor/k8s.io/component-base/cli/OWNERS
+++ b/vendor/k8s.io/component-base/cli/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Currently assigned cli to sig-cli since:
+# (a) its literally named "cli"
+# (b) flags are the bread-and-butter of cli tools.
+
+approvers:
+  - sig-cli-maintainers
+reviewers:
+  - sig-cli-reviewers
+labels:
+  - sig/cli

--- a/vendor/k8s.io/component-base/cli/run.go
+++ b/vendor/k8s.io/component-base/cli/run.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/logs"
+	"k8s.io/klog/v2"
+)
+
+// Run provides the common boilerplate code around executing a cobra command.
+// For example, it ensures that logging is set up properly. Logging
+// flags get added to the command line if not added already. Flags get normalized
+// so that help texts show them with hyphens. Underscores are accepted
+// as alternative for the command parameters.
+//
+// Run tries to be smart about how to print errors that are returned by the
+// command: before logging is known to be set up, it prints them as plain text
+// to stderr. This covers command line flag parse errors and unknown commands.
+// Afterwards it logs them. This covers runtime errors.
+//
+// Commands like kubectl where logging is not normally part of the runtime output
+// should use RunNoErrOutput instead and deal with the returned error themselves.
+func Run(cmd *cobra.Command) int {
+	if logsInitialized, err := run(cmd); err != nil {
+		// If the error is about flag parsing, then printing that error
+		// with the decoration that klog would add ("E0923
+		// 23:02:03.219216 4168816 run.go:61] unknown shorthand flag")
+		// is less readable. Using klog.Fatal is even worse because it
+		// dumps a stack trace that isn't about the error.
+		//
+		// But if it is some other error encountered at runtime, then
+		// we want to log it as error, at least in most commands because
+		// their output is a log event stream.
+		//
+		// We can distinguish these two cases depending on whether
+		// we got to logs.InitLogs() above.
+		//
+		// This heuristic might be problematic for command line
+		// tools like kubectl where the output is carefully controlled
+		// and not a log by default. They should use RunNoErrOutput
+		// instead.
+		//
+		// The usage of klog is problematic also because we don't know
+		// whether the command has managed to configure it. This cannot
+		// be checked right now, but may become possible when the early
+		// logging proposal from
+		// https://github.com/kubernetes/enhancements/pull/3078
+		// ("contextual logging") is implemented.
+		if !logsInitialized {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		} else {
+			klog.ErrorS(err, "command failed")
+		}
+		return 1
+	}
+	return 0
+}
+
+// RunNoErrOutput is a version of Run which returns the cobra command error
+// instead of printing it.
+func RunNoErrOutput(cmd *cobra.Command) error {
+	_, err := run(cmd)
+	return err
+}
+
+func run(cmd *cobra.Command) (logsInitialized bool, err error) {
+	rand.Seed(time.Now().UnixNano())
+	defer logs.FlushLogs()
+
+	cmd.SetGlobalNormalizationFunc(cliflag.WordSepNormalizeFunc)
+
+	// When error printing is enabled for the Cobra command, a flag parse
+	// error gets printed first, then optionally the often long usage
+	// text. This is very unreadable in a console because the last few
+	// lines that will be visible on screen don't include the error.
+	//
+	// The recommendation from #sig-cli was to print the usage text, then
+	// the error. We implement this consistently for all commands here.
+	// However, we don't want to print the usage text when command
+	// execution fails for other reasons than parsing. We detect this via
+	// the FlagParseError callback.
+	//
+	// Some commands, like kubectl, already deal with this themselves.
+	// We don't change the behavior for those.
+	if !cmd.SilenceUsage {
+		cmd.SilenceUsage = true
+		cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
+			// Re-enable usage printing.
+			c.SilenceUsage = false
+			return err
+		})
+	}
+
+	// In all cases error printing is done below.
+	cmd.SilenceErrors = true
+
+	// This is idempotent.
+	logs.AddFlags(cmd.PersistentFlags())
+
+	// Inject logs.InitLogs after command line parsing into one of the
+	// PersistentPre* functions.
+	switch {
+	case cmd.PersistentPreRun != nil:
+		pre := cmd.PersistentPreRun
+		cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+			logs.InitLogs()
+			logsInitialized = true
+			pre(cmd, args)
+		}
+	case cmd.PersistentPreRunE != nil:
+		pre := cmd.PersistentPreRunE
+		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+			logs.InitLogs()
+			logsInitialized = true
+			return pre(cmd, args)
+		}
+	default:
+		cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+			logs.InitLogs()
+			logsInitialized = true
+		}
+	}
+
+	err = cmd.Execute()
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2256,6 +2256,7 @@ k8s.io/code-generator/pkg/namer
 k8s.io/code-generator/pkg/util
 # k8s.io/component-base v0.26.1 => k8s.io/component-base v0.26.1
 ## explicit; go 1.19
+k8s.io/component-base/cli
 k8s.io/component-base/cli/flag
 k8s.io/component-base/config
 k8s.io/component-base/config/v1alpha1


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup

### What this PR does / why we need it:

1. There is an overlap between the flags `gops` and `debug`, so we only need to keep one of them.
2. The configuration for S3 is no longer required.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```
