### PR TITLE
fix(devops-overview): remove duplicate Project Components ASCII diagram

### DIFF
--- a/skills/kubesphere-devops-overview/SKILL.md
+++ b/skills/kubesphere-devops-overview/SKILL.md
@@ -107,23 +107,6 @@ EOF
 └──────────────┘ └───────────┘ └─────────────┘
 ```
 
-```
-┌──────────────────────────────────────────────────────────────┐
-│                     DevOps Project                            │
-│  (Namespace with devops.kubesphere.io/managed=true label)    │
-└──────────────────────┬───────────────────────────────────────┘
-                       │
-        ┌──────────────┼──────────────┐
-        │              │              │
-┌───────▼──────┐ ┌─────▼─────┐ ┌──────▼──────┐
-│  Pipelines   │ │Credentials│ │   Webhooks  │
-│              │ │           │ │             │
-│ - Graphical  │ │ - SSH     │ │ - GitHub    │
-│ - Jenkinsfile│ │ - Basic   │ │ - GitLab    │
-│ - Multi-branch│ │ - Token  │ │ - Generic   │
-└──────────────┘ └───────────┘ └─────────────┘
-```
-
 ## Installation
 
 ### Using InstallPlan (Recommended for Production)


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

In `skills/kubesphere-devops-overview/SKILL.md`, the `Project Components` ASCII architecture diagram block appears twice in succession — the identical content block was duplicated right after the first occurrence (before the `## Installation` section). This is a pure copy-paste artifact with no informational value.

The duplicate inflates the document length, creates a confusing visual double, and may cause automated documentation tools to extract or index the same data twice.

## Fix

Remove the second occurrence of the diagram block. The first occurrence (under `### Project Components`) is preserved intact. No content is lost; only the exact duplicate is removed.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-duplicate-section","fingerprint":"sha256:7baa04098f252c88f3e6494c7405143d88acfc54fb15cd376d7bc40d842c6bfc"}]}
nlpm-metadata-end -->