### PR TITLE
add kubectl controller

### DIFF
--- a/cmd/controller-manager/app/controllers.go
+++ b/cmd/controller-manager/app/controllers.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	"kubesphere.io/kubesphere/pkg/controller/kubectl"
 	ctrl "sigs.k8s.io/controller-runtime"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -558,6 +559,10 @@ func addAllControllers(mgr manager.Manager, client k8s.Client, informerFactory i
 			klog.Infof("%s controller is disabled by controller selectors.", name)
 		}
 	}
+
+	// Add kubectl controller
+	kubectlController := kubectl.NewController(client.Kubernetes(), kubernetesInformer.Core().V1().Pods())
+	addController(mgr, "kubectl", kubectlController)
 
 	return nil
 }

--- a/pkg/controller/kubectl/kubectl_controller.go
+++ b/pkg/controller/kubectl/kubectl_controller.go
@@ -1,0 +1,112 @@
+package kubectl
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinfomers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+const (
+	Finalizer   = "liks.lixiang.com/kubectl-controller"
+	parallelism = 4
+)
+
+type Controller struct {
+	podSynced cache.InformerSynced
+	workqueue workqueue.RateLimitingInterface
+	getPod    func(namespace, name string) (*v1.Pod, error)
+	updatePod func(pod *v1.Pod) (*v1.Pod, error)
+	deletePod func(namespace, name string) error
+	sync      func(key string) error
+}
+
+func NewController(k8sClient kubernetes.Interface, podInformer coreinfomers.PodInformer) *Controller {
+	klog.Infof("create kubectl controller")
+	ctl := &Controller{
+		podSynced: podInformer.Informer().HasSynced,
+		workqueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kubectl"),
+		getPod: func(namespace, name string) (*v1.Pod, error) {
+			return podInformer.Lister().Pods(namespace).Get(name)
+		},
+		updatePod: func(pod *v1.Pod) (*v1.Pod, error) {
+			return k8sClient.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
+		},
+		deletePod: func(namespace, name string) error {
+			return k8sClient.CoreV1().Pods(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		},
+		sync: nil,
+	}
+	ctl.sync = ctl.reconcile
+	klog.Infof("Setting up kubectl controller event handlers")
+	podInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: func(obj interface{}) bool {
+			if pod, ok := obj.(*v1.Pod); ok && pod.Namespace == "term.ns" && len(pod.OwnerReferences) == 0 && strings.HasPrefix(pod.Name, "term.has") {
+				return true
+			}
+			return false
+		},
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: ctl.enqueuePod,
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				ctl.enqueuePod(newObj)
+			},
+			DeleteFunc: ctl.enqueuePod,
+		},
+	})
+	return nil
+}
+
+func (c *Controller) Start(ctx context.Context) error {
+	return c.Run(parallelism, ctx.Done())
+}
+func (c *Controller) Run(threadLines int, stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+	defer c.workqueue.ShutDown()
+
+	klog.Infof("Starting kubectl controller")
+
+	klog.Infof("Waiting for informer caches to sync")
+	if ok := cache.WaitForCacheSync(stopCh, c.podSynced); !ok {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+	klog.Infof("Starting workers")
+	for i := 0; i < threadLines; i++ {
+		go wait.Until(c.runWorker, time.Second, stopCh)
+	}
+	klog.Infof("Started workers")
+	<-stopCh
+	klog.Infof("Shutting down worker")
+	return nil
+}
+
+func (c *Controller) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+func (c *Controller) processNextWorkItem() bool {
+	return true
+}
+func (c *Controller) reconcile(key string) error {
+	return nil
+}
+
+func (c *Controller) enqueuePod(obj interface{}) {
+	var key string
+	var err error
+	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	c.workqueue.Add(key)
+}

--- a/pkg/controller/kubectl/kubectl_controller.go
+++ b/pkg/controller/kubectl/kubectl_controller.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	"kubesphere.io/kubesphere/pkg/models/terminal"
 )
 
 const (
@@ -56,7 +57,7 @@ func NewController(k8sClient kubernetes.Interface, podInformer coreinfomers.PodI
 			// 1. Pod in specific namespace.
 			// 2. No controller owner.
 			// 3. Name will kubectl prefix
-			if pod, ok := obj.(*v1.Pod); ok && pod.Namespace == "term.ns" && len(pod.OwnerReferences) == 0 && strings.HasPrefix(pod.Name, "term.has") {
+			if pod, ok := obj.(*v1.Pod); ok && pod.Namespace == terminal.KubectlPodNamespace && len(pod.OwnerReferences) == 0 && strings.HasPrefix(pod.Name, terminal.KubectlPodNamePrefix) {
 				return true
 			}
 			return false

--- a/pkg/controller/kubectl/kubectl_controller.go
+++ b/pkg/controller/kubectl/kubectl_controller.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinfomers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -51,6 +53,9 @@ func NewController(k8sClient kubernetes.Interface, podInformer coreinfomers.PodI
 	klog.Infof("Setting up kubectl controller event handlers")
 	podInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
+			// 1. Pod in specific namespace.
+			// 2. No controller owner.
+			// 3. Name will kubectl prefix
 			if pod, ok := obj.(*v1.Pod); ok && pod.Namespace == "term.ns" && len(pod.OwnerReferences) == 0 && strings.HasPrefix(pod.Name, "term.has") {
 				return true
 			}
@@ -64,6 +69,47 @@ func NewController(k8sClient kubernetes.Interface, podInformer coreinfomers.PodI
 			DeleteFunc: ctl.enqueuePod,
 		},
 	})
+	return nil
+}
+
+func (c *Controller) reconcile(key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.Errorf("invalid kubectl pod key: %s", key)
+		return err
+	}
+	// get the pod with this name
+	sharedPod, err := c.getPod(namespace, name)
+	if err != nil {
+		// the user may no longer exist,in which case we stop processing
+		if errors.IsNotFound(err) {
+			utilruntime.HandleError(fmt.Errorf("pod '%s' is work queue no longer exists", key))
+			return nil
+		}
+		klog.Errorf("get kubectl pod %s failed: %v", key, err)
+		return err
+	}
+	// Make a copy so we don't mutate the shared cache
+	pod := sharedPod.DeepCopy()
+	if pod.Status.Phase == v1.PodSucceeded {
+		// check finalizer
+		if sets.NewString(pod.ObjectMeta.Finalizers...).Has(Finalizer) {
+			// remove our pod finalizer
+			finalizers := sets.NewString(pod.ObjectMeta.Finalizers...)
+			finalizers.Delete(Finalizer)
+			pod.ObjectMeta.Finalizers = finalizers.List()
+			if _, err := c.updatePod(pod); err != nil {
+				klog.Errorf("update pod %s failed: %v", key, err)
+				return err
+			}
+		} else if err := c.deletePod(namespace, name); err != nil {
+			klog.Errorf("delete kubectl pod %s failed: %v", key, err)
+			return err
+		} else if pod.ObjectMeta.DeletionTimestamp.IsZero() {
+
+		}
+		return nil
+	}
 	return nil
 }
 
