### PR TITLE
disable extensions-museum in member cluster

### DIFF
--- a/config/ks-core/templates/extension-museum.yaml
+++ b/config/ks-core/templates/extension-museum.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ksExtensionRepository.enabled }}
+{{- if and (eq (include "role" .) "host") .Values.ksExtensionRepository.enabled  }}
 
 {{- $ca := genCA "self-signed-ca" 3650 }}
 {{- $cn := printf "%s-extensions-museum" .Release.Name }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

### What this PR does / why we need it:

The member cluster does not need to deploy extensions-museum.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

