### PR TITLE
Optimize log output

### DIFF
--- a/pkg/controller/core/installplan_controller.go
+++ b/pkg/controller/core/installplan_controller.go
@@ -63,30 +63,24 @@ import (
 )
 
 const (
-	installPlanController           = "installplan"
-	installPlanProtection           = "kubesphere.io/installplan-protection"
-	systemWorkspace                 = "system-workspace"
-	agentReleaseFormat              = "%s-agent"
-	defaultRoleFormat               = "kubesphere:%s:helm-executor"
-	defaultRoleBindingFormat        = defaultRoleFormat
-	defaultClusterRoleFormat        = "kubesphere:%s:helm-executor"
-	permissionDefinitionFile        = "permissions.yaml"
-	defaultClusterRoleBindingFormat = defaultClusterRoleFormat
-	tagAgent                        = "agent"
-	tagExtension                    = "extension"
-
-	upgradeSuccessful       = "UpgradeSuccessful"
-	upgradeFailed           = "UpgradeFailed"
-	installSuccessful       = "InstallSuccessful"
-	installFailed           = "InstallFailed"
-	initialized             = "Initialized"
-	uninstallSuccessful     = "UninstallSuccessful"
-	uninstallFailed         = "UninstallFailed"
-	relatedResourceNotReady = "RelatedResourceNotReady"
-	relatedResourceReady    = "RelatedResourceReady"
-
-	typeHelmRelease = "helm.sh/release.v1"
-
+	installPlanController              = "installplan"
+	installPlanProtection              = "kubesphere.io/installplan-protection"
+	systemWorkspace                    = "system-workspace"
+	agentReleaseFormat                 = "%s-agent"
+	defaultRoleFormat                  = "kubesphere:%s:helm-executor"
+	defaultRoleBindingFormat           = defaultRoleFormat
+	defaultClusterRoleFormat           = "kubesphere:%s:helm-executor"
+	permissionDefinitionFile           = "permissions.yaml"
+	defaultClusterRoleBindingFormat    = defaultClusterRoleFormat
+	tagAgent                           = "agent"
+	tagExtension                       = "extension"
+	upgradeSuccessful                  = "UpgradeSuccessful"
+	upgradeFailed                      = "UpgradeFailed"
+	installSuccessful                  = "InstallSuccessful"
+	installFailed                      = "InstallFailed"
+	initialized                        = "Initialized"
+	uninstallFailed                    = "UninstallFailed"
+	typeHelmRelease                    = "helm.sh/release.v1"
 	globalExtensionIngressClassName    = "global.extension.ingress.ingressClassName"
 	globalExtensionIngressDomainSuffix = "global.extension.ingress.domainSuffix"
 	globalExtensionIngressHTTPPort     = "global.extension.ingress.httpPort"
@@ -274,7 +268,7 @@ func (r *InstallPlanReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if !controllerutil.ContainsFinalizer(plan, installPlanProtection) {
 		expected := plan.DeepCopy()
 		controllerutil.AddFinalizer(expected, installPlanProtection)
-		return ctrl.Result{Requeue: true}, r.Patch(ctx, expected, client.MergeFrom(plan))
+		return ctrl.Result{}, r.Patch(ctx, expected, client.MergeFrom(plan))
 	}
 
 	targetNamespace := extensionVersion.Spec.Namespace
@@ -284,7 +278,7 @@ func (r *InstallPlanReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if plan.Status.TargetNamespace != targetNamespace {
 		plan.Status.TargetNamespace = targetNamespace
-		return ctrl.Result{Requeue: true}, r.updateInstallPlan(ctx, plan)
+		return ctrl.Result{}, r.updateInstallPlan(ctx, plan)
 	}
 
 	if err := r.syncInstallPlanStatus(ctx, plan); err != nil {

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,7 +77,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if controllerutil.ContainsFinalizer(namespace, constants.CascadingDeletionFinalizer) {
 			controllerutil.RemoveFinalizer(namespace, constants.CascadingDeletionFinalizer)
 			if err := r.Update(ctx, namespace); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %v", err)
+				return ctrl.Result{}, errors.Wrapf(err, "failed to remove finalizer")
 			}
 		}
 		// Our finalizer has finished, so the reconciler can do nothing.
@@ -89,7 +90,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// then lets add the finalizer and update the object.
 	if workspaceLabelExists && !controllerutil.ContainsFinalizer(namespace, constants.CascadingDeletionFinalizer) {
 		if err := r.initCreatorRoleBinding(ctx, namespace); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to init creator role binding: %v", err)
+			return ctrl.Result{}, errors.Wrapf(err, "failed to init creator role binding")
 		}
 		updated := namespace.DeepCopy()
 		// Remove legacy finalizer
@@ -97,11 +98,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// Remove legacy ownerReferences
 		updated.OwnerReferences = make([]metav1.OwnerReference, 0)
 		controllerutil.AddFinalizer(updated, constants.CascadingDeletionFinalizer)
-		return ctrl.Result{}, r.Patch(ctx, updated, client.MergeFrom(namespace))
+		if err := r.Patch(ctx, updated, client.MergeFrom(namespace)); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "failed to add finalizer")
+		}
+		return ctrl.Result{}, nil
 	}
 
