### PR TITLE
Fix: require cluster name can not be repeated

### DIFF
--- a/config/ks-core/crds/tenant.kubesphere.io_workspacetemplates.yaml
+++ b/config/ks-core/crds/tenant.kubesphere.io_workspacetemplates.yaml
@@ -118,6 +118,9 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                 type: object
               template:
                 properties:

--- a/staging/src/kubesphere.io/api/types/v1beta1/types.go
+++ b/staging/src/kubesphere.io/api/types/v1beta1/types.go
@@ -29,6 +29,8 @@ type GenericClusterReference struct {
 }
 
 type GenericPlacementFields struct {
+	// +listType=map
+	// +listMapKey=name
 	Clusters        []GenericClusterReference `json:"clusters,omitempty"`
 	ClusterSelector *metav1.LabelSelector     `json:"clusterSelector,omitempty"`
 }


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Fix the issue of potentially duplicated entries for granted clusters in the workspace.

### Which issue(s) this PR fixes:

Fixes https://github.com/kubesphere/issues/issues/1211

### Does this PR introduced a user-facing change?

```release-note
Fix the issue of potentially duplicated entries for granted clusters in the workspace.
```