### PR TITLE
fix(devops-pipeline): close unclosed bold marker in 'Step 3b' heading

### DIFF
--- a/skills/kubesphere-devops-pipeline/SKILL.md
+++ b/skills/kubesphere-devops-pipeline/SKILL.md
@@ -320,7 +320,7 @@ spec:
     script_path: go/Jenkinsfile  # Path to Jenkinsfile in repo
 ```
 
-**Step 3b: For Private Repository (with credential):
+**Step 3b: For Private Repository (with credential):**
 ```yaml
 apiVersion: devops.kubesphere.io/v1alpha3
 kind: Pipeline


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

In `skills/kubesphere-devops-pipeline/SKILL.md` at line 323, the heading for Step 3b has an unclosed bold marker:

```markdown
**Step 3b: For Private Repository (with credential):
```

The opening `**` has no matching closing `**`. This means the bold formatting extends through the rest of the document, causing incorrect rendering in any Markdown renderer. It also makes automated section-boundary detection unreliable.

## Fix

Add the closing `**` at the end of the heading text, matching the pattern used by other step headings in the same file:

```markdown
**Step 3b: For Private Repository (with credential):**
```

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-broken-markdown","fingerprint":"sha256:3fea9e06f7927b9e887cb79c522463be8820db21b5629905df31f54e0c92d6b6"}]}
nlpm-metadata-end -->