### PR TITLE
refactor: workspace cascading deletion logic

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -13,15 +13,17 @@ const (
 	KubeSphereConfigMapDataKey = "kubesphere.yaml"
 	KubectlPodNamePrefix       = "ks-managed-kubectl"
 
-	WorkspaceLabelKey        = "kubesphere.io/workspace"
-	DisplayNameAnnotationKey = "kubesphere.io/alias-name"
-	DescriptionAnnotationKey = "kubesphere.io/description"
-	CreatorAnnotationKey     = "kubesphere.io/creator"
-	UsernameLabelKey         = "kubesphere.io/username"
-	GenericConfigTypeLabel   = "config.kubesphere.io/type"
-	KubectlPodLabel          = "kubesphere.io/kubectl-pod"
-	ConfigHashAnnotation     = "kubesphere.io/config-hash"
-	KubeSphereManagedLabel   = "kubesphere.io/managed"
+	WorkspaceLabelKey             = "kubesphere.io/workspace"
+	DisplayNameAnnotationKey      = "kubesphere.io/alias-name"
+	DescriptionAnnotationKey      = "kubesphere.io/description"
+	CreatorAnnotationKey          = "kubesphere.io/creator"
+	UsernameLabelKey              = "kubesphere.io/username"
+	GenericConfigTypeLabel        = "config.kubesphere.io/type"
+	KubectlPodLabel               = "kubesphere.io/kubectl-pod"
+	ConfigHashAnnotation          = "kubesphere.io/config-hash"
+	KubeSphereManagedLabel        = "kubesphere.io/managed"
+	DeletionPropagationAnnotation = "kubesphere.io/deletion-propagation"
+	CascadingDeletionFinalizer    = "kubesphere.io/cascading-deletion"
 )
 
 var (

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -54,41 +54,17 @@ var _ = Describe("Namespace", func() {
 			Expect(k8sClient.Create(context.Background(), namespace)).Should(Succeed())
 
 			By("Expecting to create namespace successfully")
-			Eventually(func() bool {
-				k8sClient.Get(context.Background(), types.NamespacedName{Name: namespace.Name}, namespace)
-				return !namespace.CreationTimestamp.IsZero()
-			}, timeout, interval).Should(BeTrue())
-
-			By("Expecting to set owner reference successfully")
-			Eventually(func() bool {
-				k8sClient.Get(context.Background(), types.NamespacedName{Name: namespace.Name}, namespace)
-				return len(namespace.OwnerReferences) > 0
-			}, timeout, interval).Should(BeTrue())
-
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: workspace.Name}, workspace)).Should(Succeed())
-
-			controlled := true
-			expectedOwnerReference := metav1.OwnerReference{
-				Kind:               workspace.Kind,
-				APIVersion:         workspace.APIVersion,
-				UID:                workspace.UID,
-				Name:               workspace.Name,
-				Controller:         &controlled,
-				BlockOwnerDeletion: &controlled,
-			}
-
-			By("Expecting to bind workspace successfully")
-			Expect(namespace.OwnerReferences).To(ContainElement(expectedOwnerReference))
-			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: workspace.Name}, workspace)).Should(Succeed())
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: namespace.Name}, namespace)).Should(Succeed())
 
 			By("Expecting to update namespace successfully")
 			updated := namespace.DeepCopy()
 			updated.Labels[constants.WorkspaceLabelKey] = "workspace-not-exist"
+
 			Expect(k8sClient.Update(context.Background(), updated)).Should(Succeed())
 
 			By("Expecting to unbind workspace successfully")
 			Eventually(func() bool {
-				k8sClient.Get(context.Background(), types.NamespacedName{Name: namespace.Name}, namespace)
+				_ = k8sClient.Get(context.Background(), types.NamespacedName{Name: namespace.Name}, namespace)
 				return len(namespace.OwnerReferences) == 0
 			}, timeout, interval).Should(BeTrue())
 		})

