### PR TITLE
Add Enable option for the plugin

### DIFF
--- a/cmd/controller-manager/app/controllers.go
+++ b/cmd/controller-manager/app/controllers.go
@@ -527,7 +527,7 @@ func addAllControllers(mgr manager.Manager, client k8s.Client, informerFactory i
 	}
 
 	// controllers for alerting
-	alertingOptionsEnable := cmOptions.AlertingOptions != nil && (cmOptions.AlertingOptions.PrometheusEndpoint != "" || cmOptions.AlertingOptions.ThanosRulerEndpoint != "")
+	alertingOptionsEnable := cmOptions.AlertingOptions.Enable && cmOptions.AlertingOptions != nil && (cmOptions.AlertingOptions.PrometheusEndpoint != "" || cmOptions.AlertingOptions.ThanosRulerEndpoint != "")
 	if alertingOptionsEnable {
 		// "rulegroup" controller
 		if cmOptions.IsControllerEnabled("rulegroup") {

--- a/cmd/ks-apiserver/app/options/options.go
+++ b/cmd/ks-apiserver/app/options/options.go
@@ -136,7 +136,7 @@ func (s *ServerRunOptions) NewAPIServer(stopCh <-chan struct{}) (*apiserver.APIS
 		}
 	}
 
-	if s.DevopsOptions.Host != "" {
+	if s.DevopsOptions.Host != "" && s.DevopsOptions.Enable {
 		if apiServer.DevopsClient, err = jenkins.NewDevopsClient(s.DevopsOptions); err != nil {
 			return nil, fmt.Errorf("failed to connect to jenkins, please check jenkins status, error: %v", err)
 		}
@@ -160,13 +160,13 @@ func (s *ServerRunOptions) NewAPIServer(stopCh <-chan struct{}) (*apiserver.APIS
 		}
 	}
 
-	if s.AuditingOptions.Host != "" {
+	if s.AuditingOptions.Host != "" && s.Config.AuditingOptions.Enable {
 		if apiServer.AuditingClient, err = auditingclient.NewClient(s.AuditingOptions); err != nil {
 			return nil, fmt.Errorf("failed to connect to elasticsearch, please check elasticsearch status, error: %v", err)
 		}
 	}
 
-	if s.AlertingOptions != nil && (s.AlertingOptions.PrometheusEndpoint != "" || s.AlertingOptions.ThanosRulerEndpoint != "") {
+	if s.AlertingOptions != nil && (s.AlertingOptions.PrometheusEndpoint != "" || s.AlertingOptions.ThanosRulerEndpoint != "") && s.AlertingOptions.Enable {
 		if apiServer.AlertingClient, err = alerting.NewRuleClient(s.AlertingOptions); err != nil {
 			return nil, fmt.Errorf("failed to init alerting client: %v", err)
 		}

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -257,10 +257,12 @@ func (s *APIServer) installKubeSphereAPIs(stopCh <-chan struct{}) {
 	urlruntime.Must(servicemeshv1alpha2.AddToContainer(s.Config.ServiceMeshOptions, s.container, s.KubernetesClient.Kubernetes(), s.CacheClient))
 	urlruntime.Must(networkv1alpha2.AddToContainer(s.container, s.Config.NetworkOptions.WeaveScopeHost))
 	urlruntime.Must(kapisdevops.AddToContainer(s.container, s.Config.DevopsOptions.Endpoint))
-	urlruntime.Must(alertingv1.AddToContainer(s.container, s.Config.AlertingOptions.Endpoint))
-	urlruntime.Must(alertingv2alpha1.AddToContainer(s.container, s.InformerFactory,
-		s.KubernetesClient.Prometheus(), s.AlertingClient, s.Config.AlertingOptions))
-	urlruntime.Must(alertingv2beta1.AddToContainer(s.container, s.InformerFactory, s.AlertingClient))
+	if s.Config.AlertingOptions.Enable {
+		urlruntime.Must(alertingv1.AddToContainer(s.container, s.Config.AlertingOptions.Endpoint))
+		urlruntime.Must(alertingv2alpha1.AddToContainer(s.container, s.InformerFactory,
+			s.KubernetesClient.Prometheus(), s.AlertingClient, s.Config.AlertingOptions))
+		urlruntime.Must(alertingv2beta1.AddToContainer(s.container, s.InformerFactory, s.AlertingClient))
+	}
 	urlruntime.Must(version.AddToContainer(s.container, s.KubernetesClient.Kubernetes().Discovery()))
 	urlruntime.Must(kubeedgev1alpha1.AddToContainer(s.container, s.Config.KubeEdgeOptions.Endpoint))
 	urlruntime.Must(edgeruntimev1alpha1.AddToContainer(s.container, s.Config.EdgeRuntimeOptions.Endpoint))

--- a/pkg/apiserver/auditing/types.go
+++ b/pkg/apiserver/auditing/types.go
@@ -68,7 +68,6 @@ type auditing struct {
 }
 
 func NewAuditing(informers informers.InformerFactory, opts *options.Options, stopCh <-chan struct{}) Auditing {
-
 	a := &auditing{
 		webhookLister: informers.KubeSphereSharedInformerFactory().Auditing().V1alpha1().Webhooks().Lister(),
 		devopsGetter:  devops.New(informers.KubeSphereSharedInformerFactory()),

--- a/pkg/simple/client/alerting/options.go
+++ b/pkg/simple/client/alerting/options.go
@@ -26,6 +26,7 @@ import (
 )
 
 type Options struct {
+	Enable   bool   `json:"enable" yaml:"enable"`
 	Endpoint string `json:"endpoint" yaml:"endpoint"`
 
 	// The following options are for the alerting with v2alpha1 version or higher versions

--- a/pkg/simple/client/devops/jenkins/options.go
+++ b/pkg/simple/client/devops/jenkins/options.go
@@ -25,6 +25,7 @@ import (
 )
 
 type Options struct {
+	Enable         bool   `json:"enable" yaml:"enable"`
 	Host           string `json:",omitempty" yaml:"host,omitempty" description:"Jenkins service host address"`
 	Username       string `json:",omitempty" yaml:"username,omitempty" description:"Jenkins admin username"`
 	Password       string `json:",omitempty" yaml:"password,omitempty" description:"Jenkins admin password"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
/kind api-change
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

The error reported as follows when deploying a lightweight cluster or all-in-one from the official website and locally launching ks-apiserver."

<img width="1175" alt="image" src="https://github.com/kubesphere/kubesphere/assets/13819034/ef1ec8f4-c99e-4993-a5c7-38690c126c26">

As I described in the issue below, the Webhook can be turned off through 'enable', but there's no way to turn off DevOpsProject and RuleGroup using 'enable'. I find this unreasonable.

1. [https://github.com/kubesphere/kubesphere/issues/5607](https://github.com/kubesphere/kubesphere/issues/5607)
2. [https://github.com/kubesphere/kubesphere/issues/5648](https://github.com/kubesphere/kubesphere/issues/5648)

So I add enable options to alerting and devops make configuration more flexibility. 

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5648

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
