### PR TITLE
fix: add PersistentVolumeClaim definition to prepare upgrade job

### DIFF
--- a/config/ks-core/Chart.yaml
+++ b/config/ks-core/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.4
+version: 1.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/config/ks-core/templates/pre-upgrade-job.yaml
+++ b/config/ks-core/templates/pre-upgrade-job.yaml
@@ -13,27 +13,6 @@ data:
 {{- end }}
 
 ---
-{{- if not (lookup "v1" "PersistentVolumeClaim" .Release.Namespace .Values.upgrade.persistenceVolume.name) }}
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: {{ .Values.upgrade.persistenceVolume.name }}
-  annotations:
-    "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-weight": "-1"
-  labels:
-    app: ks-upgrade
-    version: {{ .Chart.AppVersion }}
-spec:
-  accessModes:
-    - {{ .Values.upgrade.persistenceVolume.accessMode | quote }}
-  resources:
-    requests:
-      storage: {{ .Values.upgrade.persistenceVolume.size | quote }}
-  storageClassName: {{ .Values.upgrade.persistenceVolume.storageClassName }}
-{{-  end }}
-
----
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/config/ks-core/templates/prepare-upgrade-job.yaml
+++ b/config/ks-core/templates/prepare-upgrade-job.yaml
@@ -10,6 +10,27 @@ data:
     {{- toYaml .Values.upgrade.config | nindent 4 }}
 {{- end }}
 
+{{- if not (lookup "v1" "PersistentVolumeClaim" .Release.Namespace .Values.upgrade.persistenceVolume.name) }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Values.upgrade.persistenceVolume.name }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-1"
+  labels:
+    app: ks-upgrade
+    version: {{ .Chart.AppVersion }}
+spec:
+  accessModes:
+    - {{ .Values.upgrade.persistenceVolume.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.upgrade.persistenceVolume.size | quote }}
+  storageClassName: {{ .Values.upgrade.persistenceVolume.storageClassName }}
+{{-  end }}
+
 ---
 apiVersion: batch/v1
 kind: Job
@@ -40,6 +61,8 @@ spec:
             - mountPath: /etc/kubesphere/config-patch.yaml
               name: config
               subPath: config-patch.yaml
+            - mountPath: /tmp/ks-upgrade
+              name: data
           {{- end }}
       {{- if .Values.upgrade.config }}
       volumes:
@@ -47,6 +70,9 @@ spec:
           configMap:
             name: ks-upgrade-prepare-config
             defaultMode: 420
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.upgrade.persistenceVolume.name }}
       {{- end }}
 {{- end }}
 {{- end }}

--- a/config/ks-core/values.yaml
+++ b/config/ks-core/values.yaml
@@ -443,5 +443,5 @@ ksExtensionRepository:
   image:
     registry: ""
     repository: kubesphere/ks-extensions-museum
-    tag: "v1.1.3"
+    tag: "v1.1.5"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```