### PR TITLE
fix: clear all oauth Providers when reloading configuration

### DIFF
--- a/pkg/apiserver/authentication/identityprovider/identity_provider.go
+++ b/pkg/apiserver/authentication/identityprovider/identity_provider.go
@@ -47,6 +47,10 @@ type Identity interface {
 
 // SetupWithOptions will verify the configuration and initialize the identityProviders
 func SetupWithOptions(options []oauth.IdentityProviderOptions) error {
+	// Clear all providers when reloading configuration
+	oauthProviders = make(map[string]OAuthProvider)
+	genericProviders = make(map[string]GenericProvider)
+
 	for _, o := range options {
 		if oauthProviders[o.Name] != nil || genericProviders[o.Name] != nil {
 			err := fmt.Errorf("duplicate identity provider found: %s, name must be unique", o.Name)

--- a/pkg/apiserver/authentication/identityprovider/identity_provider_test.go
+++ b/pkg/apiserver/authentication/identityprovider/identity_provider_test.go
@@ -113,6 +113,12 @@ func TestSetupWith(t *testing.T) {
 					Type:          "LDAPIdentityProvider",
 					Provider:      options.DynamicOptions{},
 				},
+				{
+					Name:          "ldap",
+					MappingMethod: "auto",
+					Type:          "LDAPIdentityProvider",
+					Provider:      options.DynamicOptions{},
+				},
 			}},
 			wantErr: true,
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5185 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix: clear all oauth Providers when reloading configuration
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
