### PR TITLE
feat(api): Support network configuration when creating workload

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -65,6 +65,7 @@ import (
 	tenantapiv1beta1 "kubesphere.io/kubesphere/pkg/kapis/tenant/v1beta1"
 	terminalv1alpha2 "kubesphere.io/kubesphere/pkg/kapis/terminal/v1alpha2"
 	"kubesphere.io/kubesphere/pkg/kapis/version"
+	workloadnetworkv1alpha1 "kubesphere.io/kubesphere/pkg/kapis/workloadnetwork/v1alpha1"
 	workloadtemplatev1alpha1 "kubesphere.io/kubesphere/pkg/kapis/workloadtemplate/v1alpha1"
 	"kubesphere.io/kubesphere/pkg/models/auth"
 	"kubesphere.io/kubesphere/pkg/models/iam/am"
@@ -190,6 +191,7 @@ func (s *APIServer) installKubeSphereAPIs() {
 		gatewayv1alpha2.NewHandler(s.RuntimeCache),
 		appv2.NewHandler(s.RuntimeClient, s.ClusterClient, s.S3Options),
 		workloadtemplatev1alpha1.NewHandler(s.RuntimeClient, s.K8sVersion, rbacAuthorizer),
+		workloadnetworkv1alpha1.NewHandler(s.RuntimeClient),
 		static.NewHandler(s.CacheClient),
 	}
 

--- a/pkg/kapis/workloadnetwork/v1alpha1/handler.go
+++ b/pkg/kapis/workloadnetwork/v1alpha1/handler.go
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2024 the KubeSphere Authors.
+ * Please refer to the LICENSE file in the root directory of the project.
+ * https://github.com/kubesphere/kubesphere/blob/master/LICENSE
+ */
+
+package v1alpha1
+
+import (
+	"fmt"
+
+	"github.com/emicklei/go-restful/v3"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"kubesphere.io/kubesphere/pkg/api"
+)
+
+const (
+	KindDeployment  = "Deployment"
+	KindStatefulSet = "StatefulSet"
+	KindDaemonSet   = "DaemonSet"
+	KindJob         = "Job"
+)
+
+// getWorkloadNetworkConfig handles GET requests for workload network configuration
+func (h *networkHandler) getWorkloadNetworkConfig(req *restful.Request, resp *restful.Response) {
+	namespace := req.PathParameter("namespace")
+	name := req.PathParameter("name")
+	kind := req.PathParameter("kind")
+
+	networkConfig, err := h.getNetworkConfigFromWorkload(req, namespace, name, kind)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			api.HandleNotFound(resp, req, err)
+			return
+		}
+		api.HandleError(resp, req, err)
+		return
+	}
+
+	response := &WorkloadNetworkConfigResponse{
+		Kind:          kind,
+		Name:          name,
+		Namespace:     namespace,
+		NetworkConfig: *networkConfig,
+	}
+
+	resp.WriteAsJson(response)
+}
+
+// updateWorkloadNetworkConfig handles PUT requests to update workload network configuration
+func (h *networkHandler) updateWorkloadNetworkConfig(req *restful.Request, resp *restful.Response) {
+	namespace := req.PathParameter("namespace")
+	name := req.PathParameter("name")
+	kind := req.PathParameter("kind")
+
+	request := &WorkloadNetworkConfigRequest{}
+	if err := req.ReadEntity(request); err != nil {
+		api.HandleBadRequest(resp, req, err)
+		return
+	}
+
+	if request.Kind != "" && request.Kind != kind {
+		api.HandleBadRequest(resp, req, fmt.Errorf("kind in request body (%s) does not match path parameter (%s)", request.Kind, kind))
+		return
+	}
+
+	err := h.updateNetworkConfig(req, namespace, name, kind, &request.NetworkConfig)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			api.HandleNotFound(resp, req, err)
+			return
+		}
+		api.HandleError(resp, req, err)
+		return
+	}
+
+	updatedConfig, err := h.getNetworkConfigFromWorkload(req, namespace, name, kind)
+	if err != nil {
+		api.HandleError(resp, req, err)
+		return
+	}
+
+	response := &WorkloadNetworkConfigResponse{
+		Kind:          kind,
+		Name:          name,
+		Namespace:     namespace,
+		NetworkConfig: *updatedConfig,
+	}
+
+	resp.WriteAsJson(response)
+}
+
+// getNetworkConfigFromWorkload extracts the network configuration from a workload
+func (h *networkHandler) getNetworkConfigFromWorkload(req *restful.Request, namespace, name, kind string) (*NetworkConfig, error) {
+	ctx := req.Request.Context()
+	key := runtimeclient.ObjectKey{Namespace: namespace, Name: name}
+
+	var podSpec *corev1.PodSpec
+	switch kind {
+	case KindDeployment:
+		deployment := &appsv1.Deployment{}
+		if err := h.client.Get(ctx, key, deployment); err != nil {
+			return nil, err
+		}
+		podSpec = &deployment.Spec.Template.Spec
+	case KindStatefulSet:
+		statefulSet := &appsv1.StatefulSet{}
+		if err := h.client.Get(ctx, key, statefulSet); err != nil {
+			return nil, err
+		}
+		podSpec = &statefulSet.Spec.Template.Spec
+	case KindDaemonSet:
+		daemonSet := &appsv1.DaemonSet{}
+		if err := h.client.Get(ctx, key, daemonSet); err != nil {
+			return nil, err
+		}
+		podSpec = &daemonSet.Spec.Template.Spec
+	case KindJob:
+		job := &batchv1.Job{}
+		if err := h.client.Get(ctx, key, job); err != nil {
+			return nil, err
+		}
+		podSpec = &job.Spec.Template.Spec
+	default:
+		return nil, fmt.Errorf("unsupported workload kind: %s", kind)
+	}
+
+	return extractNetworkConfig(podSpec), nil
+}
+
+// updateNetworkConfig updates the network configuration on a workload
+func (h *networkHandler) updateNetworkConfig(req *restful.Request, namespace, name, kind string, config *NetworkConfig) error {
+	ctx := req.Request.Context()
+	key := runtimeclient.ObjectKey{Namespace: namespace, Name: name}
+
+	switch kind {
+	case KindDeployment:
+		deployment := &appsv1.Deployment{}
+		if err := h.client.Get(ctx, key, deployment); err != nil {
+			return err
+		}
+		applyNetworkConfig(&deployment.Spec.Template.Spec, config)
+		return h.client.Update(ctx, deployment)
+	case KindStatefulSet:
+		statefulSet := &appsv1.StatefulSet{}
+		if err := h.client.Get(ctx, key, statefulSet); err != nil {
+			return err
+		}
+		applyNetworkConfig(&statefulSet.Spec.Template.Spec, config)
+		return h.client.Update(ctx, statefulSet)
+	case KindDaemonSet:
+		daemonSet := &appsv1.DaemonSet{}
+		if err := h.client.Get(ctx, key, daemonSet); err != nil {
+			return err
+		}
+		applyNetworkConfig(&daemonSet.Spec.Template.Spec, config)
+		return h.client.Update(ctx, daemonSet)
+	case KindJob:
+		job := &batchv1.Job{}
+		if err := h.client.Get(ctx, key, job); err != nil {
+			return err
+		}
+		applyNetworkConfig(&job.Spec.Template.Spec, config)
+		return h.client.Update(ctx, job)
+	default:
+		return fmt.Errorf("unsupported workload kind: %s", kind)
+	}
+}
+
+// extractNetworkConfig extracts network configuration from a PodSpec
+func extractNetworkConfig(podSpec *corev1.PodSpec) *NetworkConfig {
+	return &NetworkConfig{
+		DNSPolicy:             podSpec.DNSPolicy,
+		DNSConfig:             podSpec.DNSConfig,
+		HostNetwork:           podSpec.HostNetwork,
+		HostPID:               podSpec.HostPID,
+		HostIPC:               podSpec.HostIPC,
+		Hostname:              podSpec.Hostname,
+		Subdomain:             podSpec.Subdomain,
+		HostAliases:           podSpec.HostAliases,
+		ShareProcessNamespace: podSpec.ShareProcessNamespace,
+	}
+}
+
+// applyNetworkConfig applies network configuration to a PodSpec
+func applyNetworkConfig(podSpec *corev1.PodSpec, config *NetworkConfig) {
+	if config.DNSPolicy != "" {
+		podSpec.DNSPolicy = config.DNSPolicy
+	}
+	if config.DNSConfig != nil {
+		podSpec.DNSConfig = config.DNSConfig
+	}
+	podSpec.HostNetwork = config.HostNetwork
+	podSpec.HostPID = config.HostPID
+	podSpec.HostIPC = config.HostIPC
+	if config.Hostname != "" {
+		podSpec.Hostname = config.Hostname
+	}
+	if config.Subdomain != "" {
+		podSpec.Subdomain = config.Subdomain
+	}
+	if config.HostAliases != nil {
+		podSpec.HostAliases = config.HostAliases
+	}
+	if config.ShareProcessNamespace != nil {
+		podSpec.ShareProcessNamespace = config.ShareProcessNamespace
+	}
+}