--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -7,9 +7,15 @@ package workspace
 
 import (
 	"context"
+	"fmt"
+
+	"kubesphere.io/kubesphere/pkg/constants"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	tenantv1beta1 "kubesphere.io/api/tenant/v1beta1"
@@ -24,7 +30,6 @@ import (
 
 const (
 	controllerName = "workspace"
-	finalizer      = "finalizers.tenant.kubesphere.io"
 )
 
 var _ kscontroller.Controller = &Reconciler{}
@@ -53,11 +58,6 @@ func (r *Reconciler) SetupWithManager(mgr *kscontroller.Manager) error {
 }
 
 // +kubebuilder:rbac:groups=tenant.kubesphere.io,resources=workspaces,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=tenant.kubesphere.io,resources=workspaces/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=iam.kubesphere.io,resources=users,verbs=get;list;watch
-// +kubebuilder:rbac:groups=iam.kubesphere.io,resources=rolebases,verbs=get;list;watch
-// +kubebuilder:rbac:groups=iam.kubesphere.io,resources=workspaceroles,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=iam.kubesphere.io,resources=workspacerolebindings,verbs=get;list;watch;create;update;patch;delete
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.logger.WithValues("workspace", req.NamespacedName)
@@ -70,28 +70,71 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if workspace.ObjectMeta.DeletionTimestamp.IsZero() {
 		// The object is not being deleted, so if it does not have our finalizer,
 		// then lets add the finalizer and update the object.
-		if !controllerutil.ContainsFinalizer(workspace, finalizer) {
+		if !controllerutil.ContainsFinalizer(workspace, constants.CascadingDeletionFinalizer) {
 			expected := workspace.DeepCopy()
-			controllerutil.AddFinalizer(expected, finalizer)
+			// Remove legacy finalizer
+			controllerutil.RemoveFinalizer(expected, "finalizers.tenant.kubesphere.io")
+			controllerutil.AddFinalizer(expected, constants.CascadingDeletionFinalizer)
 			if err := r.Patch(ctx, expected, client.MergeFrom(workspace)); err != nil {
-				return ctrl.Result{}, err
+				return ctrl.Result{}, fmt.Errorf("failed to add finalizer: %s", err)
 			}
 			workspaceOperation.WithLabelValues("create", workspace.Name).Inc()
 		}
 	} else {
-		// The object is being deleted
-		if controllerutil.ContainsFinalizer(workspace, finalizer) {
-			// remove our finalizer from the list and update it.
-			controllerutil.RemoveFinalizer(workspace, finalizer)
-			if err := r.Update(ctx, workspace); err != nil {
-				return ctrl.Result{}, err
+		if controllerutil.ContainsFinalizer(workspace, constants.CascadingDeletionFinalizer) {
+			ok, err := r.workspaceCascadingDeletion(ctx, workspace)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to delete workspace: %s", err)
 			}
-			workspaceOperation.WithLabelValues("delete", workspace.Name).Inc()
+			if ok {
+				controllerutil.RemoveFinalizer(workspace, constants.CascadingDeletionFinalizer)
+				if err := r.Update(ctx, workspace); err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %s", err)
+				}
+				workspaceOperation.WithLabelValues("delete", workspace.Name).Inc()
+			}
 		}
 		// Our finalizer has finished, so the reconciler can do nothing.
 		return ctrl.Result{}, nil
 	}
 
-	r.recorder.Event(workspace, corev1.EventTypeNormal, kscontroller.Synced, kscontroller.MessageResourceSynced)
+	r.recorder.Event(workspace, corev1.EventTypeNormal, "Reconcile", "Reconcile workspace successfully")
 	return ctrl.Result{}, nil
+}
+
+// workspaceCascadingDeletion handles the cascading deletion of a workspace based on its deletion propagation policy.
+// It returns a boolean indicating whether the deletion was successful and an error if any occurred.
+func (r *Reconciler) workspaceCascadingDeletion(ctx context.Context, workspace *tenantv1beta1.Workspace) (bool, error) {
+	switch workspace.Annotations[constants.DeletionPropagationAnnotation] {
+	case string(metav1.DeletePropagationOrphan):
+		// If the deletion propagation policy is "Orphan", return true without deleting namespaces.
+		return true, nil
+	case string(metav1.DeletePropagationForeground), string(metav1.DeletePropagationBackground):
+		// If the deletion propagation policy is "Foreground" or "Background", delete the namespaces.
+		if err := r.deleteNamespaces(ctx, workspace); err != nil {
+			return false, fmt.Errorf("failed to delete namespaces in workspace %s: %s", workspace.Name, err)
+		}
+		return true, nil
+	default:
+		// If the deletion propagation policy is invalid, return an error.
+		return false, fmt.Errorf("invalid deletion propagation policy: %s", workspace.Annotations[constants.DeletionPropagationAnnotation])
+	}
+}
+
+// deleteNamespaces deletes all namespaces associated with the given workspace.
+// It uses the "Background" deletion propagation policy.
+func (r *Reconciler) deleteNamespaces(ctx context.Context, workspace *tenantv1beta1.Workspace) error {
+	namespaces := &corev1.NamespaceList{}
+	if err := r.List(ctx, namespaces, client.MatchingLabels{tenantv1beta1.WorkspaceLabel: workspace.Name}); err != nil {
+		return fmt.Errorf("failed to list namespaces in workspace %s: %s", workspace.Name, err)
+	}
+	for _, ns := range namespaces.Items {
+		if err := r.Delete(ctx, &ns); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("failed to delete namespace %s: %s", ns.Name, err)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

### What this PR does / why we need it:

Adjust the cascading deletion mechanism of workspaces so that, by default, deleting a workspace no longer cascades to delete its namespaces. If you need to delete the namespaces under a workspace, add the annotation kubesphere.io/deletion-propagation=Background to the workspace before deletion. This will ensure that namespaces are not mistakenly deleted.

![image](https://github.com/user-attachments/assets/b1be4d8a-6b98-466c-8435-ed16261dad98)

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Refine the cascading deletion mechanism for workspaces.
```