@@ -95,10 +141,40 @@ func (c *Controller) runWorker() {
 	}
 }
 func (c *Controller) processNextWorkItem() bool {
+	obj, shutdown := c.workqueue.Get()
+	if shutdown {
+		return false
+	}
+	err := func(obj interface{}) error {
+		// we call Done here so the work queue knows we have finished processing this item
+		// we also must remember to call Forget if we  do not want this work item being re-queued.For example,we do
+		// not call Forget if a transient error occurs,instead the item is put back on the work queue and attempted again
+		// after a back-off period
+		defer c.workqueue.Done(obj)
+		var key string
+		var ok bool
+		if key, ok = obj.(string); !ok {
+			c.workqueue.Forget(obj)
+			utilruntime.HandleError(fmt.Errorf("expected string in workqueue  but got %#v", obj))
+			return nil
+		}
+		// Run the reconcile, passing it the namespace/name string of the
+		// Foo resource to be synced.
+		if err := c.sync(key); err != nil {
+			c.workqueue.AddRateLimited(key)
+			return fmt.Errorf("error syncing '%s': %s", key, err.Error())
+		}
+		// Finally, if no error occurs we Forget this item so it does not
+		// get queued again until another change happens.
+		c.workqueue.Forget(obj)
+		klog.Infof("Successfully synced key:%s", key)
+		return nil
+	}(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return true
+	}
 	return true
-}
-func (c *Controller) reconcile(key string) error {
-	return nil
 }
 
 func (c *Controller) enqueuePod(obj interface{}) {

--- a/pkg/controller/kubectl/kubectl_controller.go
+++ b/pkg/controller/kubectl/kubectl_controller.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	Finalizer   = "liks.lixiang.com/kubectl-controller"
+	Finalizer   = "github.com/kubesphere/kubectl-controller"
 	parallelism = 4
 )
 

--- a/pkg/controller/kubectl/kubectl_controller_test.go
+++ b/pkg/controller/kubectl/kubectl_controller_test.go
@@ -1,0 +1,256 @@
+package kubectl
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/util/workqueue"
+)
+
+func Test_NewController(t *testing.T) {
+	cs := fakeclientset.NewSimpleClientset(&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fake-node1",
+			Labels: map[string]string{
+				"fake.label.kubernetes.io": "fake",
+			},
+		},
+	})
+	informerFactory := informers.NewSharedInformerFactory(cs, time.Minute*10)
+	c := NewController(cs, informerFactory.Core().V1().Pods())
+	if c.podSynced == nil || c.getPod == nil || c.updatePod == nil || c.deletePod == nil || c.workqueue == nil || c.sync == nil {
+		t.Error("NewController failed")
+	}
+}
+
+func Test_Controller_Start(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*1)
+	defer cancel()
+	uid := uuid.New().String()
+	c := &Controller{
+		podSynced: func() bool { return true },
+		workqueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kubectl"),
+		sync: func(key string) error {
+			if key != uid {
+				t.Errorf("Test Controller Start failed: %s!=%s", key, uid)
+			}
+			cancel()
+			return nil
+		},
+	}
+	c.workqueue.Add(uid)
+	if err := c.Start(ctx); err != nil {
+		t.Errorf("Test Controller Start failed: %s", err)
+	}
+}
+
+func Test_Controller_enqueuePod(t *testing.T) {
+	c := Controller{workqueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kubectl")}
+	// Test invalid object
+	c.enqueuePod("test")
+	if c.workqueue.Len() != 0 {
+		t.Errorf("enqueuePod failed")
+	}
+	c.enqueuePod(&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-name",
+			Namespace: "test-ns",
+		},
+	})
+	if c.workqueue.Len() != 1 {
+		t.Errorf("enqueuePod failed:len != %d", c.workqueue.Len())
+	} else if obj, shutdown := c.workqueue.Get(); shutdown || !reflect.DeepEqual(obj, "test-ns/test-name") {
+		t.Errorf("enqueuePod failed:%v,%v", shutdown, obj)
+	}
+}
+
+func Test_Controller_processNextWorkItem(t *testing.T) {
+	c := &Controller{
+		workqueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kubectl"),
+	}
+
+	// 1. Test work queue is closed.
+	c.workqueue.ShutDown()
+	if c.processNextWorkItem() {
+		t.Errorf("processNextWorkItem failed")
+	}
+
+	// 2. Test invalid key
+	c.workqueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kubectl")
+	c.sync = func(key string) error {
+		t.Errorf("Test_Controller_processNextWorkItem: %s", key)
+		return nil
+	}
+	c.workqueue.Add(2)
+	if !c.processNextWorkItem() {
+		t.Errorf("processNextWorkItem failed")
+	}
+
+	// 3. Test sync failed.
+	c.sync = func(key string) error {
+		return fmt.Errorf("test error")
+	}
+	uid := uuid.New().String()
+	c.workqueue.Add(uid)
+	if !c.processNextWorkItem() {
+		t.Errorf("processNextWorkItem failed")
+	} else if key, shutdown := c.workqueue.Get(); shutdown || !reflect.DeepEqual(key, uid) {
+		t.Errorf("processNextWorkItem failed: %v, %v", key, shutdown)
+	}
+
+	// 3. Test sync succeeded.
+	c.sync = func(key string) error {
+		return nil
+	}
+	uid = uuid.New().String()
+	c.workqueue.Add(uid)
+	if !c.processNextWorkItem() {
+		t.Errorf("processNextWorkItem failed")
+	}
+	go func() {
+		time.Sleep(time.Second)
+		c.workqueue.ShutDown()
+	}()
+	if key, shutdown := c.workqueue.Get(); !shutdown || reflect.DeepEqual(key, uid) {
+		t.Errorf("processNextWorkItem failed: %v, %v", key, shutdown)
+	}
+}
+
+func Test_Controller_reconcile(t *testing.T) {
+	c := &Controller{}
+
+	// 1. test invalid key
+	err := c.reconcile("a/b/c")
+	if err == nil {
+		t.Errorf("reconcile() failed")
+	}
+
+	// 2. test not found.
+	c.getPod = func(namespace, name string) (*v1.Pod, error) {
+		return nil, errors.NewNotFound(schema.GroupResource{Group: "v1", Resource: "pod"}, "test not found")
+	}
+	err = c.reconcile("test")
+	if err != nil {
+		t.Errorf("reconcile() failed: %v", err)
+	}
+
+	// 3. test get pod failed.
+	werr := fmt.Errorf(uuid.New().String())
+	c.getPod = func(namespace, name string) (*v1.Pod, error) {
+		return nil, werr
+	}
+	err = c.reconcile("test")
+	if err != werr {
+		t.Errorf("reconcile() failed: %v", err)
+	}
+
+	// 4. test add finalizer failed.
+	name := uuid.New().String()
+	c.getPod = func(namespace, name string) (*v1.Pod, error) {
+		return &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}, nil
+	}
+	c.updatePod = func(pod *v1.Pod) (*v1.Pod, error) {
+		if pod.Name != name {
+			return nil, fmt.Errorf("invalid pod %s!=%s", name, pod.Name)
+		}
+		if !sets.NewString(pod.ObjectMeta.Finalizers...).Has(Finalizer) {
+			return nil, fmt.Errorf("without finalizer %v", pod.ObjectMeta.Finalizers)
+		}
+
+		return nil, fmt.Errorf("test add finalizer failed")
+	}
+	err = c.reconcile(name)
+	if err == nil || err.Error() != "test add finalizer failed" {
+		t.Errorf("reconcile() failed: %v", err)
+	}
+
+	// 5. test add finalizer succeeded.
+	c.updatePod = func(pod *v1.Pod) (*v1.Pod, error) {
+		return pod.DeepCopy(), nil
+	}
+	err = c.reconcile(name)
+	if err != nil {
+		t.Errorf("reconcile() failed: %v", err)
+	}
+
+	// 6. test remove finalizer failed.
+	name = uuid.New().String()
+	c.getPod = func(namespace, name string) (*v1.Pod, error) {
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       name,
+				Namespace:  namespace,
+				Finalizers: []string{Finalizer},
+			},
+			Status: v1.PodStatus{Phase: v1.PodSucceeded},
+		}, nil
+	}
+	c.updatePod = func(pod *v1.Pod) (*v1.Pod, error) {
+		if pod.Name != name {
+			return nil, fmt.Errorf("invalid pod %s!=%s", name, pod.Name)
+		}
+		if sets.NewString(pod.ObjectMeta.Finalizers...).Has(Finalizer) {
+			return nil, fmt.Errorf("with finalizer %v", pod.ObjectMeta.Finalizers)
+		}
+		return nil, fmt.Errorf("test remove finalizer failed")
+	}
+	err = c.reconcile(name)
+	if err == nil || err.Error() != "test remove finalizer failed" {
+		t.Errorf("reconcile() failed: %v", err)
+	}
+
+	// 7. test remove finalizer succeeded.
+	c.updatePod = func(pod *v1.Pod) (*v1.Pod, error) {
+		if pod.Name != name {
+			return nil, fmt.Errorf("invalid pod %s!=%s", name, pod.Name)
+		}
+		if sets.NewString(pod.ObjectMeta.Finalizers...).Has(Finalizer) {
+			return nil, fmt.Errorf("with finalizer %v", pod.ObjectMeta.Finalizers)
+		}
+		return pod.DeepCopy(), nil
+	}
+	err = c.reconcile(name)
+	if err != nil {
+		t.Errorf("reconcile() failed: %v", err)
+	}
+
+	// 8. test delete pod failed.
+	deleteTime := metav1.Now()
+	c.getPod = func(namespace, name string) (*v1.Pod, error) {
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         namespace,
+				DeletionTimestamp: &deleteTime,
+			},
+			Status: v1.PodStatus{Phase: v1.PodSucceeded},
+		}, nil
+	}
+	c.deletePod = func(namespace, name string) error {
+		return fmt.Errorf("test delete pod failed")
+	}
+	err = c.reconcile(name)
+	if err == nil || err.Error() != "test delete pod failed" {
+		t.Errorf("reconcile() failed: %v", err)
+	}
+
+	// 9. test delete pod succeeded.
+	c.deletePod = func(namespace, name string) error {
+		return nil
+	}
+	err = c.reconcile(name)
+	if err != nil {
+		t.Errorf("reconcile() failed: %v", err)
+	}
+}

