### PR TITLE
fix(v1alpha1): correct struct tag typo in RepositoryStatus

### DIFF
--- a/staging/src/kubesphere.io/api/core/v1alpha1/types.go
+++ b/staging/src/kubesphere.io/api/core/v1alpha1/types.go
@@ -294,7 +294,7 @@ type RepositorySpec struct {
 
 type RepositoryStatus struct {
 	// +optional
-	LastSyncTime *metav1.Time `json:"lastSyncTime,omitempty'"`
+	LastSyncTime *metav1.Time `json:"lastSyncTime,omitempty"`
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:
Corrects a typo in the JSON struct tag of `RepositoryStatus` in `v1alpha1/types.go`.  
This ensures the field is properly serialized/deserialized and avoids unexpected behavior when interacting with APIs.

### Which issue(s) this PR fixes:
Fixes #6572

### Special notes for reviewers:
This is a minor change limited to fixing the struct tag typo. No functional or user-facing impact besides correcting the JSON tag.

### Does this PR introduce a user-facing change?
```release-note
None
```