-	if err := r.initRoles(ctx, namespace); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to init builtin roles: %v", err)
+	if workspaceLabelExists {
+		if err := r.initRoles(ctx, namespace); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "failed to init roles in namespace %s", namespace.Name)
+		}
+	} else {
+		if err := r.cleanUp(ctx, namespace); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "failed to clean up namespace %s", namespace.Name)
+		}
 	}
 
 	r.recorder.Event(namespace, corev1.EventTypeNormal, kscontroller.Synced, kscontroller.MessageResourceSynced)
@@ -112,7 +122,7 @@ func (r *Reconciler) initRoles(ctx context.Context, namespace *corev1.Namespace)
 	logger := klog.FromContext(ctx)
 	var templates iamv1beta1.BuiltinRoleList
 	if err := r.List(ctx, &templates, client.MatchingLabels{iamv1beta1.ScopeLabel: iamv1beta1.ScopeNamespace}); err != nil {
-		return fmt.Errorf("failed to list builtin roles: %v", err)
+		return errors.Wrapf(err, "failed to list builtin role templates")
 	}
 	for _, template := range templates.Items {
 		selector, err := metav1.LabelSelectorAsSelector(&template.TargetSelector)
@@ -135,7 +145,7 @@ func (r *Reconciler) initRoles(ctx context.Context, namespace *corev1.Namespace)
 				return nil
 			})
 			if err != nil {
-				return fmt.Errorf("failed to create or update builtin role: %v", err)
+				return errors.Wrapf(err, "failed to create or update builtin role")
 			}
 			logger.V(4).Info("builtin role initialized", "operation", op)
 		} else if err != nil {
@@ -176,8 +186,20 @@ func (r *Reconciler) initCreatorRoleBinding(ctx context.Context, namespace *core
 		return nil
 	})
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to create or update creator role binding")
 	}
 	klog.FromContext(ctx).V(4).Info("creator role binding initialized", "operation", op)
+	return nil
+}
+
+func (r *Reconciler) cleanUp(ctx context.Context, namespace *corev1.Namespace) error {
+	role := &iamv1beta1.Role{}
+	if err := r.DeleteAllOf(ctx, role, client.InNamespace(namespace.Name)); err != nil {
+		return errors.Wrapf(err, "failed to delete roles")
+	}
+	roleBinding := &iamv1beta1.RoleBinding{}
+	if err := r.DeleteAllOf(ctx, roleBinding, client.InNamespace(namespace.Name)); err != nil {
+		return errors.Wrapf(err, "failed to delete role bindings")
+	}
 	return nil
 }

