### PR TITLE
fix: monitoring dashboard import, when rkClient get object ,judege err

### DIFF
--- a/pkg/kapis/monitoring/v1alpha3/handler.go
+++ b/pkg/kapis/monitoring/v1alpha3/handler.go
@@ -447,7 +447,7 @@ func (h handler) handleGrafanaDashboardImport(req *restful.Request, resp *restfu
 
 		err = h.rtClient.Get(ctx, objKey, &dashboard)
 
-		if err == nil {
+		if err != nil {
 			api.HandleBadRequest(resp, nil, errors.New("dashboards with the same name already exists."))
 			return
 		}


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

monitoring dashboard import, when rkClient get object ,judege err

### Which issue(s) this PR fixes:

Fixes #6145

### Special notes for reviewers:

### Does this PR introduced a user-facing change?
None

### Additional documentation, usage docs, etc.:
