### PR TITLE
fix typo (#1965)

### DIFF
--- a/pkg/controller/application/apprelease_controller.go
+++ b/pkg/controller/application/apprelease_controller.go
@@ -265,12 +265,12 @@ func (r *AppReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			if strings.Contains(release.Info.Description, "context deadline exceeded") && reCheck < timeoutMaxRecheck {
 
 				if apprls.Status.State != appv2.StatusTimeout {
-					err = r.updateStatus(ctx, apprls, appv2.StatusTimeout, "install time out")
+					err = r.updateStatus(ctx, apprls, appv2.StatusTimeout, "Installation timeout")
 					if err != nil {
 						klog.Errorf("failed to update apprelease %s status : %v", apprls.Name, err)
 						return ctrl.Result{}, err
 					}
-					klog.Infof("install time out, will check status again after %d second", timeoutVerificationAgain)
+					klog.Infof("Installation timeout, will check status again after %d second", timeoutVerificationAgain)
 					return ctrl.Result{RequeueAfter: timeoutVerificationAgain * time.Second}, nil
 				}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
