### PR TITLE
feat(auth): support multiple identity provider associations

### DIFF
--- a/pkg/controller/user/user_controller.go
+++ b/pkg/controller/user/user_controller.go
@@ -268,34 +268,6 @@ func (r *Reconciler) reconcileUserStatus(ctx context.Context, user *iamv1beta1.U
 		return nil
 	}
 
-	if user.Spec.EncryptedPassword == "" {
-		if user.Labels[iamv1beta1.IdentifyProviderLabel] != "" {
-			// mapped user from another identity provider always active until disabled
-			if user.Status.State != iamv1beta1.UserActive {
-				user.Status = iamv1beta1.UserStatus{
-					State:              iamv1beta1.UserActive,
-					LastTransitionTime: &metav1.Time{Time: time.Now()},
-				}
-				if err := r.Update(ctx, user, &client.UpdateOptions{}); err != nil {
-					return err
-				}
-			}
-		} else {
-			// empty password is not allowed for normal user
-			if user.Status.State != iamv1beta1.UserDisabled {
-				user.Status = iamv1beta1.UserStatus{
-					State:              iamv1beta1.UserDisabled,
-					LastTransitionTime: &metav1.Time{Time: time.Now()},
-				}
-				if err := r.Update(ctx, user, &client.UpdateOptions{}); err != nil {
-					return err
-				}
-			}
-		}
-		// skip auth limit check
-		return nil
-	}
-
 	// becomes active after password encrypted
 	if user.Status.State == "" && isEncrypted(user.Spec.EncryptedPassword) {
 		user.Status = iamv1beta1.UserStatus{

--- a/pkg/kapis/iam/v1beta1/handler.go
+++ b/pkg/kapis/iam/v1beta1/handler.go
@@ -144,11 +144,10 @@ func (h *handler) CreateUser(req *restful.Request, resp *restful.Response) {
 			api.HandleBadRequest(resp, req, err)
 			return
 		}
-		if user.Labels == nil {
+		if user.Annotations == nil {
 			user.Labels = make(map[string]string)
 		}
-		user.Labels[iamv1beta1.IdentifyProviderLabel] = extra[iamv1beta1.ExtraIdentityProvider][0]
-		user.Labels[iamv1beta1.OriginUIDLabel] = extra[iamv1beta1.ExtraUID][0]
+		user.Annotations[fmt.Sprintf("%s.%s", iamv1beta1.IdentityProviderAnnotation, extra[iamv1beta1.ExtraIdentityProvider][0])] = extra[iamv1beta1.ExtraUID][0]
 		delete(user.Annotations, iamv1beta1.GlobalRoleAnnotation)
 	}
 

--- a/pkg/kapis/oauth/handler.go
+++ b/pkg/kapis/oauth/handler.go
@@ -17,7 +17,6 @@ import (
 	"github.com/go-jose/go-jose/v4"
 	"github.com/golang-jwt/jwt/v4"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/klog/v2"
 	iamv1beta1 "kubesphere.io/api/iam/v1beta1"
@@ -530,7 +529,7 @@ func (h *handler) refreshTokenGrant(req *restful.Request, response *restful.Resp
 		idp := authenticated.GetExtra()[iamv1beta1.ExtraIdentityProvider][0]
 		uid := authenticated.GetExtra()[iamv1beta1.ExtraUID][0]
 		queryParam := query.New()
-		queryParam.LabelSelector = labels.SelectorFromSet(labels.Set{iamv1beta1.IdentifyProviderLabel: idp, iamv1beta1.OriginUIDLabel: uid}).String()
+		queryParam.Filters = map[query.Field]query.Value{query.FieldAnnotation: query.Value(fmt.Sprintf("%s.%s=%s", iamv1beta1.IdentityProviderAnnotation, idp, uid))}
 		users, err := h.im.ListUsers(queryParam)
 		if err != nil {
 			klog.Errorf("failed to list users: %s", err)

--- a/pkg/models/auth/authenticator.go
+++ b/pkg/models/auth/authenticator.go
@@ -13,7 +13,10 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	authuser "k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/klog/v2"
 	iamv1beta1 "kubesphere.io/api/iam/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"kubesphere.io/kubesphere/pkg/apiserver/authentication/identityprovider"
 )
@@ -54,17 +57,56 @@ func newRreRegistrationUser(idp string, identity identityprovider.Identity) auth
 	}
 }
 
-func newMappedUser(idp string, identity identityprovider.Identity) *iamv1beta1.User {
-	// username convert
-	username := strings.ToLower(identity.GetUsername())
-	return &iamv1beta1.User{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: username,
-			Labels: map[string]string{
-				iamv1beta1.IdentifyProviderLabel: idp,
-				iamv1beta1.OriginUIDLabel:        identity.GetUserID(),
-			},
-		},
-		Spec: iamv1beta1.UserSpec{Email: identity.GetEmail()},
+func authByIdentityProvider(ctx context.Context, client client.Client, mapper UserMapper, providerConfig *identityprovider.Configuration, identity identityprovider.Identity) (authuser.Info, error) {
+	mappedUser, err := mapper.FindMappedUser(ctx, providerConfig.Name, identity.GetUserID())
+	if err != nil {
+		return nil, fmt.Errorf("failed to find mapped user: %s", err)
 	}
+
+	if mappedUser.Name == "" {
+		if providerConfig.MappingMethod == identityprovider.MappingMethodLookup {
+			return nil, fmt.Errorf("failed to find mapped user: %s", identity.GetUserID())
+		}
+
+		if providerConfig.MappingMethod == identityprovider.MappingMethodManual {
+			return newRreRegistrationUser(providerConfig.Name, identity), nil
+		}
+
+		if providerConfig.MappingMethod == identityprovider.MappingMethodAuto {
+			mappedUser := iamv1beta1.User{ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(identity.GetUsername())}}
+
+			op, err := ctrl.CreateOrUpdate(ctx, client, &mappedUser, func() error {
+
+				if mappedUser.Status.State == iamv1beta1.UserDisabled {
+					return AccountIsNotActiveError
+				}
+
+				if mappedUser.Annotations == nil {
+					mappedUser.Annotations = make(map[string]string)
+				}
+				mappedUser.Annotations[fmt.Sprintf("%s.%s", iamv1beta1.IdentityProviderAnnotation, providerConfig.Name)] = identity.GetUserID()
+				mappedUser.Status.State = iamv1beta1.UserActive
+				if identity.GetEmail() != "" {
+					mappedUser.Spec.Email = identity.GetEmail()
+				}
+				return nil
+			})
+
+			if err != nil {
+				return nil, fmt.Errorf("failed to create or update user %s, error: %v", mappedUser.Name, err)
+			}
+
+			klog.V(4).Infof("user %s has been updated successfully, operation: %s", mappedUser.Name, op)
+
+			return &authuser.DefaultInfo{Name: mappedUser.GetName()}, nil
+		}
+
+		return nil, fmt.Errorf("invalid mapping method found %s", providerConfig.MappingMethod)
+	}
+
+	if mappedUser.Status.State == iamv1beta1.UserDisabled {
+		return nil, AccountIsNotActiveError
+	}
+
+	return &authuser.DefaultInfo{Name: mappedUser.GetName()}, nil
 }

--- a/pkg/models/auth/login_recoder.go
+++ b/pkg/models/auth/login_recoder.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	iamv1beta1 "kubesphere.io/api/iam/v1beta1"
@@ -37,12 +36,10 @@ func (l *loginRecorder) RecordLogin(ctx context.Context, username string, loginT
 	// only for existing accounts, solve the problem of huge entries
 	user, err := l.userMapper.Find(ctx, username)
 	if err != nil {
-		// ignore not found error
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		klog.Error(err)
-		return err
+		return fmt.Errorf("failed to find user %s", username)
+	}
+	if user.Name == "" {
+		return nil
 	}
 	record := &iamv1beta1.LoginRecord{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/models/auth/oauth_test.go
+++ b/pkg/models/auth/oauth_test.go
@@ -51,10 +51,7 @@ func Test_oauthAuthenticator_Authenticate(t *testing.T) {
 		},
 	}
 
-	marshal, err := yaml.Marshal(fakeIDP)
-	if err != nil {
-		return
-	}
+	marshal, _ := yaml.Marshal(fakeIDP)
 
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -71,8 +68,8 @@ func Test_oauthAuthenticator_Authenticate(t *testing.T) {
 	}
 
 	fakeCache := informertest.FakeInformers{Scheme: scheme.Scheme}
-	err = fakeCache.Start(context.Background())
-	if err != nil {
+
+	if err := fakeCache.Start(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	fakeSecretInformer, err := fakeCache.FakeInformerFor(context.Background(), &v1.Secret{})
@@ -177,9 +174,8 @@ func newUser(username string, uid string, idp string) *iamv1beta1.User {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: username,
-			Labels: map[string]string{
-				iamv1beta1.IdentifyProviderLabel: idp,
-				iamv1beta1.OriginUIDLabel:        uid,
+			Annotations: map[string]string{
+				fmt.Sprintf("%s.%s", iamv1beta1.IdentityProviderAnnotation, idp): uid,
 			},
 		},
 	}

--- a/pkg/models/auth/password_test.go
+++ b/pkg/models/auth/password_test.go
@@ -10,30 +10,24 @@ import (
 	"reflect"
 	"testing"
 
-	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
-
-	"kubesphere.io/kubesphere/pkg/constants"
-
-	"gopkg.in/yaml.v3"
-
-	runtimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	"kubesphere.io/kubesphere/pkg/scheme"
-
-	"kubesphere.io/kubesphere/pkg/server/options"
-
 	"github.com/mitchellh/mapstructure"
 	"golang.org/x/crypto/bcrypt"
+	"gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	authuser "k8s.io/apiserver/pkg/authentication/user"
 	iamv1beta1 "kubesphere.io/api/iam/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
+	runtimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"kubesphere.io/kubesphere/pkg/apiserver/authentication"
 	"kubesphere.io/kubesphere/pkg/apiserver/authentication/identityprovider"
 	"kubesphere.io/kubesphere/pkg/apiserver/authentication/oauth"
+	"kubesphere.io/kubesphere/pkg/constants"
+	"kubesphere.io/kubesphere/pkg/scheme"
+	"kubesphere.io/kubesphere/pkg/server/options"
 )
 
 func TestEncryptPassword(t *testing.T) {
@@ -112,10 +106,7 @@ func Test_passwordAuthenticator_Authenticate(t *testing.T) {
 		},
 	}
 
-	marshal1, err := yaml.Marshal(fakepwd1)
-	if err != nil {
-		return
-	}
+	marshal1, _ := yaml.Marshal(fakepwd1)
 
 	fakepwd1Secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -131,10 +122,8 @@ func Test_passwordAuthenticator_Authenticate(t *testing.T) {
 		Type: identityprovider.SecretTypeIdentityProvider,
 	}
 
-	marshal2, err := yaml.Marshal(fakepwd2)
-	if err != nil {
-		return
-	}
+	marshal2, _ := yaml.Marshal(fakepwd2)
+
 	fakepwd2Secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-fake-idp2",
@@ -149,10 +138,8 @@ func Test_passwordAuthenticator_Authenticate(t *testing.T) {
 		Type: identityprovider.SecretTypeIdentityProvider,
 	}
 
-	marshal3, err := yaml.Marshal(fakepwd3)
-	if err != nil {
-		return
-	}
+	marshal3, _ := yaml.Marshal(fakepwd3)
+
 	fakepwd3Secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-fake-idp3",
@@ -180,8 +167,8 @@ func Test_passwordAuthenticator_Authenticate(t *testing.T) {
 		Build()
 
 	fakeCache := informertest.FakeInformers{Scheme: scheme.Scheme}
-	err = fakeCache.Start(context.Background())
-	if err != nil {
+
+	if err := fakeCache.Start(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	fakeSecretInformer, err := fakeCache.FakeInformerFor(context.Background(), &v1.Secret{})

--- a/staging/src/kubesphere.io/api/iam/v1beta1/constants.go
+++ b/staging/src/kubesphere.io/api/iam/v1beta1/constants.go
@@ -54,8 +54,7 @@ const (
 	ScopeLabel                            = "iam.kubesphere.io/scope"
 	UserReferenceLabel                    = "iam.kubesphere.io/user-ref"
 	RoleReferenceLabel                    = "iam.kubesphere.io/role-ref"
-	IdentifyProviderLabel                 = "iam.kubesphere.io/identify-provider"
-	OriginUIDLabel                        = "iam.kubesphere.io/origin-uid"
+	IdentityProviderAnnotation            = "iam.kubesphere.io/identity-provider"
 	ServiceAccountReferenceLabel          = "iam.kubesphere.io/serviceaccount-ref"
 	FieldEmail                            = "email"
 	ExtraEmail                            = FieldEmail
@@ -71,7 +70,6 @@ const (
 	NamespaceAdmin                        = "admin"
 	ClusterAdmin                          = "cluster-admin"
 	PreRegistrationUser                   = "system:pre-registration"
-	OTPAuthRequiredUser                   = "system:otp-auth-required"
 	ResourcePluralGroup                   = "groups"
 	GroupReferenceLabel                   = "iam.kubesphere.io/group-ref"
 	GroupParent                           = "iam.kubesphere.io/group-parent"


### PR DESCRIPTION
### What type of PR is this?

/kind feature

### What this PR does / why we need it:

In versions 4.1.2 and earlier, a User could associate with a single Identity Provider (IdP) using the IdP Binding Labels `iam.kubesphere.io/identify-provider: <IdPName>` and `iam.kubesphere.io/origin-uid: <uid>`.

With this feature, it is now possible to associate a User with multiple IdPs by using the Annotation `iam.kubesphere.io/identity-provider.<IdPName>:<uid>`.

### Which issue(s) this PR fixes:

Fixes https://github.com/kubesphere/kubesphere/issues/6298 https://github.com/kubesphere/kubesphere/issues/5547

### Does this PR introduced a user-facing change?

```release-note
Allow users to associate with multiple identity providers.
```

### Additional documentation, usage docs, etc.:

```bash
kubectl annotate iam.kubesphere.io/identity-provider.<IdPName>=<uid>
```
