### PR TITLE
fix(whizard-logging): correct 'From Step 3' placeholder to 'From Step 2'

### DIFF
--- a/skills/whizard-logging/SKILL.md
+++ b/skills/whizard-logging/SKILL.md
@@ -101,7 +101,7 @@ spec:
 ```
 
 **Replace placeholders:**
-- `<VERSION>`: From Step 3 (e.g., `1.4.0`)
+- `<VERSION>`: From Step 2 (e.g., `1.4.0`)
 - `<TARGET_CLUSTERS>`: User-confirmed cluster names
 
 **Note:** OpenSearch sink configuration (endpoints, auth) is provided by the **vector** extension. Make sure vector is installed and configured with OpenSearch before installing logging.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

In `skills/whizard-logging/SKILL.md`, the installation template placeholder at line 104 reads:

```
- `<VERSION>`: From Step 3 (e.g., `1.4.0`)
```

However, the installation section defines only two steps:
- **Step 1**: Get Available Clusters and Confirm Target
- **Step 2**: Get Latest Version (if not provided by user)

There is no Step 3. The version value is retrieved in Step 2, so the comment points agents to a non-existent step, causing confusion during the installation workflow.

## Fix

Change `From Step 3` to `From Step 2` so the reference is accurate:

```
- `<VERSION>`: From Step 2 (e.g., `1.4.0`)
```

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-incorrect-step-reference","fingerprint":"sha256:866ff4edfa78d47baa05df21199201de19b87960829a9958f0fdab84b666cdc0"}]}
nlpm-metadata-end -->