--- a/pkg/controller/role/role_controller.go
+++ b/pkg/controller/role/role_controller.go
@@ -9,23 +9,18 @@ import (
 	"context"
 	"fmt"
 
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	rbacutils "kubesphere.io/kubesphere/pkg/utils/rbac"
-
-	rbacv1 "k8s.io/api/rbac/v1"
-
-	kscontroller "kubesphere.io/kubesphere/pkg/controller"
-
 	"github.com/go-logr/logr"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	iamv1beta1 "kubesphere.io/api/iam/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	rbachelper "kubesphere.io/kubesphere/pkg/componenthelper/auth/rbac"
+	kscontroller "kubesphere.io/kubesphere/pkg/controller"
+	rbacutils "kubesphere.io/kubesphere/pkg/utils/rbac"
 )
 
 const (
@@ -97,6 +92,7 @@ func (r *Reconciler) syncToKubernetes(ctx context.Context, role *iamv1beta1.Role
 
 	if err != nil {
 		r.logger.Error(err, "sync role failed", "namespace", role.Namespace, "role", role.Name)
+		return err
 	}
 
 	r.logger.V(4).Info("sync role to K8s", "namespace", role.Namespace, "role", role.Name, "op", op)

--- a/pkg/controller/workspace/workspace_controller_suite_test.go
+++ b/pkg/controller/workspace/workspace_controller_suite_test.go
@@ -11,19 +11,18 @@ import (
 	"testing"
 	"time"
 
-	"kubesphere.io/kubesphere/pkg/controller/controllertest"
-
-	kscontroller "kubesphere.io/kubesphere/pkg/controller"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	kscontroller "kubesphere.io/kubesphere/pkg/controller"
+	"kubesphere.io/kubesphere/pkg/controller/controllertest"
 	"kubesphere.io/kubesphere/pkg/scheme"
 )
 
@@ -45,10 +44,9 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(klog.NewKlogr())
 
 	By("bootstrapping test environment")
-	t := true
 	if os.Getenv("TEST_USE_EXISTING_CLUSTER") == "true" {
 		testEnv = &envtest.Environment{
-			UseExistingCluster: &t,
+			UseExistingCluster: ptr.To(true),
 		}
 	} else {
 		crdDirPaths, err := controllertest.LoadCrdPath()

--- a/pkg/controller/workspace/workspace_controller_test.go
+++ b/pkg/controller/workspace/workspace_controller_test.go
@@ -9,17 +9,18 @@ import (
 	"context"
 	"time"
 
-	"kubesphere.io/kubesphere/pkg/constants"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	tenantv1beta1 "kubesphere.io/api/tenant/v1beta1"
+
+	"kubesphere.io/kubesphere/pkg/constants"
 )
 
 var _ = Describe("Workspace", func() {
-
 	const timeout = time.Second * 30
 	const interval = time.Second * 1
 
@@ -28,16 +29,24 @@ var _ = Describe("Workspace", func() {
 	// Avoid adding tests for vanilla CRUD operations because they would
 	// test Kubernetes API server, which isn't the goal here.
 	Context("Workspace Controller", func() {
-		It("Should create successfully", func() {
-
+		It("DeletePropagationBackground", func() {
 			workspace := &tenantv1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "workspace-test",
+					Name: "workspace-test1",
+				},
+			}
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "namespace-test1",
+					Labels: map[string]string{
+						tenantv1beta1.WorkspaceLabel: workspace.Name,
+					},
 				},
 			}
 
 			// Create
 			Expect(k8sClient.Create(context.Background(), workspace)).Should(Succeed())
+			Expect(k8sClient.Create(context.Background(), namespace)).Should(Succeed())
 
 			By("Expecting to create workspace successfully")
 			Eventually(func() bool {
@@ -58,15 +67,6 @@ var _ = Describe("Workspace", func() {
 				return workspace.Spec.Manager == "admin"
 			}, timeout, interval).Should(BeTrue())
 
-			// Delete
-			By("Expecting to delete workspace successfully")
-			Eventually(func() error {
-				if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: workspace.Name}, workspace); err != nil {
-					return err
-				}
-				return k8sClient.Delete(context.Background(), workspace)
-			}, timeout, interval).Should(Succeed())
-
 			// Update DeletionPropagation
 			By("Expecting to delete workspace successfully")
 			Eventually(func() error {
@@ -80,10 +80,78 @@ var _ = Describe("Workspace", func() {
 				return k8sClient.Update(context.Background(), workspace)
 			}, timeout, interval).Should(Succeed())
 
-			By("Expecting to delete workspace finish")
+			// Delete workspace
+			By("Expecting to delete workspace successfully")
 			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{Name: workspace.Name}, workspace)
-			}, timeout, interval).ShouldNot(Succeed())
+				return k8sClient.Delete(context.Background(), workspace)
+			}, timeout, interval).Should(Succeed())
+
+			By("Expecting to cascading deletion finish")
+			Eventually(func() bool {
+				_ = k8sClient.Get(context.Background(), types.NamespacedName{Name: namespace.Name}, namespace)
+				// Deleting a namespace will seem to succeed, but the namespace will just be put in a Terminating state, and never actually be reclaimed.
+				// Reference: https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
+				return namespace.Status.Phase == corev1.NamespaceTerminating
+			}, timeout, interval).Should(BeTrue())
+
+			By("Expecting to delete workspace finish")
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(context.Background(), types.NamespacedName{Name: workspace.Name}, workspace))
+			}, timeout, interval).Should(BeTrue())
+		})
+		It("DeletePropagationOrphan", func() {
+			workspace := &tenantv1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "workspace-test2",
+				},
+			}
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "namespace-test2",
+					Labels: map[string]string{
+						tenantv1beta1.WorkspaceLabel: workspace.Name,
+					},
+				},
+			}
+			// Create
+			Expect(k8sClient.Create(context.Background(), workspace)).Should(Succeed())
+			Expect(k8sClient.Create(context.Background(), namespace)).Should(Succeed())
+
+			By("Expecting to create workspace successfully")
+			Eventually(func() bool {
+				_ = k8sClient.Get(context.Background(), types.NamespacedName{Name: workspace.Name}, workspace)
+				return len(workspace.Finalizers) > 0
+			}, timeout, interval).Should(BeTrue())
+
+			// Update
+			updated := &tenantv1beta1.Workspace{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: workspace.Name}, updated)).Should(Succeed())
+			updated.Spec.Manager = "admin"
+			Expect(k8sClient.Update(context.Background(), updated)).Should(Succeed())
+
+			// List workspace role bindings
+			By("Expecting to update workspace successfully")
+			Eventually(func() bool {
+				_ = k8sClient.Get(context.Background(), types.NamespacedName{Name: workspace.Name}, workspace)
+				return workspace.Spec.Manager == "admin"
+			}, timeout, interval).Should(BeTrue())
+
+			// Delete workspace
+			By("Expecting to delete workspace successfully")
+			Eventually(func() error {
+				return k8sClient.Delete(context.Background(), workspace)
+			}, timeout, interval).Should(Succeed())
+
+			By("Expecting to delete workspace finish")
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(context.Background(), types.NamespacedName{Name: workspace.Name}, workspace))
+			}, timeout, interval).Should(BeTrue())
+
+			By("Expecting to cascading deletion finish")
+			Eventually(func() bool {
+				_ = k8sClient.Get(context.Background(), types.NamespacedName{Name: namespace.Name}, namespace)
+				return namespace.Labels[tenantv1beta1.WorkspaceLabel] == "" && namespace.Status.Phase != corev1.NamespaceTerminating
+			}, timeout, interval).Should(BeTrue())
 		})
 	})
 })

