### PR TITLE
refactor: update ks-console-config.yaml use dynamic configuration values

### DIFF
--- a/config/ks-core/templates/ks-console-config.yaml
+++ b/config/ks-core/templates/ks-console-config.yaml
@@ -22,13 +22,15 @@ data:
     {{- else }}
         url: http://ks-apiserver
         wsUrl: ws://ks-apiserver
-    {{ end }}
+    {{- end }}
     client:
       version:
         kubesphere: {{ .Chart.AppVersion }}
         kubernetes: {{ .Capabilities.KubeVersion.Version }}
-      enableKubeConfig: true
-      enableNodeListTerminal: {{ .Values.console.config.enableNodeListTerminal }}
+      isWarningHeaderNotificationEnabled: {{ not (or (empty .Values.experimental.validationDirective) (eq .Values.experimental.validationDirective "Ignore")) }}
+      {{- with .Values.console.config }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
 kind: ConfigMap
 metadata:
   name: ks-console-config

--- a/config/ks-core/values.yaml
+++ b/config/ks-core/values.yaml
@@ -161,6 +161,7 @@ console:
     digest: ""
     pullPolicy: IfNotPresent
   config:
+    enableKubeConfig: true
     enableNodeListTerminal: true
   ## @param containerPorts [array] List of container ports to enable in the ks-console container
   ##


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:


fix https://github.com/kubesphere/project/issues/6058


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:

```
➜  config git:(master) helm template -n kubesphere-system -s templates/ks-console-config.yaml ks-core  --set multicluster.role=host
# Source: ks-core/templates/ks-console-config.yaml
apiVersion: v1
data:
  local_config.yaml: |
    server:
      http:
        hostname: localhost
        port: 8000
        static:
          production:
            /public: server/public
            /assets: dist/assets
            /dist: dist
      redis:
        port: 6379
        host: redis.kubesphere-system.svc
      redisTimeout: 5000
      sessionTimeout: 7200000
      apiServer:
        url: http://ks-apiserver
        wsUrl: ws://ks-apiserver
    client:
      version:
        kubesphere: v4.1.1
        kubernetes: v1.29.0
      isWarningHeaderNotificationEnabled: false
      enableKubeConfig: true
      enableNodeListTerminal: true
kind: ConfigMap
metadata:
  name: ks-console-config
```
