### PR TITLE
chore: pkg imported more than once

### DIFF
--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
-	"k8s.io/client-go/informers"
 	kubeinformers "k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
@@ -134,7 +133,7 @@ func checkAction(expected, actual core.Action, t *testing.T) {
 	}
 }
 
-func (f *fixture) newController() (*JobController, informers.SharedInformerFactory) {
+func (f *fixture) newController() (*JobController, kubeinformers.SharedInformerFactory) {
 	f.kubeclient = k8sfake.NewSimpleClientset(f.kubeobjects...)
 
 	k8sI := kubeinformers.NewSharedInformerFactory(f.kubeclient, noResyncPeriodFunc())

--- a/pkg/simple/client/openpitrix/helmwrapper/post_renderer_kustomize.go
+++ b/pkg/simple/client/openpitrix/helmwrapper/post_renderer_kustomize.go
@@ -20,7 +20,6 @@ import (
 
 	"sigs.k8s.io/kustomize/api/krusty"
 	"sigs.k8s.io/kustomize/api/resmap"
-	"sigs.k8s.io/kustomize/api/types"
 	kustypes "sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -64,10 +63,10 @@ func writeFile(fs filesys.FileSystem, path string, content *bytes.Buffer) error 
 func (k *postRendererKustomize) Run(renderedManifests *bytes.Buffer) (modifiedManifests *bytes.Buffer, err error) {
 	fs := filesys.MakeFsInMemory()
 	input := "./.local-helm-output.yaml"
-	cfg := types.Kustomization{
+	cfg := kustypes.Kustomization{
 		Resources:         []string{input},
 		CommonAnnotations: k.annotations,                    // add extra annotations to output
-		Labels:            []types.Label{{Pairs: k.labels}}, // Labels to add to all objects but not selectors.
+		Labels:            []kustypes.Label{{Pairs: k.labels}}, // Labels to add to all objects but not selectors.
 	}
 	cfg.APIVersion = kustypes.KustomizationVersion
 	cfg.Kind = kustypes.KustomizationKind


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind cleanup


### What this PR does / why we need it:
pkg/controller/job/job_controller_test.go:29:2: package "k8s.io/client-go/informers" is being imported more than once 
pkg/simple/client/openpitrix/helmwrapper/post_renderer_kustomize.go:23:2: package "sigs.k8s.io/kustomize/api/types" is being imported more than once 
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
