### PR TITLE
feat(pods): add sorting by container restart count (v1alpha3) and uni…

### DIFF
--- a/pkg/apiserver/query/field.go
+++ b/pkg/apiserver/query/field.go
@@ -24,4 +24,6 @@ const (
 	FieldStatus              = "status"
 	FieldOwnerReference      = "ownerReference"
 	FieldOwnerKind           = "ownerKind"
+	// FieldRestartCount is used for sorting by aggregated container restart counts on a Pod
+	FieldRestartCount = "restartCount"
 )

--- a/pkg/models/resources/v1alpha3/pod/pods.go
+++ b/pkg/models/resources/v1alpha3/pod/pods.go
@@ -80,6 +80,17 @@ func (p *podsGetter) compare(left runtime.Object, right runtime.Object, field qu
 		return false
 	}
 
+	// Support sorting by aggregated container restart count
+	if field == query.FieldRestartCount {
+		leftRestarts := getAggregatedRestartCount(leftPod)
+		rightRestarts := getAggregatedRestartCount(rightPod)
+		if leftRestarts != rightRestarts {
+			return leftRestarts > rightRestarts
+		}
+		// fall back to metadata if equal
+		return v1alpha3.DefaultObjectMetaCompare(leftPod.ObjectMeta, rightPod.ObjectMeta, query.FieldCreationTimeStamp)
+	}
+
 	return v1alpha3.DefaultObjectMetaCompare(leftPod.ObjectMeta, rightPod.ObjectMeta, field)
 }
 
@@ -301,4 +312,13 @@ func isPodReadyConditionReason(conditions []corev1.PodCondition, reason string) 
 		}
 	}
 	return true
+}
+
+// getAggregatedRestartCount returns the total restart count across all containers in the pod.
+func getAggregatedRestartCount(pod *corev1.Pod) int32 {
+	var total int32
+	for _, cs := range pod.Status.ContainerStatuses {
+		total += cs.RestartCount
+	}
+	return total
 }

--- a/pkg/models/resources/v1alpha3/pod/pods_test.go
+++ b/pkg/models/resources/v1alpha3/pod/pods_test.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2024 the KubeSphere Authors.
+ * Please refer to the LICENSE file in the root directory of the project.
+ * https://github.com/kubesphere/kubesphere/blob/master/LICENSE
+ */
+
+package pod
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"kubesphere.io/kubesphere/pkg/apiserver/query"
+	"kubesphere.io/kubesphere/pkg/models/resources/v1alpha3"
+)
+
+func TestCompareByRestartCount(t *testing.T) {
+	now := time.Now()
+	podLow := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod-low",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Hour)),
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "c1", RestartCount: 1},
+				{Name: "c2", RestartCount: 0},
+			},
+		},
+	}
+	podHigh := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod-high",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Hour)),
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "c1", RestartCount: 2},
+				{Name: "c2", RestartCount: 1},
+			},
+		},
+	}
+
+	g := &podsGetter{}
+	if !g.compare(podHigh, podLow, query.FieldRestartCount) {
+		t.Fatalf("expected podHigh to be greater than podLow by restartCount")
+	}
+	if g.compare(podLow, podHigh, query.FieldRestartCount) {
+		t.Fatalf("did not expect podLow to be greater than podHigh by restartCount")
+	}
+}
+
+func TestListSortByRestartCount(t *testing.T) {
+	now := time.Now()
+	podA := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod-a",
+			Namespace:         "ns",
+			CreationTimestamp: metav1.NewTime(now.Add(-3 * time.Hour)),
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "c1", RestartCount: 3},
+			},
+		},
+	}
+	podB := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod-b",
+			Namespace:         "ns",
+			CreationTimestamp: metav1.NewTime(now.Add(-2 * time.Hour)),
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "c1", RestartCount: 1},
+			},
+		},
+	}
+	podC := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod-c",
+			Namespace:         "ns",
+			CreationTimestamp: metav1.NewTime(now.Add(-1 * time.Hour)),
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "c1", RestartCount: 3},
+			},
+		},
+	}
+
+	objects := []runtime.Object{podA, podB, podC}
+
+	q := query.New()
+	q.SortBy = query.FieldRestartCount
+	q.Ascending = false
+
+	g := &podsGetter{}
+	result := v1alpha3.DefaultList(objects, q, g.compare, g.filter)
+	if result.TotalItems != 3 {
+		t.Fatalf("expected 3 items, got %d", result.TotalItems)
+	}
+
+	got := result.Items
+	// Expect highest restart first: podA and podC both 3; tie-breaker by creationTimestamp (newer first)
+	// DefaultObjectMetaCompare uses creationTimestamp desc when equal sort field not specified.
+	// In our compare, on tie we fallback to CreationTimeStamp descending.
+	if got[0].(*corev1.Pod).Name != "pod-c" {
+		t.Fatalf("expected first item to be pod-c, got %s", got[0].(*corev1.Pod).Name)
+	}
+	if got[1].(*corev1.Pod).Name != "pod-a" {
+		t.Fatalf("expected second item to be pod-a, got %s", got[1].(*corev1.Pod).Name)
+	}
+	if got[2].(*corev1.Pod).Name != "pod-b" {
+		t.Fatalf("expected third item to be pod-b, got %s", got[2].(*corev1.Pod).Name)
+	}
+}
+
+


### PR DESCRIPTION
Here’s a filled PR description you can paste into GitHub.

### What type of PR is this?
/kind feature
/area apiserver

### What this PR does / why we need it:
Adds support to sort Pods by total container restart count via the v1alpha3 resources API. This helps identify unstable Pods quickly by ordering results with the most restarts first or last.

- New sort field: `sortBy=restartCount`
- Sorting logic: sum of `.status.containerStatuses[*].restartCount` per Pod
- Tie-breaker: creation timestamp (desc), then name
- Unit tests cover comparator and list ordering

### Which issue(s) this PR fixes:
Partially addresses kubesphere/kubesphere#3449 (adds sorting; alerting to be handled in a follow-up)

### Special notes for reviewers:
- Applies to v1alpha3 resources API for `pods` (namespace and cluster scope).
- No change for other resources.
- Minimal overhead: in-memory aggregation and sort.

API examples:
```
GET /kapis/resources.kubesphere.io/v1alpha3/namespaces/<ns>/pods?sortBy=restartCount&ascending=false&limit=20
GET /kapis/resources.kubesphere.io/v1alpha3/pods?sortBy=restartCount&ascending=false&limit=20
```

### Does this PR introduced a user-facing change?
```release-note
Add sorting of Pods by total container restart count via `sortBy=restartCount` (v1alpha3 resources API). Supports `ascending=true|false`. Ties fall back to creation timestamp.
```

### Additional documentation, usage docs, etc.:
```docs
- API: v1alpha3 resources, `pods` support `sortBy=restartCount` with `ascending=true|false`.
- Usage examples:
  - /kapis/resources.kubesphere.io/v1alpha3/namespaces/<ns>/pods?sortBy=restartCount&ascending=false
  - /kapis/resources.kubesphere.io/v1alpha3/pods?sortBy=restartCount&ascending=true
```