### PR TITLE
apiserver: fix the issue that the /kapis/version API cannot be matched by routing

### DIFF
--- a/pkg/apiserver/runtime/runtime.go
+++ b/pkg/apiserver/runtime/runtime.go
@@ -17,6 +17,8 @@ limitations under the License.
 package runtime
 
 import (
+	"strings"
+
 	"github.com/emicklei/go-restful/v3"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -41,7 +43,8 @@ func init() {
 
 func NewWebService(gv schema.GroupVersion) *restful.WebService {
 	webservice := restful.WebService{}
-	webservice.Path(ApiRootPath + "/" + gv.String()).
+	// the GroupVersion might be empty, we need to remove the final /
+	webservice.Path(strings.TrimRight(ApiRootPath+"/"+gv.String(), "/")).
 		Produces(restful.MIME_JSON)
 
 	return &webservice


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Since PR https://github.com/kubesphere/kubesphere/pull/5669 was merged, The `/kapis/version` API cannot be accessed and returns a 404 error:

```
404: Page Not Found
```

After some debugging and testing, I found that it was caused by a change in the framework routing policy (https://github.com/kubesphere/kubesphere/pull/5669/files#diff-0a330bc3577078f1bd80d54d09d94c5dfe17108d08153d7607d309c485811a62). This PR fixes this issue.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @wansir 