--- a/pkg/kapis/workloadnetwork/v1alpha1/handler_test.go
+++ b/pkg/kapis/workloadnetwork/v1alpha1/handler_test.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2024 the KubeSphere Authors.
+ * Please refer to the LICENSE file in the root directory of the project.
+ * https://github.com/kubesphere/kubesphere/blob/master/LICENSE
+ */
+
+package v1alpha1
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestExtractNetworkConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		podSpec  *corev1.PodSpec
+		expected *NetworkConfig
+	}{
+		{
+			name:    "empty pod spec",
+			podSpec: &corev1.PodSpec{},
+			expected: &NetworkConfig{
+				DNSPolicy:             "",
+				DNSConfig:             nil,
+				HostNetwork:           false,
+				HostPID:               false,
+				HostIPC:               false,
+				Hostname:              "",
+				Subdomain:             "",
+				HostAliases:           nil,
+				ShareProcessNamespace: nil,
+			},
+		},
+		{
+			name: "full network config",
+			podSpec: &corev1.PodSpec{
+				DNSPolicy:   corev1.DNSClusterFirst,
+				HostNetwork: true,
+				HostPID:     true,
+				HostIPC:     true,
+				Hostname:    "test-host",
+				Subdomain:   "test-subdomain",
+				DNSConfig: &corev1.PodDNSConfig{
+					Nameservers: []string{"8.8.8.8"},
+					Searches:    []string{"example.com"},
+				},
+				HostAliases: []corev1.HostAlias{
+					{IP: "127.0.0.1", Hostnames: []string{"localhost"}},
+				},
+				ShareProcessNamespace: ptr.To(true),
+			},
+			expected: &NetworkConfig{
+				DNSPolicy:   corev1.DNSClusterFirst,
+				HostNetwork: true,
+				HostPID:     true,
+				HostIPC:     true,
+				Hostname:    "test-host",
+				Subdomain:   "test-subdomain",
+				DNSConfig: &corev1.PodDNSConfig{
+					Nameservers: []string{"8.8.8.8"},
+					Searches:    []string{"example.com"},
+				},
+				HostAliases: []corev1.HostAlias{
+					{IP: "127.0.0.1", Hostnames: []string{"localhost"}},
+				},
+				ShareProcessNamespace: ptr.To(true),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractNetworkConfig(tt.podSpec)
+
+			if result.DNSPolicy != tt.expected.DNSPolicy {
+				t.Errorf("DNSPolicy = %v, want %v", result.DNSPolicy, tt.expected.DNSPolicy)
+			}
+			if result.HostNetwork != tt.expected.HostNetwork {
+				t.Errorf("HostNetwork = %v, want %v", result.HostNetwork, tt.expected.HostNetwork)
+			}
+			if result.HostPID != tt.expected.HostPID {
+				t.Errorf("HostPID = %v, want %v", result.HostPID, tt.expected.HostPID)
+			}
+			if result.HostIPC != tt.expected.HostIPC {
+				t.Errorf("HostIPC = %v, want %v", result.HostIPC, tt.expected.HostIPC)
+			}
+			if result.Hostname != tt.expected.Hostname {
+				t.Errorf("Hostname = %v, want %v", result.Hostname, tt.expected.Hostname)
+			}
+			if result.Subdomain != tt.expected.Subdomain {
+				t.Errorf("Subdomain = %v, want %v", result.Subdomain, tt.expected.Subdomain)
+			}
+		})
+	}
+}
+
+func TestApplyNetworkConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		initialSpec *corev1.PodSpec
+		config      *NetworkConfig
+		expected    *corev1.PodSpec
+	}{
+		{
+			name:        "apply empty config",
+			initialSpec: &corev1.PodSpec{},
+			config:      &NetworkConfig{},
+			expected: &corev1.PodSpec{
+				HostNetwork: false,
+				HostPID:     false,
+				HostIPC:     false,
+			},
+		},
+		{
+			name:        "apply full config",
+			initialSpec: &corev1.PodSpec{},
+			config: &NetworkConfig{
+				DNSPolicy:   corev1.DNSClusterFirst,
+				HostNetwork: true,
+				HostPID:     true,
+				HostIPC:     true,
+				Hostname:    "new-host",
+				Subdomain:   "new-subdomain",
+				DNSConfig: &corev1.PodDNSConfig{
+					Nameservers: []string{"1.1.1.1"},
+				},
+				HostAliases: []corev1.HostAlias{
+					{IP: "192.168.1.1", Hostnames: []string{"myhost"}},
+				},
+				ShareProcessNamespace: ptr.To(true),
+			},
+			expected: &corev1.PodSpec{
+				DNSPolicy:   corev1.DNSClusterFirst,
+				HostNetwork: true,
+				HostPID:     true,
+				HostIPC:     true,
+				Hostname:    "new-host",
+				Subdomain:   "new-subdomain",
+				DNSConfig: &corev1.PodDNSConfig{
+					Nameservers: []string{"1.1.1.1"},
+				},
+				HostAliases: []corev1.HostAlias{
+					{IP: "192.168.1.1", Hostnames: []string{"myhost"}},
+				},
+				ShareProcessNamespace: ptr.To(true),
+			},
+		},
+		{
+			name: "override existing config",
+			initialSpec: &corev1.PodSpec{
+				DNSPolicy:   corev1.DNSDefault,
+				HostNetwork: true,
+				Hostname:    "old-host",
+			},
+			config: &NetworkConfig{
+				DNSPolicy:   corev1.DNSClusterFirst,
+				HostNetwork: false,
+				Hostname:    "new-host",
+			},
+			expected: &corev1.PodSpec{
+				DNSPolicy:   corev1.DNSClusterFirst,
+				HostNetwork: false,
+				HostPID:     false,
+				HostIPC:     false,
+				Hostname:    "new-host",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyNetworkConfig(tt.initialSpec, tt.config)
+
+			if tt.initialSpec.DNSPolicy != tt.expected.DNSPolicy {
+				t.Errorf("DNSPolicy = %v, want %v", tt.initialSpec.DNSPolicy, tt.expected.DNSPolicy)
+			}
+			if tt.initialSpec.HostNetwork != tt.expected.HostNetwork {
+				t.Errorf("HostNetwork = %v, want %v", tt.initialSpec.HostNetwork, tt.expected.HostNetwork)
+			}
+			if tt.initialSpec.HostPID != tt.expected.HostPID {
+				t.Errorf("HostPID = %v, want %v", tt.initialSpec.HostPID, tt.expected.HostPID)
+			}
+			if tt.initialSpec.HostIPC != tt.expected.HostIPC {
+				t.Errorf("HostIPC = %v, want %v", tt.initialSpec.HostIPC, tt.expected.HostIPC)
+			}
+			if tt.initialSpec.Hostname != tt.expected.Hostname {
+				t.Errorf("Hostname = %v, want %v", tt.initialSpec.Hostname, tt.expected.Hostname)
+			}
+			if tt.initialSpec.Subdomain != tt.expected.Subdomain {
+				t.Errorf("Subdomain = %v, want %v", tt.initialSpec.Subdomain, tt.expected.Subdomain)
+			}
+		})
+	}
+}