--- a/pkg/models/terminal/terminal.go
+++ b/pkg/models/terminal/terminal.go
@@ -21,48 +21,52 @@ limitations under the License.
 package terminal
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"strconv"
-	"sync"
-	"sync/atomic"
-	"time"
+  "context"
+  "encoding/json"
+  "fmt"
+  "io"
+  "strconv"
+  "sync"
+  "sync/atomic"
+  "time"
 
-	"github.com/gorilla/websocket"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/klog/v2"
+  "github.com/gorilla/websocket"
+  v1 "k8s.io/api/core/v1"
+  metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+  "k8s.io/apimachinery/pkg/util/wait"
+  "k8s.io/client-go/kubernetes"
+  "k8s.io/client-go/kubernetes/scheme"
+  "k8s.io/client-go/rest"
+  "k8s.io/client-go/tools/remotecommand"
+  "k8s.io/klog/v2"
 )
 
 const (
-	// Time allowed to write a message to the peer.
-	writeWait = 10 * time.Second
-	// ctrl+d to close terminal.
-	endOfTransmission = "\u0004"
+  // KubectlPodNamespace is kubectl pod namespace.
+  KubectlPodNamespace = "kubesphere-controls-system"
+  // KubectlPodNamePrefix is kubectl pod name prefix.
+  KubectlPodNamePrefix = "kubectl-"
+  // Time allowed to write a message to the peer.
+  writeWait = 10 * time.Second
+  // ctrl+d to close terminal.
+  endOfTransmission = "\u0004"
 )
 
 // PtyHandler is what remotecommand expects from a pty
 type PtyHandler interface {
-	io.Reader
-	io.Writer
-	remotecommand.TerminalSizeQueue
+  io.Reader
+  io.Writer
+  remotecommand.TerminalSizeQueue
 }
 
 // TerminalSession implements PtyHandler (using a SockJS connection)
 type TerminalSession struct {
-	conn     *websocket.Conn
-	sizeChan chan remotecommand.TerminalSize
+  conn     *websocket.Conn
+  sizeChan chan remotecommand.TerminalSize
 }
 
 var (
-	NodeSessionCounter sync.Map
+  NodeSessionCounter sync.Map
 )
 
 // TerminalMessage is the messaging protocol between ShellController and TerminalSession.
