### PR TITLE
Use autoscaling/v2 instead of autoscaling/v2beta2

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -108,7 +108,7 @@ var SupportedGroupVersionResources = map[ClientType][]schema.GroupVersionResourc
 
 		{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
 
-		{Group: "autoscaling", Version: "v2beta2", Resource: "horizontalpodautoscalers"},
+		{Group: "autoscaling", Version: "v2", Resource: "horizontalpodautoscalers"},
 	},
 
 	// all supported kubesphere api objects

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -466,7 +466,7 @@ func (s *APIServer) waitForResourceSync(ctx context.Context) error {
 			"ingresses",
 			"networkpolicies",
 		},
-		{Group: "autoscaling", Version: "v2beta2"}: {
+		{Group: "autoscaling", Version: "v2"}: {
 			"horizontalpodautoscalers",
 		},
 	}

--- a/pkg/models/resources/v1alpha2/hpa/horizontalpodautoscalers.go
+++ b/pkg/models/resources/v1alpha2/hpa/horizontalpodautoscalers.go
@@ -18,7 +18,7 @@ package hpa
 import (
 	"sort"
 
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 
@@ -35,15 +35,15 @@ func NewHpaSearcher(informers informers.SharedInformerFactory) v1alpha2.Interfac
 }
 
 func (s *hpaSearcher) Get(namespace, name string) (interface{}, error) {
-	return s.informers.Autoscaling().V2beta2().HorizontalPodAutoscalers().Lister().HorizontalPodAutoscalers(namespace).Get(name)
+	return s.informers.Autoscaling().V2().HorizontalPodAutoscalers().Lister().HorizontalPodAutoscalers(namespace).Get(name)
 }
 
-func hpaTargetMatch(item *autoscalingv2beta2.HorizontalPodAutoscaler, kind, name string) bool {
+func hpaTargetMatch(item *autoscalingv2.HorizontalPodAutoscaler, kind, name string) bool {
 	return item.Spec.ScaleTargetRef.Kind == kind && item.Spec.ScaleTargetRef.Name == name
 }
 
 // exactly Match
-func (*hpaSearcher) match(match map[string]string, item *autoscalingv2beta2.HorizontalPodAutoscaler) bool {
+func (*hpaSearcher) match(match map[string]string, item *autoscalingv2.HorizontalPodAutoscaler) bool {
 	for k, v := range match {
 		switch k {
 		case v1alpha2.TargetKind:
@@ -63,7 +63,7 @@ func (*hpaSearcher) match(match map[string]string, item *autoscalingv2beta2.Hori
 	return true
 }
 
-func (*hpaSearcher) fuzzy(fuzzy map[string]string, item *autoscalingv2beta2.HorizontalPodAutoscaler) bool {
+func (*hpaSearcher) fuzzy(fuzzy map[string]string, item *autoscalingv2.HorizontalPodAutoscaler) bool {
 	for k, v := range fuzzy {
 		if !v1alpha2.ObjectMetaFuzzyMath(k, v, item.ObjectMeta) {
 			return false
@@ -74,13 +74,13 @@ func (*hpaSearcher) fuzzy(fuzzy map[string]string, item *autoscalingv2beta2.Hori
 
 func (s *hpaSearcher) Search(namespace string, conditions *params.Conditions, orderBy string, reverse bool) ([]interface{}, error) {
 
-	horizontalPodAutoscalers, err := s.informers.Autoscaling().V2beta2().HorizontalPodAutoscalers().Lister().HorizontalPodAutoscalers(namespace).List(labels.Everything())
+	horizontalPodAutoscalers, err := s.informers.Autoscaling().V2().HorizontalPodAutoscalers().Lister().HorizontalPodAutoscalers(namespace).List(labels.Everything())
 
 	if err != nil {
 		return nil, err
 	}
 
-	result := make([]*autoscalingv2beta2.HorizontalPodAutoscaler, 0)
+	result := make([]*autoscalingv2.HorizontalPodAutoscaler, 0)
 
 	if len(conditions.Match) == 0 && len(conditions.Fuzzy) == 0 {
 		result = horizontalPodAutoscalers


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind api-change
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

Use autoscaling/v2 instead of autoscaling/v2beta2, for more details: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5832

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
 autoscaling/v2beta2 is no longer supported
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