--- a/pkg/controller/workspacetemplate/predicate/predicate.go
+++ b/pkg/controller/workspacetemplate/predicate/predicate.go
@@ -1,0 +1,46 @@
+/*
+ * Please refer to the LICENSE file in the root directory of the project.
+ * https://github.com/kubesphere/kubesphere/blob/master/LICENSE
+ */
+
+package predicate
+
+import (
+	"reflect"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	tenantv1alpha1 "kubesphere.io/api/tenant/v1beta1"
+)
+
+type WorkspaceStatusChangedPredicate struct {
+	predicate.Funcs
+}
+
+func (WorkspaceStatusChangedPredicate) Update(e event.UpdateEvent) bool {
+	oldWorkspaceTemplate, ok := e.ObjectOld.(*tenantv1alpha1.WorkspaceTemplate)
+	if !ok {
+		return false
+	}
+	newWorkspaceTemplate, ok := e.ObjectNew.(*tenantv1alpha1.WorkspaceTemplate)
+	if !ok {
+		return false
+	}
+	if !reflect.DeepEqual(oldWorkspaceTemplate.Spec, newWorkspaceTemplate.Spec) {
+		return true
+	}
+	return false
+}
+
+func (WorkspaceStatusChangedPredicate) Create(_ event.CreateEvent) bool {
+	return false
+}
+
+func (WorkspaceStatusChangedPredicate) Delete(_ event.DeleteEvent) bool {
+	return false
+}
+
+func (WorkspaceStatusChangedPredicate) Generic(_ event.GenericEvent) bool {
+	return false
+}

