### PR TITLE
fix(fluid): close unclosed double-quote in Dataset tieredstore YAML template

### DIFF
--- a/skills/kubesphere-fluid/SKILL.md
+++ b/skills/kubesphere-fluid/SKILL.md
@@ -407,7 +407,7 @@ spec:
         path: {{path}}
         quota: {{quota}}
         high: "{{high}}"
-        low: "{{low}}
+        low: "{{low}}"
 ```
 
 **When user explicitly asks for "Dataset with Runtime", generate both:**


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

In `skills/kubesphere-fluid/SKILL.md`, the Dataset tieredstore YAML template at line 410 has an unclosed double-quote:

```yaml
        low: "{{low}}
```

The missing closing `"` produces invalid YAML. Any tool or agent that generates an InstallPlan from this template will produce a document that fails to parse.

## Fix

Add the closing double-quote to match the pattern used by the `high` field immediately above it:

```yaml
        low: "{{low}}"
```

This is a one-character typo fix that makes the template consistent with the already-correct `high: "{{high}}"` on the preceding line.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-yaml-syntax-error","fingerprint":"sha256:48e59502353a5665adbede1b06db2a69a4c2002e968ccfb44ef622d00910b90a"}]}
nlpm-metadata-end -->