### PR TITLE
Fix OIDC logout redirect uri

### DIFF
--- a/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
+++ b/pkg/apiserver/authentication/identityprovider/oidc/oidc.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 
@@ -51,6 +52,10 @@ type oidcProvider struct {
 
 	// Scope specifies optional requested permissions.
 	Scopes []string `json:"scopes" yaml:"scopes"`
+
+	// Redirection to RP After Logout
+	// See https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RedirectionAfterLogout
+	PostLogoutRedirectURI string `json:"postLogoutRedirectURI" yaml:"postLogoutRedirectURI"`
 
 	// GetUserInfo uses the userinfo endpoint to get additional claims for the token.
 	// This is especially useful where upstreams return "thin" id tokens
@@ -153,6 +158,17 @@ func (f *oidcProviderFactory) Create(opts options.DynamicOptions) (identityprovi
 		oidcProvider.Endpoint.UserInfoURL, _ = providerJSON["userinfo_endpoint"].(string)
 		oidcProvider.Endpoint.JWKSURL, _ = providerJSON["jwks_uri"].(string)
 		oidcProvider.Endpoint.EndSessionURL, _ = providerJSON["end_session_endpoint"].(string)
+
+		endSessionUrl, err := url.Parse(oidcProvider.Endpoint.EndSessionURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse end session url: %v", err)
+		}
+		endSessionQuery := endSessionUrl.Query()
+		endSessionQuery.Add("post_logout_redirect_uri", oidcProvider.PostLogoutRedirectURI)
+		endSessionQuery.Add("client_id", oidcProvider.ClientID)
+		endSessionUrl.RawQuery = endSessionQuery.Encode()
+
+		oidcProvider.Endpoint.EndSessionURL = endSessionUrl.String()
 		oidcProvider.Provider = provider
 		oidcProvider.Verifier = provider.Verifier(&oidc.Config{
 			// TODO: support HS256

--- a/pkg/apiserver/authentication/identityprovider/oidc/oidc_test.go
+++ b/pkg/apiserver/authentication/identityprovider/oidc/oidc_test.go
@@ -175,7 +175,7 @@ var _ = Describe("OIDC", func() {
 					"tokenURL":      fmt.Sprintf("%s/token", oidcServer.URL),
 					"userInfoURL":   fmt.Sprintf("%s/userinfo", oidcServer.URL),
 					"jwksURL":       fmt.Sprintf("%s/keys", oidcServer.URL),
-					"endSessionURL": fmt.Sprintf("%s/endsession", oidcServer.URL),
+					"endSessionURL": fmt.Sprintf("%s/endsession?client_id=kubesphere&post_logout_redirect_uri=", oidcServer.URL),
 				},
 			}
 			Expect(config).Should(Equal(expected))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/kubesphere/issues/6347

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Support logout redirect to postLogoutRedirectURI.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
name: keycloak
type: OIDCIdentityProvider
mappingMethod: auto
provider:
  clientID: ******
  clientSecret: ******
  issuer: 'https://example-kc-service.default.svc.cluster.local/realms/kubesphere'
  redirectURL: 'http://<host>:<port>/oauth/redirect/keycloak'
  insecureSkipVerify: true
  postLogoutRedirectURI: http://<host>:<port>
  scopes:
  - openid
  - email
  - profile
```
