### PR TITLE
allow anonymous users to watch extension changes

### DIFF
--- a/config/ks-core/templates/globalroles.yaml
+++ b/config/ks-core/templates/globalroles.yaml
@@ -14,6 +14,20 @@ rules:
       - '/static/images/*'
     verbs:
       - GET
+  - apiGroups:
+      - extensions.kubesphere.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - watch
+  - apiGroups:
+      - kubesphere.io
+    resources:
+      - extensions
+    verbs:
+      - get
+      - watch
 
 ---
 apiVersion: iam.kubesphere.io/v1beta1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug


### What this PR does / why we need it:

![image](https://github.com/user-attachments/assets/24200c2d-366f-4d3b-b9af-3a76a2a31ede)

The ks-console will use an anonymous identity to watch for changes in the extension. This is a temporary solution, and API access will require the credentials of a KubeSphere service account.


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```
