### PR TITLE
add rule_type label to indicate rule type

### DIFF
--- a/pkg/controller/alerting/util.go
+++ b/pkg/controller/alerting/util.go
@@ -42,9 +42,13 @@ const (
 	RuleLevelCluster   RuleLevel = "cluster"
 	RuleLevelGlobal    RuleLevel = "global"
 
+	RuleTypeTemplate RuleType = "template" // for template rule configured by exprBuilder to build expression
+	RuleTypeCustom   RuleType = "custom"   // for custom rule configured by direct expression
+
 	// for rule.labels
 	RuleLabelKeyRuleLevel         = "rule_level"
 	RuleLabelKeyRuleGroup         = "rule_group"
+	RuleLabelKeyRuleType          = "rule_type"
 	RuleLabelKeyCluster           = "cluster"
 	RuleLabelKeyNamespace         = "namespace"
 	RuleLabelKeySeverity          = "severity"
@@ -74,6 +78,8 @@ const (
 )
 
 type RuleLevel string
+
+type RuleType string
 
 var maxConfigMapDataSize = int(float64(corev1.MaxSecretSize) * 0.5)
 
@@ -193,6 +199,11 @@ func makePrometheusRuleGroups(log logr.Logger, groupList client.ObjectList,
 					continue
 				}
 				if prule != nil {
+					if rule.ExprBuilder != nil && rule.ExprBuilder.Workload != nil {
+						prule.Labels[RuleLabelKeyRuleType] = string(RuleTypeTemplate)
+					} else {
+						prule.Labels[RuleLabelKeyRuleType] = string(RuleTypeCustom)
+					}
 					prules = append(prules, *prule)
 				}
 			}
@@ -216,6 +227,11 @@ func makePrometheusRuleGroups(log logr.Logger, groupList client.ObjectList,
 					continue
 				}
 				if prule != nil {
+					if rule.ExprBuilder != nil && rule.ExprBuilder.Node != nil {
+						prule.Labels[RuleLabelKeyRuleType] = string(RuleTypeTemplate)
+					} else {
+						prule.Labels[RuleLabelKeyRuleType] = string(RuleTypeCustom)
+					}
 					prules = append(prules, *prule)
 				}
 			}
@@ -241,6 +257,11 @@ func makePrometheusRuleGroups(log logr.Logger, groupList client.ObjectList,
 					continue
 				}
 				if prule != nil {
+					if rule.ExprBuilder != nil && (rule.ExprBuilder.Node != nil || rule.ExprBuilder.Workload != nil) {
+						prule.Labels[RuleLabelKeyRuleType] = string(RuleTypeTemplate)
+					} else {
+						prule.Labels[RuleLabelKeyRuleType] = string(RuleTypeCustom)
+					}
 					prules = append(prules, *prule)
 				}
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
add `rule_type` label to the rule's labels to mark the rule type, and alerts generated by the rule will also be with this label

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubesphere/kubesphere/issues/5827
### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
