### PR TITLE
adjust the log level of unexpected exceptions

### DIFF
--- a/pkg/controller/openapi/openapi_controller.go
+++ b/pkg/controller/openapi/openapi_controller.go
@@ -40,19 +40,19 @@ func (c *Controller) WatchOpenAPIChanges(ctx context.Context, cache runtimecache
 			AddFunc: func(obj interface{}) {
 				apiService := obj.(*extensionsv1alpha1.APIService)
 				if err := openAPIV2Service.AddUpdateApiService(apiService); err != nil {
-					klog.Error(err)
+					klog.V(4).Infof("add openapi v2 service failed: %v", err)
 				}
 				if err := openAPIV3Service.AddUpdateApiService(apiService); err != nil {
-					klog.Error(err)
+					klog.V(4).Infof("add openapi v3 service failed: %v", err)
 				}
 			},
 			UpdateFunc: func(old, new interface{}) {
 				apiService := new.(*extensionsv1alpha1.APIService)
 				if err := openAPIV2Service.AddUpdateApiService(apiService); err != nil {
-					klog.Error(err)
+					klog.V(4).Infof("update openapi v2 service failed: %v", err)
 				}
 				if err := openAPIV3Service.AddUpdateApiService(apiService); err != nil {
-					klog.Error(err)
+					klog.V(4).Infof("update openapi v3 service failed: %v", err)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

### What this PR does / why we need it:

```
E0926 01:38:29.119364       1 openapi_controller.go:52] fetch ApiService v1alpha1.gitops.kubesphere.io openapi-v2 error: resource not found
E0926 01:38:29.120229       1 openapi_controller.go:55] fetch ApiService v1alpha1.gitops.kubesphere.io openapi-v3 error: resource not found
E0926 01:38:29.123557       1 openapi_controller.go:52] fetch ApiService v1alpha2.logging.kubesphere.io openapi-v2 error: resource not found
E0926 01:38:29.124349       1 openapi_controller.go:55] fetch ApiService v1alpha2.logging.kubesphere.io openapi-v3 error: resource not found
E0926 01:38:29.127163       1 openapi_controller.go:52] fetch ApiService v1alpha2.servicemesh.kubesphere.io openapi-v2 error: resource not found
E0926 01:38:29.127984       1 openapi_controller.go:55] fetch ApiService v1alpha2.servicemesh.kubesphere.io openapi-v3 error: resource not found
E0926 01:38:29.128933       1 openapi_controller.go:52] fetch ApiService v1alpha3.devops.kubesphere.io openapi-v2 error: resource not found
E0926 01:38:29.129517       1 openapi_controller.go:55] fetch ApiService v1alpha3.devops.kubesphere.io openapi-v3 error: resource not found
E0926 01:38:29.132250       1 openapi_controller.go:52] fetch ApiService v1beta1.constraints.gatekeeper.sh openapi-v2 error: resource not found
E0926 01:38:29.132969       1 openapi_controller.go:55] fetch ApiService v1beta1.constraints.gatekeeper.sh openapi-v3 error: resource not found
E0926 01:38:29.136172       1 openapi_controller.go:52] fetch ApiService v2alpha1.gateway.kubesphere.io openapi-v2 error: resource not found
E0926 01:38:29.136972       1 openapi_controller.go:55] fetch ApiService v2alpha1.gateway.kubesphere.io openapi-v3 error: resource not found
E0926 01:38:29.139842       1 openapi_controller.go:52] fetch ApiService v1alpha1.tower.kubesphere.io openapi-v2 error: resource not found
E0926 01:38:29.140672       1 openapi_controller.go:55] fetch ApiService v1alpha1.tower.kubesphere.io openapi-v3 error: resource not found
E0926 01:38:29.141523       1 openapi_controller.go:52] fetch ApiService v1alpha2.devops.kubesphere.io openapi-v2 error: resource not found
E0926 01:38:29.142220       1 openapi_controller.go:55] fetch ApiService v1alpha2.devops.kubesphere.io openapi-v3 error: resource not found
E0926 01:38:29.144627       1 openapi_controller.go:52] fetch ApiService v1alpha2.network.kubesphere.io openapi-v2 error: resource not found
E0926 01:38:29.145151       1 openapi_controller.go:55] fetch ApiService v1alpha2.network.kubesphere.io openapi-v3 error: resource not found
E0926 01:38:29.146076       1 openapi_controller.go:52] fetch ApiService v1beta1.monitoring.kubesphere.io openapi-v2 error: resource not found
E0926 01:38:29.146900       1 openapi_controller.go:55] fetch ApiService v1beta1.monitoring.kubesphere.io openapi-v3 error: resource not found
E0926 01:38:29.147450       1 openapi_controller.go:52] fetch ApiService v2beta2.notification.kubesphere.io openapi-v2 error: resource not found
E0926 01:38:29.147920       1 openapi_controller.go:55] fetch ApiService v2beta2.notification.kubesphere.io openapi-v3 error: resource not found
```

These errors do not affect normal operation and can be ignored.


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```