@@ -74,339 +78,339 @@ var (
 // stdout  be->fe     Data           Output from the process
 // toast   be->fe     Data           OOB message to be shown to the user
 type TerminalMessage struct {
-	Op, Data   string
-	Rows, Cols uint16
+  Op, Data   string
+  Rows, Cols uint16
 }
 
 // Next handles pty->process resize events
 // Called in a loop from remotecommand as long as the process is running
 func (t TerminalSession) Next() *remotecommand.TerminalSize {
-	size := <-t.sizeChan
-	if size.Height == 0 && size.Width == 0 {
-		return nil
-	}
-	return &size
+  size := <-t.sizeChan
+  if size.Height == 0 && size.Width == 0 {
+    return nil
+  }
+  return &size
 }
 
 // Read handles pty->process messages (stdin, resize)
 // Called in a loop from remotecommand as long as the process is running
 func (t TerminalSession) Read(p []byte) (int, error) {
 
-	var msg TerminalMessage
-	err := t.conn.ReadJSON(&msg)
-	if err != nil {
-		return copy(p, endOfTransmission), err
-	}
+  var msg TerminalMessage
+  err := t.conn.ReadJSON(&msg)
+  if err != nil {
+    return copy(p, endOfTransmission), err
+  }
 
-	switch msg.Op {
-	case "stdin":
-		return copy(p, msg.Data), nil
-	case "resize":
-		t.sizeChan <- remotecommand.TerminalSize{Width: msg.Cols, Height: msg.Rows}
-		return 0, nil
-	default:
-		return copy(p, endOfTransmission), fmt.Errorf("unknown message type '%s'", msg.Op)
-	}
+  switch msg.Op {
+  case "stdin":
+    return copy(p, msg.Data), nil
+  case "resize":
+    t.sizeChan <- remotecommand.TerminalSize{Width: msg.Cols, Height: msg.Rows}
+    return 0, nil
+  default:
+    return copy(p, endOfTransmission), fmt.Errorf("unknown message type '%s'", msg.Op)
+  }
 }
 
 // Write handles process->pty stdout
 // Called from remotecommand whenever there is any output
 func (t TerminalSession) Write(p []byte) (int, error) {
-	msg, err := json.Marshal(TerminalMessage{
-		Op:   "stdout",
-		Data: string(p),
-	})
-	if err != nil {
-		return 0, err
-	}
-	t.conn.SetWriteDeadline(time.Now().Add(writeWait))
-	if err = t.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
-		return 0, err
-	}
-	return len(p), nil
+  msg, err := json.Marshal(TerminalMessage{
+    Op:   "stdout",
+    Data: string(p),
+  })
+  if err != nil {
+    return 0, err
+  }
+  t.conn.SetWriteDeadline(time.Now().Add(writeWait))
+  if err = t.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+    return 0, err
+  }
+  return len(p), nil
 }
 
 // Toast can be used to send the user any OOB messages
 // hterm puts these in the center of the terminal
 func (t TerminalSession) Toast(p string) error {
-	msg, err := json.Marshal(TerminalMessage{
-		Op:   "toast",
-		Data: p,
-	})
-	if err != nil {
-		return err
-	}
-	t.conn.SetWriteDeadline(time.Now().Add(writeWait))
-	if err = t.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
-		return err
-	}
-	return nil
+  msg, err := json.Marshal(TerminalMessage{
+    Op:   "toast",
+    Data: p,
+  })
+  if err != nil {
+    return err
+  }
+  t.conn.SetWriteDeadline(time.Now().Add(writeWait))
+  if err = t.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+    return err
+  }
+  return nil
 }
 
 // Close shuts down the SockJS connection and sends the status code and reason to the client
 // Can happen if the process exits or if there is an error starting up the process
 // For now the status code is unused and reason is shown to the user (unless "")
 func (t TerminalSession) Close(status uint32, reason string) {
-	klog.Warning(status, reason)
-	close(t.sizeChan)
-	t.conn.Close()
+  klog.Warning(status, reason)
+  close(t.sizeChan)
+  t.conn.Close()
 }
 
 type Interface interface {
-	HandleSession(shell, namespace, podName, containerName string, conn *websocket.Conn)
-	HandleShellAccessToNode(nodename string, conn *websocket.Conn)
+  HandleSession(shell, namespace, podName, containerName string, conn *websocket.Conn)
+  HandleShellAccessToNode(nodename string, conn *websocket.Conn)
 }
 
 type terminaler struct {
-	client  kubernetes.Interface
-	config  *rest.Config
-	options *Options
+  client  kubernetes.Interface
+  config  *rest.Config
+  options *Options
 }
 
 type NodeTerminaler struct {
-	Nodename      string
-	Namespace     string
-	PodName       string
-	ContainerName string
-	Shell         string
-	Privileged    bool
-	Config        *Options
-	client        kubernetes.Interface
+  Nodename      string
+  Namespace     string
+  PodName       string
+  ContainerName string
+  Shell         string
+  Privileged    bool
+  Config        *Options
+  client        kubernetes.Interface
 }
 
 func NewTerminaler(client kubernetes.Interface, config *rest.Config, options *Options) Interface {
-	return &terminaler{client: client, config: config, options: options}
+  return &terminaler{client: client, config: config, options: options}
 }
 
 func NewNodeTerminaler(nodename string, options *Options, client kubernetes.Interface) (*NodeTerminaler, error) {
 
-	n := &NodeTerminaler{
-		Namespace:     "kubesphere-controls-system",
-		ContainerName: "nsenter",
-		Nodename:      nodename,
-		PodName:       nodename + "-shell-access",
-		Shell:         "sh",
-		Privileged:    true,
-		Config:        options,
-		client:        client,
-	}
+  n := &NodeTerminaler{
+    Namespace:     "kubesphere-controls-system",
+    ContainerName: "nsenter",
+    Nodename:      nodename,
+    PodName:       nodename + "-shell-access",
+    Shell:         "sh",
+    Privileged:    true,
+    Config:        options,
+    client:        client,
+  }
 
-	node, err := n.client.CoreV1().Nodes().Get(context.Background(), n.Nodename, metav1.GetOptions{})
+  node, err := n.client.CoreV1().Nodes().Get(context.Background(), n.Nodename, metav1.GetOptions{})
 
-	if err != nil {
-		return n, fmt.Errorf("getting node error. nodename:%s, err: %v", n.Nodename, err)
-	}
+  if err != nil {
+    return n, fmt.Errorf("getting node error. nodename:%s, err: %v", n.Nodename, err)
+  }
 
-	flag := false
-	for _, condition := range node.Status.Conditions {
-		if condition.Type == v1.NodeReady && condition.Status == v1.ConditionTrue {
-			flag = true
-			break
-		}
-	}
-	if !flag {
-		return n, fmt.Errorf("node status error. node: %s", n.Nodename)
-	}
+  flag := false
+  for _, condition := range node.Status.Conditions {
+    if condition.Type == v1.NodeReady && condition.Status == v1.ConditionTrue {
+      flag = true
+      break
+    }
+  }
+  if !flag {
+    return n, fmt.Errorf("node status error. node: %s", n.Nodename)
+  }
 
-	return n, nil
+  return n, nil
 }
 
 func (n *NodeTerminaler) getNSEnterPod() (*v1.Pod, error) {
-	pod, err := n.client.CoreV1().Pods(n.Namespace).Get(context.Background(), n.PodName, metav1.GetOptions{})
+  pod, err := n.client.CoreV1().Pods(n.Namespace).Get(context.Background(), n.PodName, metav1.GetOptions{})
 
-	if err != nil || (pod.Status.Phase != v1.PodRunning && pod.Status.Phase != v1.PodPending) {
-		// pod has timed out, but has not been cleaned up
-		if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
-			err := n.client.CoreV1().Pods(n.Namespace).Delete(context.Background(), n.PodName, metav1.DeleteOptions{})
-			if err != nil {
-				return pod, err
-			}
-		}
+  if err != nil || (pod.Status.Phase != v1.PodRunning && pod.Status.Phase != v1.PodPending) {
+    // pod has timed out, but has not been cleaned up
+    if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+      err := n.client.CoreV1().Pods(n.Namespace).Delete(context.Background(), n.PodName, metav1.DeleteOptions{})
+      if err != nil {
+        return pod, err
+      }
+    }
 
-		var p = &v1.Pod{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "pod",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: n.PodName,
-			},
-			Spec: v1.PodSpec{
-				NodeName:      n.Nodename,
-				HostPID:       true,
-				HostNetwork:   true,
-				RestartPolicy: v1.RestartPolicyNever,
-				Containers: []v1.Container{
-					{
-						Name:  n.ContainerName,
-						Image: n.Config.Image,
-						Command: []string{
-							"nsenter", "-m", "-u", "-i", "-n", "-p", "-t", "1",
-						},
-						Stdin: true,
-						TTY:   true,
-						SecurityContext: &v1.SecurityContext{
-							Privileged: &n.Privileged,
-						},
-					},
-				},
-			},
-		}
+    var p = &v1.Pod{
+      TypeMeta: metav1.TypeMeta{
+        Kind:       "pod",
+        APIVersion: "v1",
+      },
+      ObjectMeta: metav1.ObjectMeta{
+        Name: n.PodName,
+      },
+      Spec: v1.PodSpec{
+        NodeName:      n.Nodename,
+        HostPID:       true,
+        HostNetwork:   true,
+        RestartPolicy: v1.RestartPolicyNever,
+        Containers: []v1.Container{
+          {
+            Name:  n.ContainerName,
+            Image: n.Config.Image,
+            Command: []string{
+              "nsenter", "-m", "-u", "-i", "-n", "-p", "-t", "1",
+            },
+            Stdin: true,
+            TTY:   true,
+            SecurityContext: &v1.SecurityContext{
+              Privileged: &n.Privileged,
+            },
+          },
+        },
+      },
+    }
 
-		if n.Config.Timeout == 0 {
-			p.Spec.Containers[0].Args = []string{"tail", "-f", "/dev/null"}
-		} else {
-			p.Spec.Containers[0].Args = []string{"sleep", strconv.Itoa(n.Config.Timeout)}
-		}
+    if n.Config.Timeout == 0 {
+      p.Spec.Containers[0].Args = []string{"tail", "-f", "/dev/null"}
+    } else {
+      p.Spec.Containers[0].Args = []string{"sleep", strconv.Itoa(n.Config.Timeout)}
+    }
 
-		pod, err = n.client.CoreV1().Pods(n.Namespace).Create(context.Background(), p, metav1.CreateOptions{})
-		if err != nil {
-			return nil, fmt.Errorf("create pod failed on %s node: %v", n.Nodename, err)
-		}
-	}
+    pod, err = n.client.CoreV1().Pods(n.Namespace).Create(context.Background(), p, metav1.CreateOptions{})
+    if err != nil {
+      return nil, fmt.Errorf("create pod failed on %s node: %v", n.Nodename, err)
+    }
+  }
 