--- a/pkg/kapis/workloadnetwork/v1alpha1/register.go
+++ b/pkg/kapis/workloadnetwork/v1alpha1/register.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 the KubeSphere Authors.
+ * Please refer to the LICENSE file in the root directory of the project.
+ * https://github.com/kubesphere/kubesphere/blob/master/LICENSE
+ */
+
+package v1alpha1
+
+import (
+	"net/http"
+
+	"github.com/emicklei/go-restful/v3"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"kubesphere.io/kubesphere/pkg/api"
+	"kubesphere.io/kubesphere/pkg/apiserver/rest"
+	"kubesphere.io/kubesphere/pkg/apiserver/runtime"
+)
+
+var (
+	SchemeGroupVersion = schema.GroupVersion{Group: "workloadnetwork.kubesphere.io", Version: "v1alpha1"}
+)
+
+type networkHandler struct {
+	client runtimeclient.Client
+}
+
+// NewHandler creates a new network configuration handler
+func NewHandler(client runtimeclient.Client) rest.Handler {
+	return &networkHandler{
+		client: client,
+	}
+}
+
+// AddToContainer adds the network configuration API routes to the container
+func (h *networkHandler) AddToContainer(c *restful.Container) error {
+	ws := runtime.NewWebService(SchemeGroupVersion)
+
+	ws.Route(ws.GET("/namespaces/{namespace}/workloads/{kind}/{name}/networkconfig").
+		To(h.getWorkloadNetworkConfig).
+		Doc("Get network configuration for a workload").
+		Notes("Retrieves the network configuration (DNS, host network, etc.) for a specific workload.").
+		Operation("getWorkloadNetworkConfig").
+		Param(ws.PathParameter("namespace", "Namespace of the workload").Required(true)).
+		Param(ws.PathParameter("kind", "Kind of workload (Deployment, StatefulSet, DaemonSet, Job)").Required(true)).
+		Param(ws.PathParameter("name", "Name of the workload").Required(true)).
+		Returns(http.StatusOK, api.StatusOK, WorkloadNetworkConfigResponse{}).
+		Metadata("tag", api.TagNamespacedResources))
+
+	ws.Route(ws.PUT("/namespaces/{namespace}/workloads/{kind}/{name}/networkconfig").
+		To(h.updateWorkloadNetworkConfig).
+		Doc("Update network configuration for a workload").
+		Notes("Updates the network configuration (DNS, host network, etc.) for a specific workload.").
+		Operation("updateWorkloadNetworkConfig").
+		Param(ws.PathParameter("namespace", "Namespace of the workload").Required(true)).
+		Param(ws.PathParameter("kind", "Kind of workload (Deployment, StatefulSet, DaemonSet, Job)").Required(true)).
+		Param(ws.PathParameter("name", "Name of the workload").Required(true)).
+		Reads(WorkloadNetworkConfigRequest{}).
+		Returns(http.StatusOK, api.StatusOK, WorkloadNetworkConfigResponse{}).
+		Metadata("tag", api.TagNamespacedResources))
+
+	c.Add(ws)
+	return nil
+}

