### PR TITLE
fix: correct step references in whizard-logging installation guide

### DIFF
--- a/skills/whizard-logging/SKILL.md
+++ b/skills/whizard-logging/SKILL.md
@@ -101,7 +101,7 @@ spec:
 ```
 
 **Replace placeholders:**
-- `<VERSION>`: From Step 3 (e.g., `1.4.0`)
+- `<VERSION>`: From Step 2 (e.g., `1.4.0`)
 - `<TARGET_CLUSTERS>`: User-confirmed cluster names
 
 **Note:** OpenSearch sink configuration (endpoints, auth) is provided by the **vector** extension. Make sure vector is installed and configured with OpenSearch before installing logging.
@@ -118,7 +118,7 @@ metadata:
 spec:
   extension:
     name: whizard-logging
-    version: <VERSION>  # From Step 3
+    version: <VERSION>  # From Step 2
   enabled: true
   upgradeStrategy: Manual
   config: |


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

In `skills/whizard-logging/SKILL.md`, two version placeholder comments refer to a non-existent "Step 3":

```yaml
- `<VERSION>`: From Step 3 (e.g., `1.4.0`)    # line 104
    version: <VERSION>  # From Step 3            # line 121
```

The installation section defines only **Step 1** (Get Available Clusters) and **Step 2** (Get Latest Version). Step 3 does not exist. This confuses agents and users who follow the instructions looking for a step that isn't there. The version is retrieved in Step 2.

The same file already uses the correct reference at line 94:
```yaml
    version: <VERSION>  # From Step 2
```

## Fix

Replace both `From Step 3` occurrences with `From Step 2`, making the version comments consistent throughout the file.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-incorrect-step-reference","fingerprint":"sha256:866ff4edfa78d47baa05df21199201de19b87960829a9958f0fdab84b666cdc0"}]}
nlpm-metadata-end -->