### PR TITLE
Use responsewriter.UserProvidedDecorator instead of auto flush response

### DIFF
--- a/pkg/apiserver/filters/auditing.go
+++ b/pkg/apiserver/filters/auditing.go
@@ -8,6 +8,7 @@ package filters
 import (
 	"net/http"
 
+	"k8s.io/apiserver/pkg/endpoints/responsewriter"
 	"k8s.io/klog/v2"
 
 	"kubesphere.io/kubesphere/pkg/apiserver/auditing"
@@ -44,7 +45,7 @@ func (a *auditingFilter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	if event := a.LogRequestObject(req, info); event != nil {
 		resp := auditing.NewResponseCapture(w)
-		a.next.ServeHTTP(resp, req)
+		a.next.ServeHTTP(responsewriter.WrapForHTTP1Or2(resp), req)
 		go a.LogResponseObject(event, resp)
 	} else {
 		a.next.ServeHTTP(w, req)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

### What this PR does / why we need it:

Related to https://github.com/kubesphere/kubesphere/pull/6157

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```
