### PR TITLE
fix: close missing double-quote in fluid Dataset YAML template

### DIFF
--- a/skills/kubesphere-fluid/SKILL.md
+++ b/skills/kubesphere-fluid/SKILL.md
@@ -407,7 +407,7 @@ spec:
         path: {{path}}
         quota: {{quota}}
         high: "{{high}}"
-        low: "{{low}}
+        low: "{{low}}"
 ```
 
 **When user explicitly asks for "Dataset with Runtime", generate both:**


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

In `skills/kubesphere-fluid/SKILL.md`, the YAML template for a Dataset with tiered storage has a syntax error at the `low` field:

```yaml
        low: "{{low}}
```

The closing double-quote is missing. This produces invalid YAML — any tooling or agent that renders this template and applies it as a KubeSphere InstallPlan will get a parse error.

## Fix

Add the missing closing double-quote:

```yaml
        low: "{{low}}"
```

This makes the template consistent with the `high` field immediately above it, which is already correctly quoted.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-yaml-syntax-error","fingerprint":"sha256:48e59502353a5665adbede1b06db2a69a4c2002e968ccfb44ef622d00910b90a"}]}
nlpm-metadata-end -->