--- a/pkg/controller/workspacetemplate/workspacetemplate_controller.go
+++ b/pkg/controller/workspacetemplate/workspacetemplate_controller.go
@@ -115,6 +115,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// The object is not being deleted, so if it does not have our finalizer,
 		// then lets add the finalizer and update the object.
 		if !controllerutil.ContainsFinalizer(workspaceTemplate, constants.CascadingDeletionFinalizer) {
+			if err := r.initWorkspaceRoles(ctx, workspaceTemplate); err != nil {
+				return ctrl.Result{}, err
+			}
+			if err := r.initManagerRoleBinding(ctx, workspaceTemplate); err != nil {
+				return ctrl.Result{}, err
+			}
 			updated := workspaceTemplate.DeepCopy()
 			// Remove legacy finalizer
 			controllerutil.RemoveFinalizer(updated, "finalizers.workspacetemplate.kubesphere.io")
@@ -140,12 +146,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.initWorkspaceRoles(ctx, workspaceTemplate); err != nil {
-		return ctrl.Result{}, err
-	}
-	if err := r.initManagerRoleBinding(ctx, workspaceTemplate); err != nil {
-		return ctrl.Result{}, err
-	}
 	if err := r.multiClusterSync(ctx, workspaceTemplate); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controller/workspacetemplate/workspacetemplate_controller.go
+++ b/pkg/controller/workspacetemplate/workspacetemplate_controller.go
@@ -11,14 +11,13 @@ import (
 	"fmt"
 	"strings"
 
-	"kubesphere.io/kubesphere/pkg/constants"
-
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -33,11 +32,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"kubesphere.io/kubesphere/pkg/constants"
 	kscontroller "kubesphere.io/kubesphere/pkg/controller"
 	"kubesphere.io/kubesphere/pkg/controller/cluster/predicate"
 	clusterutils "kubesphere.io/kubesphere/pkg/controller/cluster/utils"
 	"kubesphere.io/kubesphere/pkg/controller/workspacetemplate/utils"
 	"kubesphere.io/kubesphere/pkg/utils/clusterclient"
+	"kubesphere.io/kubesphere/pkg/utils/hashutil"
 )
 
 const (
@@ -231,7 +232,7 @@ func (r *Reconciler) initWorkspaceRoles(ctx context.Context, workspaceTemplate *
 			builtinWorkspaceRole.Kind == iamv1beta1.ResourceKindWorkspaceRole {
 			target := &iamv1beta1.WorkspaceRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: fmt.Sprintf("%s-%s", workspaceTemplate.Name, builtinWorkspaceRole.Name),
+					Name: ensureWorkspaceRoleName(workspaceTemplate.Name, builtinWorkspaceRole.Name),
 				},
 			}
 			op, err := controllerutil.CreateOrUpdate(ctx, r.Client, target, func() error {
@@ -256,12 +257,21 @@ func (r *Reconciler) initWorkspaceRoles(ctx context.Context, workspaceTemplate *
 	return nil
 }
 
+func ensureWorkspaceRoleName(workspace, role string) string {
+	workspaceRoleName := fmt.Sprintf("%s-%s", workspace, role)
+	if len(workspaceRoleName) <= validation.LabelValueMaxLength {
+		return workspaceRoleName
+	}
+	hashedWorkspaceName := hashutil.FNVString([]byte(workspace))
+	return fmt.Sprintf("%s.%s", role, hashedWorkspaceName)
+}
+
 func (r *Reconciler) initManagerRoleBinding(ctx context.Context, workspaceTemplate *tenantv1beta1.WorkspaceTemplate) error {
 	manager := workspaceTemplate.Spec.Template.Spec.Manager
 	if manager == "" {
 		return nil
 	}
-	workspaceAdminRoleName := fmt.Sprintf("%s-admin", workspaceTemplate.Name)
+	workspaceAdminRoleName := ensureWorkspaceRoleName(workspaceTemplate.Name, "admin")
 	existWorkspaceRoleBinding := &iamv1beta1.WorkspaceRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: workspaceAdminRoleName}}
 	if _, err := ctrl.CreateOrUpdate(ctx, r.Client, existWorkspaceRoleBinding, func() error {
 		existWorkspaceRoleBinding.Labels = map[string]string{
@@ -269,7 +279,6 @@ func (r *Reconciler) initManagerRoleBinding(ctx context.Context, workspaceTempla
 			iamv1beta1.UserReferenceLabel: manager,
 			iamv1beta1.RoleReferenceLabel: workspaceAdminRoleName,
 		}
-
 		existWorkspaceRoleBinding.RoleRef = rbacv1.RoleRef{
 			APIGroup: iamv1beta1.SchemeGroupVersion.Group,
 			Kind:     iamv1beta1.ResourceKindWorkspaceRole,
@@ -290,13 +299,6 @@ func (r *Reconciler) initManagerRoleBinding(ctx context.Context, workspaceTempla
 }
 
 func (r *Reconciler) workspaceTemplateCascadingDeletion(ctx context.Context, workspaceTemplate *tenantv1beta1.WorkspaceTemplate) (bool, error) {
-	switch workspaceTemplate.Annotations[constants.DeletionPropagationAnnotation] {
-	case string(metav1.DeletePropagationOrphan), string(metav1.DeletePropagationForeground), string(metav1.DeletePropagationBackground):
-	default:
-		klog.FromContext(ctx).V(4).Info(fmt.Sprintf("waiting for deletion propagation update, invalid deletion propagation policy found: %s", workspaceTemplate.Annotations[constants.DeletionPropagationAnnotation]))
-		return false, nil
-	}
-
 	clusters, err := r.clusterClientSet.ListClusters(ctx)
 	if err != nil {
 		return false, fmt.Errorf("failed to list clusters: %s", err)
@@ -330,12 +332,7 @@ func (r *Reconciler) workspaceCascadingDeletion(ctx context.Context, clusterName
 	if err := clusterClient.Get(ctx, types.NamespacedName{Name: workspaceTemplate.Name}, workspace); err != nil {
 		return client.IgnoreNotFound(err)
 	}
-	if workspace.DeletionTimestamp.IsZero() {
-		if err := clusterClient.Delete(ctx, workspace); err != nil {
-			return fmt.Errorf("failed to delete workspace %s in cluster %s: %s", workspace.Name, clusterName, err)
-		}
-	}
-	if workspace.Annotations[constants.DeletionPropagationAnnotation] == workspaceTemplate.Annotations[constants.DeletionPropagationAnnotation] {
+	if !workspace.DeletionTimestamp.IsZero() {
 		return nil
 	}
 	if workspace.Annotations == nil {
@@ -344,6 +341,9 @@ func (r *Reconciler) workspaceCascadingDeletion(ctx context.Context, clusterName
 	workspace.Annotations[constants.DeletionPropagationAnnotation] = workspaceTemplate.Annotations[constants.DeletionPropagationAnnotation]
 	if err := clusterClient.Update(ctx, workspace); err != nil {
 		return fmt.Errorf("failed to update workspace %s in cluster %s: %s", workspace.Name, clusterName, err)
+	}
+	if err := clusterClient.Delete(ctx, workspace); err != nil {
+		return fmt.Errorf("failed to delete workspace %s in cluster %s: %s", workspace.Name, clusterName, err)
 	}
 	return nil
 }

--- a/pkg/kapis/tenant/v1beta1/handler.go
+++ b/pkg/kapis/tenant/v1beta1/handler.go
@@ -48,7 +48,7 @@ func (h *handler) ListWorkspaces(req *restful.Request, resp *restful.Response) {
 		return
 	}
 
-	resp.WriteEntity(result)
+	_ = resp.WriteEntity(result)
 }
 
 func (h *handler) GetWorkspace(request *restful.Request, response *restful.Response) {
@@ -63,7 +63,7 @@ func (h *handler) GetWorkspace(request *restful.Request, response *restful.Respo
 		return
 	}
 
-	response.WriteEntity(workspace)
+	_ = response.WriteEntity(workspace)
 }
 
 func (h *handler) CreateWorkspaceTemplate(req *restful.Request, resp *restful.Response) {
@@ -99,23 +99,18 @@ func (h *handler) CreateWorkspaceTemplate(req *restful.Request, resp *restful.Re
 		return
 	}
 
-	resp.WriteEntity(created)
+	_ = resp.WriteEntity(created)
 }
 
 func (h *handler) DeleteWorkspaceTemplate(request *restful.Request, response *restful.Response) {
 	workspace := request.PathParameter("workspace")
-
 	opts := metav1.DeleteOptions{}
-
-	err := request.ReadEntity(&opts)
-	if err != nil {
-		opts = *metav1.NewDeleteOptions(0)
+	if err := request.ReadEntity(&opts); err != nil {
+		api.HandleBadRequest(response, request, err)
+		return
 	}
 
-	err = h.tenant.DeleteWorkspaceTemplate(workspace, opts)
-
-	if err != nil {
-		klog.Error(err)
+	if err := h.tenant.DeleteWorkspaceTemplate(workspace, opts); err != nil {
 		if errors.IsNotFound(err) {
 			api.HandleNotFound(response, request, err)
 			return
@@ -124,7 +119,7 @@ func (h *handler) DeleteWorkspaceTemplate(request *restful.Request, response *re
 		return
 	}
 
-	response.WriteEntity(servererr.None)
+	_ = response.WriteEntity(servererr.None)
 }
 
 func (h *handler) UpdateWorkspaceTemplate(req *restful.Request, resp *restful.Response) {
@@ -173,7 +168,7 @@ func (h *handler) UpdateWorkspaceTemplate(req *restful.Request, resp *restful.Re
 		return
 	}
 
-	resp.WriteEntity(updated)
+	_ = resp.WriteEntity(updated)
 }
 
 func (h *handler) DescribeWorkspaceTemplate(request *restful.Request, response *restful.Response) {
@@ -187,7 +182,7 @@ func (h *handler) DescribeWorkspaceTemplate(request *restful.Request, response *
 		api.HandleInternalError(response, request, err)
 		return
 	}
-	response.WriteEntity(workspace)
+	_ = response.WriteEntity(workspace)
 }
 
 func (h *handler) PatchWorkspaceTemplate(req *restful.Request, resp *restful.Response) {
@@ -227,7 +222,7 @@ func (h *handler) PatchWorkspaceTemplate(req *restful.Request, resp *restful.Res
 		return
 	}
 
-	resp.WriteEntity(patched)
+	_ = resp.WriteEntity(patched)
 }
 
 func (h *handler) ListWorkspaceTemplates(req *restful.Request, resp *restful.Response) {
@@ -248,5 +243,5 @@ func (h *handler) ListWorkspaceTemplates(req *restful.Request, resp *restful.Res
 		return
 	}
 
-	resp.WriteEntity(result)
+	_ = resp.WriteEntity(result)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

Optimize log output.

```
I1224 10:18:00.175318       1 controller.go:314] "Warning: Reconciler returned both a non-zero result and a non-nil error. The result will always be ignored if the error is non-nil and the non-nil error causes reqeueuing with exponential backoff. For more details, see: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler" controller="installplan" controllerGroup="kubesphere.io" controllerKind="InstallPlan" InstallPlan="ks-console-embed" namespace="" name="ks-console-embed" reconcileID="65f95801-037c-43d8-a2b9-94c1691014f9"
```

```
I1224 10:18:00.175318       1 controller.go:314] "Warning: Reconciler returned both a non-zero result and a non-nil error. The result will always be ignored if the error is non-nil and the non-nil error causes reqeueuing with exponential backoff. For more details, see: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler" controller="installplan" controllerGroup="kubesphere.io" controllerKind="InstallPlan" InstallPlan="ks-console-embed" namespace="" name="ks-console-embed" reconcileID="65f95801-037c-43d8-a2b9-94c1691014f9"
```

```
E1224 10:18:00.206647       1 controller.go:316] "Reconciler error" err="failed to sync cluster membership for host: failed to create cluster admin: Operation cannot be fulfilled on clusters.cluster.kubesphere.io \"host\": the object has been modified; please apply your changes to the latest version and try again" controller="cluster" controllerGroup="cluster.kubesphere.io" controllerKind="Cluster" Cluster="host" namespace="" name="host" reconcileID="8f4cfacb-0deb-471f-985a-471badf8ddad"
E1224 10:18:00.295622       1 controller.go:316] "Reconciler error" err="Operation cannot be fulfilled on workspaceroles.iam.kubesphere.io \"system-workspace-self-provisioner\": the object has been modified; please apply your changes to the latest version and try again" controller="workspacerole" controllerGroup="iam.kubesphere.io" controllerKind="WorkspaceRole" WorkspaceRole="system-workspace-self-provisioner" namespace="" name="system-workspace-self-provisioner" reconcileID="c60454f8-0e6b-4940-b2bf-8634757e6563"
E1224 10:18:01.512284       1 controller.go:316] "Reconciler error" err="Operation cannot be fulfilled on categories.kubesphere.io \"observability\": the object has been modified; please apply your changes to the latest version and try again" controller="extension-category" controllerGroup="kubesphere.io" controllerKind="Category" Category="observability" namespace="" name="observability" reconcileID="82cc5072-ecb8-4389-91e3-c0b5732651f6"
```

```
E1224 10:30:08.331458       1 controller.go:316] "Reconciler error" err="Operation cannot be fulfilled on workspaceroles.iam.kubesphere.io \"system-workspace-admin\": the object has been modified; please apply your changes to the latest version and try again" controller="workspacerole" controllerGroup="iam.kubesphere.io" controllerKind="WorkspaceRole" WorkspaceRole="system-workspace-admin" namespace="" name="system-workspace-admin" reconcileID="76452eaa-863a-4b85-9ffa-2e6c1a8ebdc4"
E1224 10:30:08.372505       1 controller.go:316] "Reconciler error" err="Operation cannot be fulfilled on roles.iam.kubesphere.io \"admin\": the object has been modified; please apply your changes to the latest version and try again" controller="roletemplate" controllerGroup="iam.kubesphere.io" controllerKind="RoleTemplate" RoleTemplate="namespace-manage-roles" namespace="" name="namespace-manage-roles" reconcileID="aba4b1e8-1cbe-45a2-a14e-79b347330303"
E1224 10:30:08.420017       1 controller.go:316] "Reconciler error" err="Operation cannot be fulfilled on roles.iam.kubesphere.io \"admin\": the object has been modified; please apply your changes to the latest version and try again" controller="role" controllerGroup="iam.kubesphere.io" controllerKind="Role" Role="default/admin" namespace="default" name="admin" reconcileID="f191122a-723f-4b4e-bf09-06fdfe242c84"
E1224 10:30:08.420681       1 controller.go:316] "Reconciler error" err="Operation cannot be fulfilled on roles.iam.kubesphere.io \"admin\": the object has been modified; please apply your changes to the latest version and try again" controller="roletemplate" controllerGroup="iam.kubesphere.io" controllerKind="RoleTemplate" RoleTemplate="namespace-view-project-settings" namespace="" name="namespace-view-project-settings" reconcileID="c4dad856-3689-4947-b92e-7149ec39353b"
E1224 10:30:08.482247       1 controller.go:316] "Reconciler error" err="Operation cannot be fulfilled on roles.iam.kubesphere.io \"admin\": the object has been modified; please apply your changes to the latest version and try again" controller="role" controllerGroup="iam.kubesphere.io" controllerKind="Role" Role="default/admin" namespace="default" name="admin" reconcileID="f81af262-3afa-4d0c-8220-28cccf824fac"
E1224 10:30:08.700074       1 controller.go:316] "Reconciler error" err="Operation cannot be fulfilled on roles.iam.kubesphere.io \"viewer\": the object has been modified; please apply your changes to the latest version and try again" controller="roletemplate" controllerGroup="iam.kubesphere.io" controllerKind="RoleTemplate" RoleTemplate="namespace-view-project-settings" namespace="" name="namespace-view-project-settings" reconcileID="39a11316-f761-40f8-87f3-b6e37b30f07b"
E1224 10:30:08.741155       1 controller.go:316] "Reconciler error" err="Operation cannot be fulfilled on roles.iam.kubesphere.io \"viewer\": the object has been modified; please apply your changes to the latest version and try again" controller="roletemplate" controllerGroup="iam.kubesphere.io" controllerKind="RoleTemplate" RoleTemplate="namespace-view-project-settings" namespace="" name="namespace-view-project-settings" reconcileID="73c46b19-33c5-4987-a333-0b6648c8d52a"
E1224 10:30:08.773379       1 controller.go:316] "Reconciler error" err="Operation cannot be fulfilled on roles.iam.kubesphere.io \"operator\": the object has been modified; please apply your changes to the latest version and try again" controller="roletemplate" controllerGroup="iam.kubesphere.io" controllerKind="RoleTemplate" RoleTemplate="namespace-view-project-settings" namespace="" name="namespace-view-project-settings" reconcileID="b99c202c-b462-459d-ae55-663574b7e359"
```


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

