### PR TITLE
fix: support LDAPS && STARTTLS

### DIFF
--- a/pkg/apiserver/authentication/identityprovider/ldap/ldap.go
+++ b/pkg/apiserver/authentication/identityprovider/ldap/ldap.go
@@ -10,6 +10,8 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"time"
 
@@ -163,16 +165,23 @@ func (l ldapProvider) Authenticate(username string, password string) (identitypr
 }
 
 func (l *ldapProvider) newConn() (*ldap.Conn, error) {
-	if !l.StartTLS {
-		return ldap.Dial("tcp", l.Host)
+	lurl, err := url.Parse(l.Host)
+	if err != nil {
+		return nil, ldap.NewError(ldap.ErrorNetwork, err)
 	}
+
+	host, port, err := net.SplitHostPort(lurl.Host)
+	if err != nil {
+		host = lurl.Host
+		port = ""
+	}
+
 	tlsConfig := tls.Config{}
 	if l.InsecureSkipVerify {
 		tlsConfig.InsecureSkipVerify = true
 	}
 	tlsConfig.RootCAs = x509.NewCertPool()
 	var caCert []byte
-	var err error
 	// Load CA cert
 	if l.RootCA != "" {
 		if caCert, err = os.ReadFile(l.RootCA); err != nil {
@@ -189,5 +198,36 @@ func (l *ldapProvider) newConn() (*ldap.Conn, error) {
 	if caCert != nil {
 		tlsConfig.RootCAs.AppendCertsFromPEM(caCert)
 	}
-	return ldap.DialTLS("tcp", l.Host, &tlsConfig)
+
+	var conn *ldap.Conn
+	switch lurl.Scheme {
+	case "ldap":
+		if port == "" {
+			port = ldap.DefaultLdapPort
+		}
+		conn, err = ldap.Dial("tcp", net.JoinHostPort(host, port))
+		if err != nil {
+			klog.Error(err)
+			return nil, err
+		}
+	case "ldaps":
+		if port == "" {
+			port = ldap.DefaultLdapsPort
+		}
+		conn, err = ldap.DialTLS("tcp", net.JoinHostPort(host, port), &tlsConfig)
+		if err != nil {
+			klog.Error(err)
+			return nil, err
+		}
+	default:
+		return nil, ldap.NewError(ldap.ErrorNetwork, fmt.Errorf("unknown scheme '%s'", lurl.Scheme))
+	}
+
+	if l.StartTLS {
+		if err = conn.StartTLS(&tlsConfig); err != nil {
+			klog.Error(err)
+			return nil, err
+		}
+	}
+	return conn, err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

### What this PR does / why we need it:

Fixed the issue with old version LDAPS and STARTTLS configuration confusion.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
# LDAPS vs STARTTLS

## 1. Basic Concepts

### LDAPS (LDAP over SSL)
- Uses a dedicated SSL/TLS port (default 636)
- Encrypted channel from the start of connection
- Works similar to HTTPS
- Also known as "tunneled" SSL

### STARTTLS
- Uses standard LDAP port (default 389)
- Upgrades a plain connection to encrypted via command
- Supports both encrypted and unencrypted connections on the same port
- More flexible encryption upgrade mechanism

## 2. Key Differences

### 2.1 Connection Method
LDAPS:
Client =(SSL/TLS)=> Port 636 -> LDAP Server

STARTTLS:
Client => Port 389 -> STARTTLS Command -> SSL/TLS Upgrade -> LDAP Server

### 2.2 Port Usage
- LDAPS: Dedicated encrypted port 636
- STARTTLS: Standard LDAP port 389

### 2.3 Flexibility
- LDAPS: Encrypted connections only
- STARTTLS: Can upgrade to encrypted connection as needed

### 2.4 Compatibility
- LDAPS: Older standard, widely supported
- STARTTLS: More modern approach, requires server support

```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fixed the issue with old version LDAPS and STARTTLS configuration confusion.
```
