### PR TITLE
fix(devops-credentials): use correct Secret type in credential API examples

### DIFF
--- a/skills/kubesphere-devops-credentials/SKILL.md
+++ b/skills/kubesphere-devops-credentials/SKILL.md
@@ -107,7 +107,7 @@ curl -X POST "https://kubesphere-api/kapis/devops.kubesphere.io/v1alpha3/namespa
       "username": "git",
       "privatekey": "-----BEGIN OPENSSH PRIVATE KEY-----\n...\n-----END OPENSSH PRIVATE KEY-----"
     },
-    "type": "Opaque"
+    "type": "credential.devops.kubesphere.io/ssh-auth"
   }'
 ```
 
@@ -130,7 +130,7 @@ curl -X POST "https://kubesphere-api/kapis/devops.kubesphere.io/v1alpha3/namespa
       "username": "docker-user",
       "password": "docker-password"
     },
-    "type": "Opaque"
+    "type": "credential.devops.kubesphere.io/basic-auth"
   }'
 ```
 
@@ -191,7 +191,7 @@ curl -X POST "https://kubesphere-api/kapis/devops.kubesphere.io/v1alpha3/namespa
     "stringData": {
       "secret": "my-api-token-value"
     },
-    "type": "Opaque"
+    "type": "credential.devops.kubesphere.io/secret-text"
   }'
 ```
 
@@ -465,7 +465,7 @@ curl -s -X POST "${KUBESPHERE_API}/kapis/devops.kubesphere.io/v1alpha3/namespace
       "username": "git",
       "password": "'${GITHUB_TOKEN}'"
     },
-    "type": "Opaque"
+    "type": "credential.devops.kubesphere.io/basic-auth"
   }' | jq -r '.metadata.name'
 
 # 2. Create GitRepository


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

The API curl examples in `skills/kubesphere-devops-credentials/SKILL.md` create credentials using `"type": "Opaque"`, but the file's own warning section (lines 56–70) explicitly states that `type: Opaque` breaks Jenkins credential sync. The credential controller only watches secrets whose type starts with `credential.devops.kubesphere.io/` (confirmed at `devopscredential_controller.go` line 102). Secrets with `type: Opaque` are silently ignored, causing pipelines to fail with `CredentialId could not be found`.

## Fix

Replace `"type": "Opaque"` with the correct domain-specific type in all four API examples:

| Example | Before | After |
|---------|--------|-------|
| Create SSH Credential | `"type": "Opaque"` | `"type": "credential.devops.kubesphere.io/ssh-auth"` |
| Create Basic Auth Credential | `"type": "Opaque"` | `"type": "credential.devops.kubesphere.io/basic-auth"` |
| Create Secret Text Credential | `"type": "Opaque"` | `"type": "credential.devops.kubesphere.io/secret-text"` |
| Create GitRepository script | `"type": "Opaque"` | `"type": "credential.devops.kubesphere.io/basic-auth"` |

The warning text and the YAML example at the top of the file already use the correct types — this PR makes the curl examples consistent with that existing guidance.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-incorrect-api-example","fingerprint":"sha256:d7125c5c8c94a753e89aaf150c84e91185af2824559c8e8597bcef64aa04fa7c"}]}
nlpm-metadata-end -->