--- a/pkg/kapis/workloadnetwork/v1alpha1/types.go
+++ b/pkg/kapis/workloadnetwork/v1alpha1/types.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 the KubeSphere Authors.
+ * Please refer to the LICENSE file in the root directory of the project.
+ * https://github.com/kubesphere/kubesphere/blob/master/LICENSE
+ */
+
+package v1alpha1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NetworkConfig represents the network configuration options for a workload.
+// This mirrors the network-related fields in Kubernetes PodSpec.
+type NetworkConfig struct {
+	// DNSPolicy specifies the DNS policy for the pod.
+	// Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+	// DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+	// +optional
+	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
+
+	// DNSConfig specifies the DNS parameters of a pod.
+	// Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
+	// +optional
+	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
+
+	// HostNetwork indicates whether the pod should use the host's network namespace.
+	// If this option is set, the ports that will be used must be specified.
+	// Default to false.
+	// +optional
+	HostNetwork bool `json:"hostNetwork,omitempty"`
+
+	// HostPID indicates whether the pod should use the host's pid namespace.
+	// Default to false.
+	// +optional
+	HostPID bool `json:"hostPID,omitempty"`
+
+	// HostIPC indicates whether the pod should use the host's ipc namespace.
+	// Default to false.
+	// +optional
+	HostIPC bool `json:"hostIPC,omitempty"`
+
+	// Hostname specifies the hostname of the pod.
+	// If not specified, the pod's hostname will be set to a system-defined value.
+	// +optional
+	Hostname string `json:"hostname,omitempty"`
+
+	// Subdomain specifies the subdomain of the pod.
+	// If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+	// +optional
+	Subdomain string `json:"subdomain,omitempty"`
+
+	// HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file.
+	// This is only valid for non-hostNetwork pods.
+	// +optional
+	HostAliases []corev1.HostAlias `json:"hostAliases,omitempty"`
+
+	// ShareProcessNamespace enables sharing a single process namespace between all containers in a pod.
+	// When enabled, containers can see and signal processes from other containers in the pod.
+	// +optional
+	ShareProcessNamespace *bool `json:"shareProcessNamespace,omitempty"`
+}
+
+// WorkloadNetworkConfigRequest is the request body for updating network configuration
+// on a workload resource.
+type WorkloadNetworkConfigRequest struct {
+	// Kind is the workload kind (Deployment, StatefulSet, DaemonSet, Job)
+	Kind string `json:"kind"`
+
+	// NetworkConfig contains the network configuration to apply
+	NetworkConfig NetworkConfig `json:"networkConfig"`
+}
+
+// WorkloadNetworkConfigResponse is the response body containing the current
+// network configuration of a workload.
+type WorkloadNetworkConfigResponse struct {
+	// Kind is the workload kind
+	Kind string `json:"kind"`
+
+	// Name is the workload name
+	Name string `json:"name"`
+
+	// Namespace is the workload namespace
+	Namespace string `json:"namespace"`
+
+	// NetworkConfig contains the current network configuration
+	NetworkConfig NetworkConfig `json:"networkConfig"`
+}


### PR DESCRIPTION
## Summary
This PR fixes #4670

## Changes
- Add new REST API endpoints for workload network configuration management
- Support GET and PUT operations for network config on Deployment, StatefulSet, DaemonSet, and Job workloads
- Expose network-related PodSpec fields: DNSPolicy, DNSConfig, HostNetwork, HostPID, HostIPC, Hostname, Subdomain, HostAliases, and ShareProcessNamespace
- Include comprehensive unit tests for network config extraction and application

## New API Endpoints
- `GET /kapis/workloadnetwork.kubesphere.io/v1alpha1/namespaces/{namespace}/workloads/{kind}/{name}/networkconfig`
- `PUT /kapis/workloadnetwork.kubesphere.io/v1alpha1/namespaces/{namespace}/workloads/{kind}/{name}/networkconfig`

## Test Plan
- [x] Unit tests for `extractNetworkConfig` function
- [x] Unit tests for `applyNetworkConfig` function
- [x] All tests pass (`go test ./pkg/kapis/workloadnetwork/...`)
- [x] Code builds successfully (`go build ./pkg/apiserver/...`)
- [x] go vet passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)