-	return pod, nil
+  return pod, nil
 }
 
 func (n NodeTerminaler) CleanUpNSEnterPod() {
-	idx, _ := NodeSessionCounter.Load(n.Nodename)
-	atomic.AddInt64(idx.(*int64), -1)
+  idx, _ := NodeSessionCounter.Load(n.Nodename)
+  atomic.AddInt64(idx.(*int64), -1)
 
-	if *(idx.(*int64)) == 0 {
-		err := n.client.CoreV1().Pods(n.Namespace).Delete(context.Background(), n.PodName, metav1.DeleteOptions{})
-		if err != nil {
-			klog.Warning(err)
-		}
-	}
+  if *(idx.(*int64)) == 0 {
+    err := n.client.CoreV1().Pods(n.Namespace).Delete(context.Background(), n.PodName, metav1.DeleteOptions{})
+    if err != nil {
+      klog.Warning(err)
+    }
+  }
 }
 
 // startProcess is called by handleAttach
 // Executed cmd in the container specified in request and connects it up with the ptyHandler (a session)
 func (t *terminaler) startProcess(namespace, podName, containerName string, cmd []string, ptyHandler PtyHandler) error {
-	req := t.client.CoreV1().RESTClient().Post().
-		Resource("pods").
-		Name(podName).
-		Namespace(namespace).
-		SubResource("exec")
-	req.VersionedParams(&v1.PodExecOptions{
-		Container: containerName,
-		Command:   cmd,
-		Stdin:     true,
-		Stdout:    true,
-		Stderr:    true,
-		TTY:       true,
-	}, scheme.ParameterCodec)
+  req := t.client.CoreV1().RESTClient().Post().
+    Resource("pods").
+    Name(podName).
+    Namespace(namespace).
+    SubResource("exec")
+  req.VersionedParams(&v1.PodExecOptions{
+    Container: containerName,
+    Command:   cmd,
+    Stdin:     true,
+    Stdout:    true,
+    Stderr:    true,
+    TTY:       true,
+  }, scheme.ParameterCodec)
 
-	exec, err := remotecommand.NewSPDYExecutor(t.config, "POST", req.URL())
-	if err != nil {
-		return err
-	}
+  exec, err := remotecommand.NewSPDYExecutor(t.config, "POST", req.URL())
+  if err != nil {
+    return err
+  }
 
-	err = exec.Stream(remotecommand.StreamOptions{
-		Stdin:             ptyHandler,
-		Stdout:            ptyHandler,
-		Stderr:            ptyHandler,
-		TerminalSizeQueue: ptyHandler,
-		Tty:               true,
-	})
-	if err != nil {
-		return err
-	}
+  err = exec.Stream(remotecommand.StreamOptions{
+    Stdin:             ptyHandler,
+    Stdout:            ptyHandler,
+    Stderr:            ptyHandler,
+    TerminalSizeQueue: ptyHandler,
+    Tty:               true,
+  })
+  if err != nil {
+    return err
+  }
 
-	return nil
+  return nil
 }
 
 // isValidShell checks if the shell is an allowed one
 func isValidShell(validShells []string, shell string) bool {
-	for _, validShell := range validShells {
-		if validShell == shell {
-			return true
-		}
-	}
-	return false
+  for _, validShell := range validShells {
+    if validShell == shell {
+      return true
+    }
+  }
+  return false
 }
 
 func (t *terminaler) HandleSession(shell, namespace, podName, containerName string, conn *websocket.Conn) {
-	var err error
-	validShells := []string{"bash", "sh"}
+  var err error
+  validShells := []string{"bash", "sh"}
 
-	session := &TerminalSession{conn: conn, sizeChan: make(chan remotecommand.TerminalSize)}
+  session := &TerminalSession{conn: conn, sizeChan: make(chan remotecommand.TerminalSize)}
 
-	if isValidShell(validShells, shell) {
-		cmd := []string{shell}
-		err = t.startProcess(namespace, podName, containerName, cmd, session)
-	} else {
-		// No shell given or it was not valid: try some shells until one succeeds or all fail
-		// FIXME: if the first shell fails then the first keyboard event is lost
-		for _, testShell := range validShells {
-			cmd := []string{testShell}
-			if err = t.startProcess(namespace, podName, containerName, cmd, session); err == nil {
-				break
-			}
-		}
-	}
+  if isValidShell(validShells, shell) {
+    cmd := []string{shell}
+    err = t.startProcess(namespace, podName, containerName, cmd, session)
+  } else {
+    // No shell given or it was not valid: try some shells until one succeeds or all fail
+    // FIXME: if the first shell fails then the first keyboard event is lost
+    for _, testShell := range validShells {
+      cmd := []string{testShell}
+      if err = t.startProcess(namespace, podName, containerName, cmd, session); err == nil {
+        break
+      }
+    }
+  }
 
-	if err != nil {
-		session.Close(2, err.Error())
-		return
-	}
+  if err != nil {
+    session.Close(2, err.Error())
+    return
+  }
 
-	session.Close(1, "Process exited")
+  session.Close(1, "Process exited")
 }
 
 func (t *terminaler) HandleShellAccessToNode(nodename string, conn *websocket.Conn) {
 
-	nodeTerminaler, err := NewNodeTerminaler(nodename, t.options, t.client)
-	if err != nil {
-		klog.Warning("node terminaler init error: ", err)
-		return
-	}
+  nodeTerminaler, err := NewNodeTerminaler(nodename, t.options, t.client)
+  if err != nil {
+    klog.Warning("node terminaler init error: ", err)
+    return
+  }
 
-	pod, err := nodeTerminaler.getNSEnterPod()
-	if err != nil {
-		klog.Warning("get nsenter pod error: ", err)
-		return
-	}
+  pod, err := nodeTerminaler.getNSEnterPod()
+  if err != nil {
+    klog.Warning("get nsenter pod error: ", err)
+    return
+  }
 
-	if err := nodeTerminaler.WatchPodStatusBeRunning(pod); err != nil {
-		klog.Warning("watching pod status error: ", err)
-		return
-	} else {
-		t.HandleSession(nodeTerminaler.Shell, nodeTerminaler.Namespace, nodeTerminaler.PodName, nodeTerminaler.ContainerName, conn)
-		defer nodeTerminaler.CleanUpNSEnterPod()
-	}
+  if err := nodeTerminaler.WatchPodStatusBeRunning(pod); err != nil {
+    klog.Warning("watching pod status error: ", err)
+    return
+  } else {
+    t.HandleSession(nodeTerminaler.Shell, nodeTerminaler.Namespace, nodeTerminaler.PodName, nodeTerminaler.ContainerName, conn)
+    defer nodeTerminaler.CleanUpNSEnterPod()
+  }
 }
 
 func (n *NodeTerminaler) WatchPodStatusBeRunning(pod *v1.Pod) error {
-	if pod.Status.Phase == v1.PodRunning {
-		idx, ok := NodeSessionCounter.Load(n.Nodename)
-		if ok {
-			atomic.AddInt64(idx.(*int64), 1)
-		} else {
-			i := int64(1)
-			NodeSessionCounter.LoadOrStore(n.Nodename, &i)
-		}
+  if pod.Status.Phase == v1.PodRunning {
+    idx, ok := NodeSessionCounter.Load(n.Nodename)
+    if ok {
+      atomic.AddInt64(idx.(*int64), 1)
+    } else {
+      i := int64(1)
+      NodeSessionCounter.LoadOrStore(n.Nodename, &i)
+    }
 
-		return nil
-	}
+    return nil
+  }
 
-	return wait.Poll(time.Millisecond*500, time.Second*5, func() (done bool, err error) {
-		pod, err = n.client.CoreV1().Pods(pod.ObjectMeta.Namespace).Get(context.Background(), pod.ObjectMeta.Name, metav1.GetOptions{})
-		if err != nil {
-			klog.Warning(err)
-			return false, err
-		}
+  return wait.Poll(time.Millisecond*500, time.Second*5, func() (done bool, err error) {
+    pod, err = n.client.CoreV1().Pods(pod.ObjectMeta.Namespace).Get(context.Background(), pod.ObjectMeta.Name, metav1.GetOptions{})
+    if err != nil {
+      klog.Warning(err)
+      return false, err
+    }
 
-		if pod.Status.Phase == v1.PodRunning {
-			idx, ok := NodeSessionCounter.Load(n.Nodename)
-			if ok {
-				atomic.AddInt64(idx.(*int64), 1)
-			} else {
-				i := int64(1)
-				NodeSessionCounter.LoadOrStore(n.Nodename, &i)
-			}
-			return true, nil
-		}
-		return false, nil
-	})
+    if pod.Status.Phase == v1.PodRunning {
+      idx, ok := NodeSessionCounter.Load(n.Nodename)
+      if ok {
+        atomic.AddInt64(idx.(*int64), 1)
+      } else {
+        i := int64(1)
+        NodeSessionCounter.LoadOrStore(n.Nodename, &i)
+      }
+      return true, nil
+    }
+    return false, nil
+  })
 }

