### PR TITLE
fix: pod list with owner filter logic

### DIFF
--- a/pkg/models/resources/v1alpha3/pod/pods.go
+++ b/pkg/models/resources/v1alpha3/pod/pods.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -23,12 +25,13 @@ import (
 )
 
 const (
-	fieldNodeName    = "nodeName"
-	fieldPVCName     = "pvcName"
-	fieldServiceName = "serviceName"
-	fieldPhase       = "phase"
-	fieldStatus      = "status"
-	fieldPodIP       = "podIP"
+	fieldNodeName       = "nodeName"
+	fieldPVCName        = "pvcName"
+	fieldServiceName    = "serviceName"
+	fieldPhase          = "phase"
+	fieldStatus         = "status"
+	fieldPodIP          = "podIP"
+	fieldOwnerReference = "ownerReference"
 
 	statusTypeWaitting  = "Waiting"
 	statusTypeRunning   = "Running"
@@ -98,6 +101,8 @@ func (p *podsGetter) filter(object runtime.Object, filter query.Filter) bool {
 		return string(pod.Status.Phase) == string(filter.Value)
 	case fieldPodIP:
 		return p.podWithIP(pod, string(filter.Value))
+	case fieldOwnerReference:
+		return p.podWithOwnerReference(pod, string(filter.Value))
 	default:
 		return v1alpha3.DefaultObjectMetaFilter(pod.ObjectMeta, filter)
 	}
@@ -249,6 +254,34 @@ func (p *podsGetter) getPodStatus(pod *corev1.Pod) string {
 		}
 	}
 	return statusType
+}
+
+func (p *podsGetter) podWithOwnerReference(pod *corev1.Pod, uid string) bool {
+	var replicaSetOwner *metav1.OwnerReference
+	for _, ownerReference := range pod.OwnerReferences {
+		if ownerReference.Kind == "ReplicaSet" {
+			replicaSetOwner = ownerReference.DeepCopy()
+		}
+		if strings.Compare(string(ownerReference.UID), uid) == 0 {
+			return true
+		}
+	}
+	if replicaSetOwner == nil {
+		return false
+	}
+	replicaSet := &appsv1.ReplicaSet{}
+	if err := p.cache.Get(context.Background(), types.NamespacedName{
+		Namespace: pod.Namespace,
+		Name:      replicaSetOwner.Name,
+	}, replicaSet); err != nil {
+		return false
+	}
+	for _, ownerReference := range replicaSet.OwnerReferences {
+		if strings.Compare(string(ownerReference.UID), uid) == 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func hasPodReadyCondition(conditions []corev1.PodCondition) bool {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fixed the issue that deployments and statefulsets use the same label, which causes abnormal pod list data.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
