### PR TITLE
Support configuring the maximum number of logs that can be exported

### DIFF
--- a/pkg/simple/client/es/versions/opensearchv1/opensearchv1.go
+++ b/pkg/simple/client/es/versions/opensearchv1/opensearchv1.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/opensearch-project/opensearch-go"
 	"github.com/opensearch-project/opensearch-go/opensearchapi"
 
@@ -86,9 +87,16 @@ func (o *OpenSearch) Search(indices string, body []byte, scroll bool) ([]byte, e
 }
 
 func (o *OpenSearch) Scroll(id string) ([]byte, error) {
+	body, err := jsoniter.Marshal(map[string]string{
+		"scroll_id": id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	response, err := o.client.Scroll(
 		o.client.Scroll.WithContext(context.Background()),
-		o.client.Scroll.WithScrollID(id),
+		o.client.Scroll.WithBody(bytes.NewBuffer(body)),
 		o.client.Scroll.WithScroll(time.Minute))
 	if err != nil {
 		return nil, err

--- a/pkg/simple/client/es/versions/opensearchv2/opensearchv2.go
+++ b/pkg/simple/client/es/versions/opensearchv2/opensearchv2.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/opensearch-project/opensearch-go/v2"
 	"github.com/opensearch-project/opensearch-go/v2/opensearchapi"
 
@@ -86,9 +87,16 @@ func (o *OpenSearch) Search(indices string, body []byte, scroll bool) ([]byte, e
 }
 
 func (o *OpenSearch) Scroll(id string) ([]byte, error) {
+	body, err := jsoniter.Marshal(map[string]string{
+		"scroll_id": id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	response, err := o.client.Scroll(
 		o.client.Scroll.WithContext(context.Background()),
-		o.client.Scroll.WithScrollID(id),
+		o.client.Scroll.WithBody(bytes.NewBuffer(body)),
 		o.client.Scroll.WithScroll(time.Minute))
 	if err != nil {
 		return nil, err

--- a/pkg/simple/client/es/versions/v5/v5.go
+++ b/pkg/simple/client/es/versions/v5/v5.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v5"
 	"github.com/elastic/go-elasticsearch/v5/esapi"
+	jsoniter "github.com/json-iterator/go"
 
 	"kubesphere.io/kubesphere/pkg/simple/client/es/versions"
 )
@@ -85,9 +86,16 @@ func (e *Elastic) Search(indices string, body []byte, scroll bool) ([]byte, erro
 }
 
 func (e *Elastic) Scroll(id string) ([]byte, error) {
+	body, err := jsoniter.Marshal(map[string]string{
+		"scroll_id": id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	response, err := e.client.Scroll(
 		e.client.Scroll.WithContext(context.Background()),
-		e.client.Scroll.WithScrollID(id),
+		e.client.Scroll.WithBody(bytes.NewBuffer(body)),
 		e.client.Scroll.WithScroll(time.Minute))
 	if err != nil {
 		return nil, err

--- a/pkg/simple/client/es/versions/v6/v6.go
+++ b/pkg/simple/client/es/versions/v6/v6.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v6"
 	"github.com/elastic/go-elasticsearch/v6/esapi"
+	jsoniter "github.com/json-iterator/go"
 
 	"kubesphere.io/kubesphere/pkg/simple/client/es/versions"
 )
@@ -85,9 +86,16 @@ func (e *Elastic) Search(indices string, body []byte, scroll bool) ([]byte, erro
 }
 
 func (e *Elastic) Scroll(id string) ([]byte, error) {
+	body, err := jsoniter.Marshal(map[string]string{
+		"scroll_id": id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	response, err := e.Client.Scroll(
 		e.Client.Scroll.WithContext(context.Background()),
-		e.Client.Scroll.WithScrollID(id),
+		e.Client.Scroll.WithBody(bytes.NewBuffer(body)),
 		e.Client.Scroll.WithScroll(time.Minute))
 	if err != nil {
 		return nil, err

--- a/pkg/simple/client/es/versions/v7/v7.go
+++ b/pkg/simple/client/es/versions/v7/v7.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
+	jsoniter "github.com/json-iterator/go"
 
 	"kubesphere.io/kubesphere/pkg/simple/client/es/versions"
 )
@@ -86,9 +87,16 @@ func (e *Elastic) Search(indices string, body []byte, scroll bool) ([]byte, erro
 }
 
 func (e *Elastic) Scroll(id string) ([]byte, error) {
+	body, err := jsoniter.Marshal(map[string]string{
+		"scroll_id": id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	response, err := e.client.Scroll(
 		e.client.Scroll.WithContext(context.Background()),
-		e.client.Scroll.WithScrollID(id),
+		e.client.Scroll.WithBody(bytes.NewBuffer(body)),
 		e.client.Scroll.WithScroll(time.Minute))
 	if err != nil {
 		return nil, err

--- a/pkg/simple/client/logging/options.go
+++ b/pkg/simple/client/logging/options.go
@@ -22,20 +22,26 @@ import (
 	"kubesphere.io/kubesphere/pkg/utils/reflectutils"
 )
 
+const (
+	exportLogsLimitDefault = 100000
+)
+
 type Options struct {
-	Host        string `json:"host" yaml:"host"`
-	BasicAuth   bool   `json:"basicAuth" yaml:"basicAuth"`
-	Username    string `json:"username" yaml:"username"`
-	Password    string `json:"password" yaml:"password"`
-	IndexPrefix string `json:"indexPrefix,omitempty" yaml:"indexPrefix,omitempty"`
-	Version     string `json:"version" yaml:"version"`
+	Host            string `json:"host" yaml:"host"`
+	BasicAuth       bool   `json:"basicAuth" yaml:"basicAuth"`
+	Username        string `json:"username" yaml:"username"`
+	Password        string `json:"password" yaml:"password"`
+	IndexPrefix     string `json:"indexPrefix,omitempty" yaml:"indexPrefix,omitempty"`
+	Version         string `json:"version" yaml:"version"`
+	ExportLogsLimit int    `json:"exportLogsLimit" yaml:"exportLogsLimit"`
 }
 
 func NewLoggingOptions() *Options {
 	return &Options{
-		Host:        "",
-		IndexPrefix: "fluentbit",
-		Version:     "",
+		Host:            "",
+		IndexPrefix:     "fluentbit",
+		Version:         "",
+		ExportLogsLimit: exportLogsLimitDefault,
 	}
 }
 
@@ -76,4 +82,7 @@ func (s *Options) AddFlags(fs *pflag.FlagSet, c *Options) {
 	fs.StringVar(&s.Version, "logging-elasticsearch-version", c.Version, ""+
 		"Elasticsearch major version, e.g. 5/6/7, if left blank, will detect automatically."+
 		"Currently, minimum supported version is 5.x")
+
+	fs.IntVar(&s.ExportLogsLimit, "logging-export-logs-limit", c.ExportLogsLimit, ""+
+		"Maximum lines of logs to export")
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubesphere/issues#916 

### Special notes for reviewers:
```
To configure the maximum number of logs that can be exported, you can edit the kubesphere-config cm as following

logging:
  exportLogsLimit: 1000000 
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Support configuring the maximum number of logs that can be exported
```