--- a/pkg/models/terminal/terminal.go
+++ b/pkg/models/terminal/terminal.go
@@ -21,52 +21,52 @@ limitations under the License.
 package terminal
 
 import (
-  "context"
-  "encoding/json"
-  "fmt"
-  "io"
-  "strconv"
-  "sync"
-  "sync/atomic"
-  "time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
 
-  "github.com/gorilla/websocket"
-  v1 "k8s.io/api/core/v1"
-  metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-  "k8s.io/apimachinery/pkg/util/wait"
-  "k8s.io/client-go/kubernetes"
-  "k8s.io/client-go/kubernetes/scheme"
-  "k8s.io/client-go/rest"
-  "k8s.io/client-go/tools/remotecommand"
-  "k8s.io/klog/v2"
+	"github.com/gorilla/websocket"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/klog/v2"
 )
 
 const (
-  // KubectlPodNamespace is kubectl pod namespace.
-  KubectlPodNamespace = "kubesphere-controls-system"
-  // KubectlPodNamePrefix is kubectl pod name prefix.
-  KubectlPodNamePrefix = "kubectl-"
-  // Time allowed to write a message to the peer.
-  writeWait = 10 * time.Second
-  // ctrl+d to close terminal.
-  endOfTransmission = "\u0004"
+	// KubectlPodNamespace is kubectl pod namespace
+	KubectlPodNamespace = "kubesphere-controls-system"
+	// KubectlPodNamePrefix is kubectl pod name prefix.
+	KubectlPodNamePrefix = "kubectl-"
+	// Time allowed to write a message to the peer.
+	writeWait = 10 * time.Second
+	// ctrl+d to close terminal.
+	endOfTransmission = "\u0004"
 )
 
 // PtyHandler is what remotecommand expects from a pty
 type PtyHandler interface {
-  io.Reader
-  io.Writer
-  remotecommand.TerminalSizeQueue
+	io.Reader
+	io.Writer
+	remotecommand.TerminalSizeQueue
 }
 
 // TerminalSession implements PtyHandler (using a SockJS connection)
 type TerminalSession struct {
-  conn     *websocket.Conn
-  sizeChan chan remotecommand.TerminalSize
+	conn     *websocket.Conn
+	sizeChan chan remotecommand.TerminalSize
 }
 
 var (
-  NodeSessionCounter sync.Map
+	NodeSessionCounter sync.Map
 )
 
 // TerminalMessage is the messaging protocol between ShellController and TerminalSession.
@@ -78,339 +78,339 @@ var (
 // stdout  be->fe     Data           Output from the process
 // toast   be->fe     Data           OOB message to be shown to the user
 type TerminalMessage struct {
-  Op, Data   string
-  Rows, Cols uint16
+	Op, Data   string
+	Rows, Cols uint16
 }
 
 // Next handles pty->process resize events
 // Called in a loop from remotecommand as long as the process is running
 func (t TerminalSession) Next() *remotecommand.TerminalSize {
-  size := <-t.sizeChan
-  if size.Height == 0 && size.Width == 0 {
-    return nil
-  }
-  return &size
+	size := <-t.sizeChan
+	if size.Height == 0 && size.Width == 0 {
+		return nil
+	}
+	return &size
 }
 
 // Read handles pty->process messages (stdin, resize)
 // Called in a loop from remotecommand as long as the process is running
 func (t TerminalSession) Read(p []byte) (int, error) {
 
-  var msg TerminalMessage
-  err := t.conn.ReadJSON(&msg)
-  if err != nil {
-    return copy(p, endOfTransmission), err
-  }
+	var msg TerminalMessage
+	err := t.conn.ReadJSON(&msg)
+	if err != nil {
+		return copy(p, endOfTransmission), err
+	}
 
-  switch msg.Op {
-  case "stdin":
-    return copy(p, msg.Data), nil
-  case "resize":
-    t.sizeChan <- remotecommand.TerminalSize{Width: msg.Cols, Height: msg.Rows}
-    return 0, nil
-  default:
-    return copy(p, endOfTransmission), fmt.Errorf("unknown message type '%s'", msg.Op)
-  }
+	switch msg.Op {
+	case "stdin":
+		return copy(p, msg.Data), nil
+	case "resize":
+		t.sizeChan <- remotecommand.TerminalSize{Width: msg.Cols, Height: msg.Rows}
+		return 0, nil
+	default:
+		return copy(p, endOfTransmission), fmt.Errorf("unknown message type '%s'", msg.Op)
+	}
 }
 
 // Write handles process->pty stdout
 // Called from remotecommand whenever there is any output
 func (t TerminalSession) Write(p []byte) (int, error) {
-  msg, err := json.Marshal(TerminalMessage{
-    Op:   "stdout",
-    Data: string(p),
-  })
-  if err != nil {
-    return 0, err
-  }
-  t.conn.SetWriteDeadline(time.Now().Add(writeWait))
-  if err = t.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
-    return 0, err
-  }
-  return len(p), nil
+	msg, err := json.Marshal(TerminalMessage{
+		Op:   "stdout",
+		Data: string(p),
+	})
+	if err != nil {
+		return 0, err
+	}
+	t.conn.SetWriteDeadline(time.Now().Add(writeWait))
+	if err = t.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+		return 0, err
+	}
+	return len(p), nil
 }
 
 // Toast can be used to send the user any OOB messages
 // hterm puts these in the center of the terminal
 func (t TerminalSession) Toast(p string) error {
-  msg, err := json.Marshal(TerminalMessage{
-    Op:   "toast",
-    Data: p,
-  })
-  if err != nil {
-    return err
-  }
-  t.conn.SetWriteDeadline(time.Now().Add(writeWait))
-  if err = t.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
-    return err
-  }
-  return nil
+	msg, err := json.Marshal(TerminalMessage{
+		Op:   "toast",
+		Data: p,
+	})
+	if err != nil {
+		return err
+	}
+	t.conn.SetWriteDeadline(time.Now().Add(writeWait))
+	if err = t.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Close shuts down the SockJS connection and sends the status code and reason to the client
 // Can happen if the process exits or if there is an error starting up the process
 // For now the status code is unused and reason is shown to the user (unless "")
 func (t TerminalSession) Close(status uint32, reason string) {
-  klog.Warning(status, reason)
-  close(t.sizeChan)
-  t.conn.Close()
+	klog.Warning(status, reason)
+	close(t.sizeChan)
+	t.conn.Close()
 }
 
 type Interface interface {
-  HandleSession(shell, namespace, podName, containerName string, conn *websocket.Conn)
-  HandleShellAccessToNode(nodename string, conn *websocket.Conn)
+	HandleSession(shell, namespace, podName, containerName string, conn *websocket.Conn)
+	HandleShellAccessToNode(nodename string, conn *websocket.Conn)
 }
 
 type terminaler struct {
-  client  kubernetes.Interface
-  config  *rest.Config
-  options *Options
+	client  kubernetes.Interface
+	config  *rest.Config
+	options *Options
 }
 
 type NodeTerminaler struct {
-  Nodename      string
-  Namespace     string
-  PodName       string
-  ContainerName string
-  Shell         string
-  Privileged    bool
-  Config        *Options
-  client        kubernetes.Interface
+	Nodename      string
+	Namespace     string
+	PodName       string
+	ContainerName string
+	Shell         string
+	Privileged    bool
+	Config        *Options
+	client        kubernetes.Interface
 }
 
 func NewTerminaler(client kubernetes.Interface, config *rest.Config, options *Options) Interface {
-  return &terminaler{client: client, config: config, options: options}
+	return &terminaler{client: client, config: config, options: options}
 }
 
 func NewNodeTerminaler(nodename string, options *Options, client kubernetes.Interface) (*NodeTerminaler, error) {
 
-  n := &NodeTerminaler{
-    Namespace:     "kubesphere-controls-system",
-    ContainerName: "nsenter",
-    Nodename:      nodename,
-    PodName:       nodename + "-shell-access",
-    Shell:         "sh",
-    Privileged:    true,
-    Config:        options,
-    client:        client,
-  }
+	n := &NodeTerminaler{
+		Namespace:     "kubesphere-controls-system",
+		ContainerName: "nsenter",
+		Nodename:      nodename,
+		PodName:       nodename + "-shell-access",
+		Shell:         "sh",
+		Privileged:    true,
+		Config:        options,
+		client:        client,
+	}
 
-  node, err := n.client.CoreV1().Nodes().Get(context.Background(), n.Nodename, metav1.GetOptions{})
+	node, err := n.client.CoreV1().Nodes().Get(context.Background(), n.Nodename, metav1.GetOptions{})
 
-  if err != nil {
-    return n, fmt.Errorf("getting node error. nodename:%s, err: %v", n.Nodename, err)
-  }
+	if err != nil {
+		return n, fmt.Errorf("getting node error. nodename:%s, err: %v", n.Nodename, err)
+	}
 
-  flag := false
-  for _, condition := range node.Status.Conditions {
-    if condition.Type == v1.NodeReady && condition.Status == v1.ConditionTrue {
-      flag = true
-      break
-    }
-  }
-  if !flag {
-    return n, fmt.Errorf("node status error. node: %s", n.Nodename)
-  }
+	flag := false
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == v1.NodeReady && condition.Status == v1.ConditionTrue {
+			flag = true
+			break
+		}
+	}
+	if !flag {
+		return n, fmt.Errorf("node status error. node: %s", n.Nodename)
+	}
 
