### PR TITLE
fix: close unclosed bold marker in devops-pipeline SKILL.md

### DIFF
--- a/skills/kubesphere-devops-pipeline/SKILL.md
+++ b/skills/kubesphere-devops-pipeline/SKILL.md
@@ -320,7 +320,7 @@ spec:
     script_path: go/Jenkinsfile  # Path to Jenkinsfile in repo
 ```
 
-**Step 3b: For Private Repository (with credential):
+**Step 3b: For Private Repository (with credential):**
 ```yaml
 apiVersion: devops.kubesphere.io/v1alpha3
 kind: Pipeline


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

In `skills/kubesphere-devops-pipeline/SKILL.md` at line 323, a bold heading is missing its closing `**` marker:

```markdown
**Step 3b: For Private Repository (with credential):
```yaml
```

The unclosed bold marker causes the text to render incorrectly in Markdown renderers (the bold continues into the code block fence), and may confuse agents that parse section boundaries based on heading formatting.

## Fix

Add the missing closing `**` before the colon:

```markdown
**Step 3b: For Private Repository (with credential):**
```yaml
```

This makes the heading consistent with other bold step headings in the same file.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-broken-markdown","fingerprint":"sha256:3fea9e06f7927b9e887cb79c522463be8820db21b5629905df31f54e0c92d6b6"}]}
nlpm-metadata-end -->