### PR TITLE
fix chunked encoding API no response

### DIFF
--- a/pkg/apiserver/auditing/client.go
+++ b/pkg/apiserver/auditing/client.go
@@ -420,7 +420,15 @@ func (c *ResponseCapture) Header() http.Header {
 func (c *ResponseCapture) Write(data []byte) (int, error) {
 	c.WriteHeader(http.StatusOK)
 	c.body.Write(data)
-	return c.ResponseWriter.Write(data)
+
+	n, err := c.ResponseWriter.Write(data)
+	if err != nil {
+		return n, err
+	}
+	if flusher, ok := c.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+	return n, nil
 }
 
 func (c *ResponseCapture) WriteHeader(statusCode int) {

--- a/pkg/apiserver/filters/filters.go
+++ b/pkg/apiserver/filters/filters.go
@@ -22,7 +22,6 @@ import (
 
 type metaResponseWriter struct {
 	http.ResponseWriter
-
 	statusCode int
 	size       int
 }
@@ -39,10 +38,20 @@ func (r *metaResponseWriter) WriteHeader(code int) {
 	r.ResponseWriter.WriteHeader(code)
 }
 
+func (r *metaResponseWriter) Header() http.Header {
+	return r.ResponseWriter.Header()
+}
+
 func (r *metaResponseWriter) Write(b []byte) (int, error) {
 	size, err := r.ResponseWriter.Write(b)
 	r.size += size
-	return size, err
+	if err != nil {
+		return size, err
+	}
+	if flusher, ok := r.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+	return size, nil
 }
 
 func (r *metaResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind regression

### What this PR does / why we need it:

Fix the issue where the chunked encoding API does not respond correctly.

When the chunked encoding response data is smaller than 2 KB, no result is returned.

```
➜  ~ curl -u admin:P@88w0rd 'http://172.31.17.3:30881/api/v1/namespaces/default/pods/xxx/log?follow=true&timestamps=true'  -v
*   Trying 172.31.17.3:30881...
* Connected to 172.31.17.3 (172.31.17.3) port 30881 (#0)
* Server auth using Basic with user 'admin'
> GET /api/v1/namespaces/default/pods/xxx/log?follow=true&timestamps=true HTTP/1.1
> Host: 172.31.17.3:30881
> Authorization: Basic YWRtaW46UEA4OHcwcmQ=
> User-Agent: curl/7.87.0
> Accept: */*
>
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```
