### PR TITLE
fix: remove duplicate Project Components diagram in devops-overview

### DIFF
--- a/skills/kubesphere-devops-overview/SKILL.md
+++ b/skills/kubesphere-devops-overview/SKILL.md
@@ -107,23 +107,6 @@ EOF
 └──────────────┘ └───────────┘ └─────────────┘
 ```
 
-```
-┌──────────────────────────────────────────────────────────────┐
-│                     DevOps Project                            │
-│  (Namespace with devops.kubesphere.io/managed=true label)    │
-└──────────────────────┬───────────────────────────────────────┘
-                       │
-        ┌──────────────┼──────────────┐
-        │              │              │
-┌───────▼──────┐ ┌─────▼─────┐ ┌──────▼──────┐
-│  Pipelines   │ │Credentials│ │   Webhooks  │
-│              │ │           │ │             │
-│ - Graphical  │ │ - SSH     │ │ - GitHub    │
-│ - Jenkinsfile│ │ - Basic   │ │ - GitLab    │
-│ - Multi-branch│ │ - Token  │ │ - Generic   │
-└──────────────┘ └───────────┘ └─────────────┘
-```
-
 ## Installation
 
 ### Using InstallPlan (Recommended for Production)


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

In `skills/kubesphere-devops-overview/SKILL.md`, the `Project Components` ASCII architecture diagram appears twice consecutively under the same heading (lines 93–108 and 110–125). The two blocks are byte-for-byte identical:

```
┌──────────────────────────────────────────────────────────────┐
│                     DevOps Project                            │
│  (Namespace with devops.kubesphere.io/managed=true label)    │
└──────────────────────┬───────────────────────────────────────┘
                       │
        ┌──────────────┼──────────────┐
        │              │              │
┌───────▼──────┐ ┌─────▼─────┐ ┌──────▼──────┐
│  Pipelines   │ │Credentials│ │   Webhooks  │
│              │ │           │ │             │
│ - Graphical  │ │ - SSH     │ │ - GitHub    │
│ - Jenkinsfile│ │ - Basic   │ │ - GitLab    │
│ - Multi-branch│ │ - Token  │ │ - Generic   │
└──────────────┘ └───────────┘ └─────────────┘
```

The duplication increases file size and creates a maintenance hazard (any future edit needs to be applied twice).

## Fix

Remove the second identical block, leaving a single clean diagram under `Project Components`.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-duplicate-section","fingerprint":"sha256:7baa04098f252c88f3e6494c7405143d88acfc54fb15cd376d7bc40d842c6bfc"}]}
nlpm-metadata-end -->