-  return n, nil
+	return n, nil
 }
 
 func (n *NodeTerminaler) getNSEnterPod() (*v1.Pod, error) {
-  pod, err := n.client.CoreV1().Pods(n.Namespace).Get(context.Background(), n.PodName, metav1.GetOptions{})
+	pod, err := n.client.CoreV1().Pods(n.Namespace).Get(context.Background(), n.PodName, metav1.GetOptions{})
 
-  if err != nil || (pod.Status.Phase != v1.PodRunning && pod.Status.Phase != v1.PodPending) {
-    // pod has timed out, but has not been cleaned up
-    if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
-      err := n.client.CoreV1().Pods(n.Namespace).Delete(context.Background(), n.PodName, metav1.DeleteOptions{})
-      if err != nil {
-        return pod, err
-      }
-    }
+	if err != nil || (pod.Status.Phase != v1.PodRunning && pod.Status.Phase != v1.PodPending) {
+		// pod has timed out, but has not been cleaned up
+		if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+			err := n.client.CoreV1().Pods(n.Namespace).Delete(context.Background(), n.PodName, metav1.DeleteOptions{})
+			if err != nil {
+				return pod, err
+			}
+		}
 
-    var p = &v1.Pod{
-      TypeMeta: metav1.TypeMeta{
-        Kind:       "pod",
-        APIVersion: "v1",
-      },
-      ObjectMeta: metav1.ObjectMeta{
-        Name: n.PodName,
-      },
-      Spec: v1.PodSpec{
-        NodeName:      n.Nodename,
-        HostPID:       true,
-        HostNetwork:   true,
-        RestartPolicy: v1.RestartPolicyNever,
-        Containers: []v1.Container{
-          {
-            Name:  n.ContainerName,
-            Image: n.Config.Image,
-            Command: []string{
-              "nsenter", "-m", "-u", "-i", "-n", "-p", "-t", "1",
-            },
-            Stdin: true,
-            TTY:   true,
-            SecurityContext: &v1.SecurityContext{
-              Privileged: &n.Privileged,
-            },
-          },
-        },
-      },
-    }
+		var p = &v1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "pod",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: n.PodName,
+			},
+			Spec: v1.PodSpec{
+				NodeName:      n.Nodename,
+				HostPID:       true,
+				HostNetwork:   true,
+				RestartPolicy: v1.RestartPolicyNever,
+				Containers: []v1.Container{
+					{
+						Name:  n.ContainerName,
+						Image: n.Config.Image,
+						Command: []string{
+							"nsenter", "-m", "-u", "-i", "-n", "-p", "-t", "1",
+						},
+						Stdin: true,
+						TTY:   true,
+						SecurityContext: &v1.SecurityContext{
+							Privileged: &n.Privileged,
+						},
+					},
+				},
+			},
+		}
 
-    if n.Config.Timeout == 0 {
-      p.Spec.Containers[0].Args = []string{"tail", "-f", "/dev/null"}
-    } else {
-      p.Spec.Containers[0].Args = []string{"sleep", strconv.Itoa(n.Config.Timeout)}
-    }
+		if n.Config.Timeout == 0 {
+			p.Spec.Containers[0].Args = []string{"tail", "-f", "/dev/null"}
+		} else {
+			p.Spec.Containers[0].Args = []string{"sleep", strconv.Itoa(n.Config.Timeout)}
+		}
 
-    pod, err = n.client.CoreV1().Pods(n.Namespace).Create(context.Background(), p, metav1.CreateOptions{})
-    if err != nil {
-      return nil, fmt.Errorf("create pod failed on %s node: %v", n.Nodename, err)
-    }
-  }
+		pod, err = n.client.CoreV1().Pods(n.Namespace).Create(context.Background(), p, metav1.CreateOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("create pod failed on %s node: %v", n.Nodename, err)
+		}
+	}
 
-  return pod, nil
+	return pod, nil
 }
 
 func (n NodeTerminaler) CleanUpNSEnterPod() {
-  idx, _ := NodeSessionCounter.Load(n.Nodename)
-  atomic.AddInt64(idx.(*int64), -1)
+	idx, _ := NodeSessionCounter.Load(n.Nodename)
+	atomic.AddInt64(idx.(*int64), -1)
 
-  if *(idx.(*int64)) == 0 {
-    err := n.client.CoreV1().Pods(n.Namespace).Delete(context.Background(), n.PodName, metav1.DeleteOptions{})
-    if err != nil {
-      klog.Warning(err)
-    }
-  }
+	if *(idx.(*int64)) == 0 {
+		err := n.client.CoreV1().Pods(n.Namespace).Delete(context.Background(), n.PodName, metav1.DeleteOptions{})
+		if err != nil {
+			klog.Warning(err)
+		}
+	}
 }
 
 // startProcess is called by handleAttach
 // Executed cmd in the container specified in request and connects it up with the ptyHandler (a session)
 func (t *terminaler) startProcess(namespace, podName, containerName string, cmd []string, ptyHandler PtyHandler) error {
-  req := t.client.CoreV1().RESTClient().Post().
-    Resource("pods").
-    Name(podName).
-    Namespace(namespace).
-    SubResource("exec")
-  req.VersionedParams(&v1.PodExecOptions{
-    Container: containerName,
-    Command:   cmd,
-    Stdin:     true,
-    Stdout:    true,
-    Stderr:    true,
-    TTY:       true,
-  }, scheme.ParameterCodec)
+	req := t.client.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec")
+	req.VersionedParams(&v1.PodExecOptions{
+		Container: containerName,
+		Command:   cmd,
+		Stdin:     true,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       true,
+	}, scheme.ParameterCodec)
 
-  exec, err := remotecommand.NewSPDYExecutor(t.config, "POST", req.URL())
-  if err != nil {
-    return err
-  }
+	exec, err := remotecommand.NewSPDYExecutor(t.config, "POST", req.URL())
+	if err != nil {
+		return err
+	}
 
-  err = exec.Stream(remotecommand.StreamOptions{
-    Stdin:             ptyHandler,
-    Stdout:            ptyHandler,
-    Stderr:            ptyHandler,
-    TerminalSizeQueue: ptyHandler,
-    Tty:               true,
-  })
-  if err != nil {
-    return err
-  }
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:             ptyHandler,
+		Stdout:            ptyHandler,
+		Stderr:            ptyHandler,
+		TerminalSizeQueue: ptyHandler,
+		Tty:               true,
+	})
+	if err != nil {
+		return err
+	}
 
