### PR TITLE
fix: remove the incorrect RBAC rule merging logic

### DIFF
--- a/pkg/componenthelper/auth/rbac/helper.go
+++ b/pkg/componenthelper/auth/rbac/helper.go
@@ -157,8 +157,7 @@ func (h *Helper) AggregationRole(ctx context.Context, ruleOwner RuleOwner, recor
 	if !cover {
 		needUpdate = true
 		newRule := append(ruleOwner.GetRules(), uncovered...)
-		squashedRules := SquashRules(len(newRule), newRule)
-		ruleOwner.SetRules(squashedRules)
+		ruleOwner.SetRules(newRule)
 	}
 
 	if !templateNamesEqual {

--- a/pkg/componenthelper/auth/rbac/policy_comparator.go
+++ b/pkg/componenthelper/auth/rbac/policy_comparator.go
@@ -149,7 +149,8 @@ func ruleCovers(ownerRule, subRule rbacv1.PolicyRule) bool {
 	verbMatches := has(ownerRule.Verbs, rbacv1.VerbAll) || hasAll(ownerRule.Verbs, subRule.Verbs)
 	groupMatches := has(ownerRule.APIGroups, rbacv1.APIGroupAll) || hasAll(ownerRule.APIGroups, subRule.APIGroups)
 	resourceMatches := resourceCoversAll(ownerRule.Resources, subRule.Resources)
-	nonResourceURLMatches := nonResourceURLsCoversAll(ownerRule.NonResourceURLs, subRule.NonResourceURLs)
+	nonResourceURLMatches := (len(ownerRule.NonResourceURLs) == 0 && len(subRule.NonResourceURLs) == 0) || (len(ownerRule.Resources) == 0 &&
+		len(subRule.Resources) == 0 && nonResourceURLsCoversAll(ownerRule.NonResourceURLs, subRule.NonResourceURLs))
 
 	resourceNameMatches := false
 

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -140,7 +140,7 @@ func (r *Reconciler) reconcileWorkspaceOwnerReference(ctx context.Context, names
 		return nil
 	}
 
-	if !metav1.IsControlledBy(namespace, workspace) {
+	if !metav1.IsControlledBy(namespace, workspace) && namespace.Labels[constants.KubeSphereManagedLabel] == "true" {
 		namespace = namespace.DeepCopy()
 		if err := controllerutil.SetControllerReference(workspace, namespace, scheme.Scheme); err != nil {
 			return err

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -42,8 +42,11 @@ var _ = Describe("Namespace", func() {
 		It("Should create successfully", func() {
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "test-namespace",
-					Labels: map[string]string{tenantv1beta1.WorkspaceLabel: workspace.Name},
+					Name: "test-namespace",
+					Labels: map[string]string{
+						tenantv1beta1.WorkspaceLabel:     workspace.Name,
+						constants.KubeSphereManagedLabel: "true",
+					},
 				},
 			}
 

--- a/pkg/controller/role/role_controller.go
+++ b/pkg/controller/role/role_controller.go
@@ -96,9 +96,9 @@ func (r *Reconciler) syncToKubernetes(ctx context.Context, role *iamv1beta1.Role
 	})
 
 	if err != nil {
-		r.logger.Error(err, "sync role failed", "role", role.Name)
+		r.logger.Error(err, "sync role failed", "namespace", role.Namespace, "role", role.Name)
 	}
 
-	r.logger.V(4).Info("sync role to K8s", "role", role.Name, "op", op)
+	r.logger.V(4).Info("sync role to K8s", "namespace", role.Namespace, "role", role.Name, "op", op)
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


/kind bug

### What this PR does / why we need it:


```
E0926 15:10:26.939182       1 role_controller.go:99] "sync role failed" err="Role.rbac.authorization.k8s.io \"kubesphere:iam:operator\" is invalid: rules[5].nonResourceURLs: Invalid value: []string{\"jenkins/labelsdashboard/labelsData\"}: namespaced rules cannot apply to non-resource URLs" logger="controllers.role" role="operator"
E0926 15:10:32.069667       1 role_controller.go:99] "sync role failed" err="Role.rbac.authorization.k8s.io \"kubesphere:iam:operator\" is invalid: [rules[3].nonResourceURLs: Invalid value: []string{\"jenkins/labelsdashboard/labelsData\"}: namespaced rules cannot apply to non-resource URLs, rules[3].nonResourceURLs: Invalid value: []string{\"jenkins/labelsdashboard/labelsData\"}: rules cannot apply to both regular resources and non-resource URLs]" logger="controllers.role" role="operator"
E0926 15:10:32.077260       1 controller.go:329] "Reconciler error" err="Object /testk2z4v is already owned by another DevOpsProject controller testk2z4v" controller="namespace" controllerGroup="" controllerKind="Namespace" Namespace="testk2z4v" namespace="" name="testk2z4v" reconcileID="2c2ee83c-ed06-432c-abcd-caabf6d2a4b1"
E0926 15:10:32.092509       1 role_controller.go:99] "sync role failed" err="Role.rbac.authorization.k8s.io \"kubesphere:iam:operator\" is invalid: [rules[3].nonResourceURLs: Invalid value: []string{\"jenkins/labelsdashboard/labelsData\"}: namespaced rules cannot apply to non-resource URLs, rules[3].nonResourceURLs: Invalid value: []string{\"jenkins/labelsdashboard/labelsData\"}: rules cannot apply to both regular resources and non-resource URLs]" logger="controllers.role" role="operator"
E0926 15:10:32.109524       1 role_controller.go:99] "sync role failed" err="Role.rbac.authorization.k8s.io \"kubesphere:iam:admin\" is invalid: [rules[2].nonResourceURLs: Invalid value: []string{\"jenkins/labelsdashboard/labelsData\"}: namespaced rules cannot apply to non-resource URLs, rules[2].nonResourceURLs: Invalid value: []string{\"jenkins/labelsdashboard/labelsData\"}: rules cannot apply to both regular resources and non-resource URLs]" logger="controllers.role" role="admin"
E0926 15:10:32.115778       1 role_controller.go:99] "sync role failed" err="Role.rbac.authorization.k8s.io \"kubesphere:iam:admin\" is invalid: [rules[2].nonResourceURLs: Invalid value: []string{\"jenkins/labelsdashboard/labelsData\"}: namespaced rules cannot apply to non-resource URLs, rules[2].nonResourceURLs: Invalid value: []string{\"jenkins/labelsdashboard/labelsData\"}: rules cannot apply to both regular resources and non-resource URLs]" logger="controllers.role" role="admin"
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix incorrect RBAC rule merging logic
```

