### PR TITLE
fix: incorrect redis config (#2130)

### DIFF
--- a/config/ks-core/templates/redis.yaml
+++ b/config/ks-core/templates/redis.yaml
@@ -3,14 +3,18 @@
 {{- if lookup "v1" "Secret" "kubesphere-system" "redis-secret" }}
 {{- lookup "v1" "Secret" "kubesphere-system" "redis-secret" | toYaml }}
 {{- else }}
+{{-  $auth := randAlphaNum 15 }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: redis-secret
-  namespace: kubesphere-system
 type: Opaque
-data:
-  auth: {{  randAlphaNum 15 | b64enc }}
+stringData:
+  auth: {{ $auth | quote }}
+  redis.conf: |
+    requirepass {{ $auth }}
+    masterauth {{ $auth }}
+    port {{ .Values.redis.port | default 6379 }}
 {{- end }}
 {{- end }}
 
@@ -21,27 +25,21 @@ kind: Deployment
 metadata:
   labels:
     app: redis
-    tier: database
-    version: redis-4.0
   name: redis
-  namespace: kubesphere-system
 spec:
   replicas: {{ .Values.redis.replicaCount }}
   selector:
     matchLabels:
       app: redis
-      tier: database
   template:
     metadata:
       labels:
         app: redis
-        tier: database
-        version: redis-4.0
     spec:
       containers:
         - image: {{ template "redis.image" . }}
           imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
-          command: ['sh', '-c', 'cat /tmp/redis/redis.conf | sed "s/REDIS_PASSWORD/$KUBESPHERE_CACHE_OPTIONS_PASSWORD/" > /data/redis.conf | redis-server /data/redis.conf']
+          command: ['sh', '-c', 'redis-server /etc/redis/redis.conf']
           name: redis
           args: ["/data/redis.conf"]
           env:
@@ -52,7 +50,8 @@ spec:
                   key: auth
           volumeMounts:
             - name: redis-config
-              mountPath: "/tmp/redis"
+              mountPath: "/etc/redis/redis.conf"
+              subPath: redis.conf
               readOnly: true
 {{- if .Values.redis.persistentVolume.enabled }}
             - mountPath: /data
@@ -71,8 +70,8 @@ spec:
               memory: 100Mi
       volumes:
         - name: redis-config
-          configMap:
-            name: redis-configmap
+          secret:
+            secretName: redis-secret
 {{- if .Values.redis.persistentVolume.enabled }}
         - name: redis-pvc
           persistentVolumeClaim:
@@ -95,20 +94,6 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- toYaml .Values.tolerations | nindent 8 }}{{- end }}
 
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redis-configmap
-  labels:
-    app: redis
-    tier: database
-    version: redis-4.0
-data:
-  redis.conf: |
-    requirepass REDIS_PASSWORD
-    masterauth REDIS_PASSWORD
-    port {{ .Values.redis.port | default 6379 }}
 
 ---
 apiVersion: v1
@@ -116,9 +101,7 @@ kind: Service
 metadata:
   labels:
     app: redis
-    tier: database
   name: redis
-  namespace: kubesphere-system
 spec:
   ports:
     - name: redis
@@ -127,7 +110,6 @@ spec:
       targetPort: {{ .Values.redis.port | default 6379 }}
   selector:
     app: redis
-    tier: database
   sessionAffinity: None
   type: ClusterIP
 
@@ -137,7 +119,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: redis-pvc
-  namespace: kubesphere-system
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
### What this PR does / why we need it:

```
cat /tmp/redis/redis.conf | sed "s/REDIS_PASSWORD/$KUBESPHERE_CACHE_OPTIONS_PASSWORD/" > /data/redis.conf | redis-server /data/redis.conf
```

The password configuration may not take effect when starting for the first time.


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