-  return nil
+	return nil
 }
 
 // isValidShell checks if the shell is an allowed one
 func isValidShell(validShells []string, shell string) bool {
-  for _, validShell := range validShells {
-    if validShell == shell {
-      return true
-    }
-  }
-  return false
+	for _, validShell := range validShells {
+		if validShell == shell {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *terminaler) HandleSession(shell, namespace, podName, containerName string, conn *websocket.Conn) {
-  var err error
-  validShells := []string{"bash", "sh"}
+	var err error
+	validShells := []string{"bash", "sh"}
 
-  session := &TerminalSession{conn: conn, sizeChan: make(chan remotecommand.TerminalSize)}
+	session := &TerminalSession{conn: conn, sizeChan: make(chan remotecommand.TerminalSize)}
 
-  if isValidShell(validShells, shell) {
-    cmd := []string{shell}
-    err = t.startProcess(namespace, podName, containerName, cmd, session)
-  } else {
-    // No shell given or it was not valid: try some shells until one succeeds or all fail
-    // FIXME: if the first shell fails then the first keyboard event is lost
-    for _, testShell := range validShells {
-      cmd := []string{testShell}
-      if err = t.startProcess(namespace, podName, containerName, cmd, session); err == nil {
-        break
-      }
-    }
-  }
+	if isValidShell(validShells, shell) {
+		cmd := []string{shell}
+		err = t.startProcess(namespace, podName, containerName, cmd, session)
+	} else {
+		// No shell given or it was not valid: try some shells until one succeeds or all fail
+		// FIXME: if the first shell fails then the first keyboard event is lost
+		for _, testShell := range validShells {
+			cmd := []string{testShell}
+			if err = t.startProcess(namespace, podName, containerName, cmd, session); err == nil {
+				break
+			}
+		}
+	}
 
-  if err != nil {
-    session.Close(2, err.Error())
-    return
-  }
+	if err != nil {
+		session.Close(2, err.Error())
+		return
+	}
 
-  session.Close(1, "Process exited")
+	session.Close(1, "Process exited")
 }
 
 func (t *terminaler) HandleShellAccessToNode(nodename string, conn *websocket.Conn) {
 
-  nodeTerminaler, err := NewNodeTerminaler(nodename, t.options, t.client)
-  if err != nil {
-    klog.Warning("node terminaler init error: ", err)
-    return
-  }
+	nodeTerminaler, err := NewNodeTerminaler(nodename, t.options, t.client)
+	if err != nil {
+		klog.Warning("node terminaler init error: ", err)
+		return
+	}
 
-  pod, err := nodeTerminaler.getNSEnterPod()
-  if err != nil {
-    klog.Warning("get nsenter pod error: ", err)
-    return
-  }
+	pod, err := nodeTerminaler.getNSEnterPod()
+	if err != nil {
+		klog.Warning("get nsenter pod error: ", err)
+		return
+	}
 
-  if err := nodeTerminaler.WatchPodStatusBeRunning(pod); err != nil {
-    klog.Warning("watching pod status error: ", err)
-    return
-  } else {
-    t.HandleSession(nodeTerminaler.Shell, nodeTerminaler.Namespace, nodeTerminaler.PodName, nodeTerminaler.ContainerName, conn)
-    defer nodeTerminaler.CleanUpNSEnterPod()
-  }
+	if err := nodeTerminaler.WatchPodStatusBeRunning(pod); err != nil {
+		klog.Warning("watching pod status error: ", err)
+		return
+	} else {
+		t.HandleSession(nodeTerminaler.Shell, nodeTerminaler.Namespace, nodeTerminaler.PodName, nodeTerminaler.ContainerName, conn)
+		defer nodeTerminaler.CleanUpNSEnterPod()
+	}
 }
 
 func (n *NodeTerminaler) WatchPodStatusBeRunning(pod *v1.Pod) error {
-  if pod.Status.Phase == v1.PodRunning {
-    idx, ok := NodeSessionCounter.Load(n.Nodename)
-    if ok {
-      atomic.AddInt64(idx.(*int64), 1)
-    } else {
-      i := int64(1)
-      NodeSessionCounter.LoadOrStore(n.Nodename, &i)
-    }
+	if pod.Status.Phase == v1.PodRunning {
+		idx, ok := NodeSessionCounter.Load(n.Nodename)
+		if ok {
+			atomic.AddInt64(idx.(*int64), 1)
+		} else {
+			i := int64(1)
+			NodeSessionCounter.LoadOrStore(n.Nodename, &i)
+		}
 
-    return nil
-  }
+		return nil
+	}
 
-  return wait.Poll(time.Millisecond*500, time.Second*5, func() (done bool, err error) {
-    pod, err = n.client.CoreV1().Pods(pod.ObjectMeta.Namespace).Get(context.Background(), pod.ObjectMeta.Name, metav1.GetOptions{})
-    if err != nil {
-      klog.Warning(err)
-      return false, err
-    }
+	return wait.Poll(time.Millisecond*500, time.Second*5, func() (done bool, err error) {
+		pod, err = n.client.CoreV1().Pods(pod.ObjectMeta.Namespace).Get(context.Background(), pod.ObjectMeta.Name, metav1.GetOptions{})
+		if err != nil {
+			klog.Warning(err)
+			return false, err
+		}
 
-    if pod.Status.Phase == v1.PodRunning {
-      idx, ok := NodeSessionCounter.Load(n.Nodename)
-      if ok {
-        atomic.AddInt64(idx.(*int64), 1)
-      } else {
-        i := int64(1)
-        NodeSessionCounter.LoadOrStore(n.Nodename, &i)
-      }
-      return true, nil
-    }
-    return false, nil
-  })
+		if pod.Status.Phase == v1.PodRunning {
+			idx, ok := NodeSessionCounter.Load(n.Nodename)
+			if ok {
+				atomic.AddInt64(idx.(*int64), 1)
+			} else {
+				i := int64(1)
+				NodeSessionCounter.LoadOrStore(n.Nodename, &i)
+			}
+			return true, nil
+		}
+		return false, nil
+	})
 }


### PR DESCRIPTION
### What type of PR is this?
/kind feature


### What this PR does / why we need it:
This PR adds a new kubectl controller to KubeSphere. The controller allows users to easily execute kubectl commands through the KubeSphere UI. 

With this controller, users will be able to:

- Run kubectl commands on their Kubernetes clusters managed by KubeSphere
- View command execution results and logs
- Provide convenience functions like port forwarding
It improves the user experience and saves users the trouble of installing kubectl locally or spinning up a jump server.

### Which issue(s) this PR fixes:

### Special notes for reviewers:
```
The new controller code is located under `pkg/controllers/kubectl/kubectl_controller.go`.
I have added unit tests under `pkg/controllers/kubectl/kubectl_controller_test.go`. Please help review if the test cases cover the major logic.
```

### Does this PR introduced a user-facing change?
```
None
```

### Additional documentation, usage docs, etc.:
```
```
