### PR TITLE
fix: parse first forwarded client IP

### DIFF
--- a/pkg/utils/iputil/iputils.go
+++ b/pkg/utils/iputil/iputils.go
@@ -9,6 +9,7 @@ package iputil
 import (
 	"net"
 	"net/http"
+	"strings"
 )
 
 const (
@@ -24,7 +25,7 @@ func RemoteIp(req *http.Request) string {
 	} else if ip := req.Header.Get(XRealIP); ip != "" {
 		remoteAddr = ip
 	} else if ip = req.Header.Get(XForwardedFor); ip != "" {
-		remoteAddr = ip
+		remoteAddr = strings.TrimSpace(strings.Split(ip, ",")[0])
 	} else {
 		remoteAddr, _, _ = net.SplitHostPort(remoteAddr)
 	}

--- a/pkg/utils/iputil/iputils_test.go
+++ b/pkg/utils/iputil/iputils_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 the KubeSphere Authors.
+ * Please refer to the LICENSE file in the root directory of the project.
+ * https://github.com/kubesphere/kubesphere/blob/master/LICENSE
+ */
+
+package iputil
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestRemoteIp(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		headers    http.Header
+		want       string
+	}{
+		{
+			name:       "uses remote address host",
+			remoteAddr: "192.0.2.10:12345",
+			want:       "192.0.2.10",
+		},
+		{
+			name:       "normalizes IPv6 localhost",
+			remoteAddr: "[::1]:12345",
+			want:       "127.0.0.1",
+		},
+		{
+			name:       "x-client-ip has highest priority",
+			remoteAddr: "192.0.2.10:12345",
+			headers: http.Header{
+				"X-Client-Ip":     []string{"203.0.113.10"},
+				"X-Real-Ip":       []string{"203.0.113.20"},
+				"X-Forwarded-For": []string{"203.0.113.30"},
+			},
+			want: "203.0.113.10",
+		},
+		{
+			name:       "x-forwarded-for returns original client",
+			remoteAddr: "192.0.2.10:12345",
+			headers: http.Header{
+				"X-Forwarded-For": []string{"203.0.113.10, 10.0.0.2"},
+			},
+			want: "203.0.113.10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &http.Request{
+				RemoteAddr: tt.remoteAddr,
+				Header:     tt.headers,
+			}
+
+			if got := RemoteIp(req); got != tt.want {
+				t.Fatalf("RemoteIp() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:
RemoteIp returned the whole X-Forwarded-For chain, like `203.0.113.10, 10.0.0.2`. That value goes into request info, audit source IPs and access logs. tiny fix, real bug tho

This now uses the first forwarded IP and keeps the existing x-client-ip, X-Real-IP and RemoteAddr paths covered by tests.

Repro:
1. Add the new `TestRemoteIp/x-forwarded-for returns original client` case on the parent commit.
2. Run `go test ./pkg/utils/iputil`.
3. It fails with `RemoteIp() = "203.0.113.10, 10.0.0.2", want "203.0.113.10"`.

Checked real-world trigger: XFF is a normal proxy header, and AWS ALB can append comma-separated IPs by default. No quota gymnastics needed.

### Which issue(s) this PR fixes:
None

### Special notes for reviewers:
```
Related old source-IP reports: #4736, #5998
Tested: go test ./pkg/utils/iputil ./pkg/apiserver/request ./pkg/apiserver/filters ./pkg/apiserver/auditing
```

### Does this PR introduced a user-facing change?
```release-note
Fix client IP parsing from multi-hop X-Forwarded-For headers.
```

### Additional documentation, usage docs, etc.:
```docs
None
```