### PR TITLE
chore: remove deprecated CronJob for restarting extensions museum

### DIFF
--- a/config/ks-core/templates/extension-museum.yaml
+++ b/config/ks-core/templates/extension-museum.yaml
@@ -83,26 +83,4 @@ metadata:
 spec:
   url: https://extensions-museum.{{ .Release.Namespace }}.svc
   caBundle: {{ b64enc $ca.Cert }}
-
----
-apiVersion: {{ if semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version }}batch/v1{{ else }}batch/v1beta1{{end}}
-kind: CronJob
-metadata:
-  name: restart-extensions-museum
-  namespace: {{ .Release.Namespace }}
-spec:
-  schedule: "0 0 * * *"
-  jobTemplate:
-    spec:
-      template:
-        spec:
-          containers:
-            - name: restart-extensions-museum
-              image: {{ template "kubectl.image" . }}
-              command:
-                - /bin/sh
-                - -c
-                - "kubectl rollout restart deployment/extensions-museum -n {{ .Release.Namespace }}"
-          restartPolicy: OnFailure
-          serviceAccountName: {{ template "ks-core.serviceAccountName" . }}
 {{end}}


### PR DESCRIPTION
### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```