### PR TITLE
fix: correct Secret type in DevOps credential API examples

### DIFF
--- a/skills/kubesphere-devops-credentials/SKILL.md
+++ b/skills/kubesphere-devops-credentials/SKILL.md
@@ -107,7 +107,7 @@ curl -X POST "https://kubesphere-api/kapis/devops.kubesphere.io/v1alpha3/namespa
       "username": "git",
       "privatekey": "-----BEGIN OPENSSH PRIVATE KEY-----\n...\n-----END OPENSSH PRIVATE KEY-----"
     },
-    "type": "Opaque"
+    "type": "credential.devops.kubesphere.io/ssh-auth"
   }'
 ```
 
@@ -130,7 +130,7 @@ curl -X POST "https://kubesphere-api/kapis/devops.kubesphere.io/v1alpha3/namespa
       "username": "docker-user",
       "password": "docker-password"
     },
-    "type": "Opaque"
+    "type": "credential.devops.kubesphere.io/basic-auth"
   }'
 ```
 
@@ -191,7 +191,7 @@ curl -X POST "https://kubesphere-api/kapis/devops.kubesphere.io/v1alpha3/namespa
     "stringData": {
       "secret": "my-api-token-value"
     },
-    "type": "Opaque"
+    "type": "credential.devops.kubesphere.io/secret-text"
   }'
 ```
 
@@ -465,7 +465,7 @@ curl -s -X POST "${KUBESPHERE_API}/kapis/devops.kubesphere.io/v1alpha3/namespace
       "username": "git",
       "password": "'${GITHUB_TOKEN}'"
     },
-    "type": "Opaque"
+    "type": "credential.devops.kubesphere.io/basic-auth"
   }' | jq -r '.metadata.name'
 
 # 2. Create GitRepository


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

The API examples in `skills/kubesphere-devops-credentials/SKILL.md` use `"type": "Opaque"` for Secret objects, but the file's own documentation (lines 56–70) explicitly warns that `type: Opaque` causes credentials to be silently ignored by the credential controller:

> **Controller Logic:** The credential controller only watches secrets with types starting with `credential.devops.kubesphere.io/` (see `devopscredential_controller.go` line 102). Secrets with `type: Opaque` are completely ignored.

This internal contradiction means agents or users following the API examples will create credentials that:
- stay stuck at "pending" sync status
- are invisible to Jenkins
- cause pipeline builds to fail with "CredentialId could not be found"

## Fix

Replace `"type": "Opaque"` with the correct domain-specific type in all four affected examples:

| Example | Old type | New type |
|---------|----------|----------|
| SSH key (`github-ssh-key`) | `Opaque` | `credential.devops.kubesphere.io/ssh-auth` |
| Basic auth (`docker-registry`) | `Opaque` | `credential.devops.kubesphere.io/basic-auth` |
| Secret text (`api-token`) | `Opaque` | `credential.devops.kubesphere.io/secret-text` |
| Git access token (`github-token`) | `Opaque` | `credential.devops.kubesphere.io/basic-auth` |

The types match the `credential.devops.kubesphere.io/type` annotations already present in each example.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-incorrect-api-example","fingerprint":"sha256:d7125c5c8c94a753e89aaf150c84e91185af2824559c8e8597bcef64aa04fa7c"}]}
nlpm-metadata-end -->