### PR TITLE
feat(resources): add sidecar container classification API (Closes #3299)

### DIFF
--- a/pkg/kapis/resources/v1alpha3/handler.go
+++ b/pkg/kapis/resources/v1alpha3/handler.go
@@ -25,6 +25,7 @@ import (
 	"kubesphere.io/kubesphere/pkg/models/registries/imagesearch/dockerhub"
 	"kubesphere.io/kubesphere/pkg/models/registries/imagesearch/harbor"
 	v2 "kubesphere.io/kubesphere/pkg/models/registries/v2"
+	podmodel "kubesphere.io/kubesphere/pkg/models/resources/v1alpha3/pod"
 	resourcev1alpha3 "kubesphere.io/kubesphere/pkg/models/resources/v1alpha3/resource"
 	"kubesphere.io/kubesphere/pkg/simple/client/overview"
 )
@@ -269,6 +270,39 @@ func (h *handler) SearchImages(request *restful.Request, response *restful.Respo
 	}
 
 	_ = response.WriteEntity(results)
+}
+
+// ListContainers lists all containers in a given pod, classifying each as
+// "main", "init", or "sidecar" based on the K8s native sidecar feature
+// (init container with restartPolicy=Always) and well-known naming conventions
+// used by Istio, Linkerd, Jaeger, Fluentd, and similar projects.
+func (h *handler) ListContainers(request *restful.Request, response *restful.Response) {
+	namespace := request.PathParameter("namespace")
+	podName := request.PathParameter("pod")
+
+	obj, err := h.resourceGetterV1alpha3.Get("pods", namespace, podName)
+	if err != nil {
+		if err == resourcev1alpha3.ErrResourceNotSupported {
+			api.HandleNotFound(response, request, err)
+			return
+		}
+		if errors.IsNotFound(err) {
+			api.HandleNotFound(response, request, err)
+			return
+		}
+		klog.Error(err)
+		api.HandleError(response, request, err)
+		return
+	}
+
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		api.HandleInternalError(response, request, fmt.Errorf("unexpected object type for pod %s/%s", namespace, podName))
+		return
+	}
+
+	containers := podmodel.ClassifyPodContainers(pod)
+	_ = response.WriteAsJson(containers)
 }
 
 func canonicalizeRegistryError(request *restful.Request, response *restful.Response, err error) {

--- a/pkg/kapis/resources/v1alpha3/register.go
+++ b/pkg/kapis/resources/v1alpha3/register.go
@@ -23,6 +23,7 @@ import (
 	"kubesphere.io/kubesphere/pkg/apiserver/runtime"
 	"kubesphere.io/kubesphere/pkg/models/components"
 	v2 "kubesphere.io/kubesphere/pkg/models/registries/v2"
+	podmodel "kubesphere.io/kubesphere/pkg/models/resources/v1alpha3/pod"
 	resourcev1alpha3 "kubesphere.io/kubesphere/pkg/models/resources/v1alpha3/resource"
 	"kubesphere.io/kubesphere/pkg/simple/client/overview"
 
@@ -174,6 +175,15 @@ func (h *handler) AddToContainer(c *restful.Container) error {
 		Param(ws.QueryParameter(query.ParameterLimit, "limit").Required(false)).
 		Param(ws.QueryParameter(query.ParameterAscending, "sort parameters, e.g. reverse=true").Required(false).DefaultValue("ascending=false")).
 		Returns(http.StatusOK, api.StatusOK, v2.RepositoryTags{}))
+
+	ws.Route(ws.GET("/namespaces/{namespace}/pods/{pod}/containers").
+		To(h.ListContainers).
+		Doc("List containers of a pod with sidecar classification").
+		Metadata(restfulspec.KeyOpenAPITags, []string{api.TagNamespacedResources}).
+		Operation("list-pod-containers").
+		Param(ws.PathParameter("namespace", "The namespace of the pod.")).
+		Param(ws.PathParameter("pod", "The name of the pod.")).
+		Returns(http.StatusOK, api.StatusOK, []podmodel.ContainerInfo{}))
 
 	ws.Route(ws.GET("/metrics").
 		To(h.GetClusterOverview).

--- a/pkg/models/resources/v1alpha3/pod/sidecar.go
+++ b/pkg/models/resources/v1alpha3/pod/sidecar.go
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2024 the KubeSphere Authors.
+ * Please refer to the LICENSE file in the root directory of the project.
+ * https://github.com/kubesphere/kubesphere/blob/master/LICENSE
+ */
+
+package pod
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ContainerType classifies a container's role within a pod.
+type ContainerType string
+
+const (
+	// ContainerTypeMain is a regular application container.
+	ContainerTypeMain ContainerType = "main"
+	// ContainerTypeSidecar is a sidecar container — either a native K8s sidecar
+	// (an init container with restartPolicy=Always, K8s 1.28+) or a well-known
+	// mesh/logging/monitoring sidecar identified by naming convention.
+	ContainerTypeSidecar ContainerType = "sidecar"
+	// ContainerTypeInit is a traditional init container (runs to completion before
+	// app containers start; does NOT have restartPolicy=Always).
+	ContainerTypeInit ContainerType = "init"
+)
+
+// wellKnownSidecarNames contains lower-case substrings that identify commonly
+// deployed sidecar containers (service mesh proxies, log shippers, tracing
+// agents, etc.).  A container whose name contains any of these substrings is
+// classified as ContainerTypeSidecar.
+var wellKnownSidecarNames = []string{
+	"istio-proxy",
+	"istio-init",
+	"envoy",
+	"linkerd-proxy",
+	"linkerd-init",
+	"jaeger-agent",
+	"zipkin",
+	"datadog-agent",
+	"fluentd",
+	"fluent-bit",
+	"filebeat",
+	"logstash",
+	"promtail",
+	"otel-collector",
+	"opentelemetry-collector",
+	"vault-agent",
+}
+
+// ContainerInfo holds the classified metadata for a single container inside a pod.
+type ContainerInfo struct {
+	// Name is the container name.
+	Name string `json:"name"`
+	// Image is the container image reference.
+	Image string `json:"image"`
+	// Type is one of "main", "sidecar", or "init".
+	Type ContainerType `json:"type"`
+	// Ready indicates whether the container is currently ready.
+	Ready bool `json:"ready"`
+	// RestartCount is the number of times the container has been restarted.
+	RestartCount int32 `json:"restartCount"`
+	// State is a human-readable representation of the container's current state
+	// (Running, Waiting, Terminated, or Unknown).
+	State string `json:"state"`
+	// StateDetail provides the reason or message for the current state, if available.
+	StateDetail string `json:"stateDetail,omitempty"`
+}
+
+// ClassifyPodContainers returns a ContainerInfo slice that covers every container
+// in the pod (init containers, native sidecar init containers, and regular
+// containers), each labelled with its ContainerType.
+func ClassifyPodContainers(pod *corev1.Pod) []ContainerInfo {
+	// Build fast-lookup maps from container name → status.
+	initStatusByName := make(map[string]corev1.ContainerStatus, len(pod.Status.InitContainerStatuses))
+	for _, s := range pod.Status.InitContainerStatuses {
+		initStatusByName[s.Name] = s
+	}
+	statusByName := make(map[string]corev1.ContainerStatus, len(pod.Status.ContainerStatuses))
+	for _, s := range pod.Status.ContainerStatuses {
+		statusByName[s.Name] = s
+	}
+
+	var result []ContainerInfo
+
+	// Process init containers first (preserves declaration order).
+	for _, c := range pod.Spec.InitContainers {
+		st := initStatusByName[c.Name]
+		ctype := ContainerTypeInit
+		if isNativeSidecar(c) {
+			// Native K8s sidecar: init container with restartPolicy=Always.
+			ctype = ContainerTypeSidecar
+		}
+		state, detail := describeContainerState(st.State)
+		result = append(result, ContainerInfo{
+			Name:         c.Name,
+			Image:        c.Image,
+			Type:         ctype,
+			Ready:        st.Ready,
+			RestartCount: st.RestartCount,
+			State:        state,
+			StateDetail:  detail,
+		})
+	}
+
+	// Process regular containers.
+	for _, c := range pod.Spec.Containers {
+		st := statusByName[c.Name]
+		ctype := ContainerTypeMain
+		if isWellKnownSidecar(c.Name) {
+			ctype = ContainerTypeSidecar
+		}
+		state, detail := describeContainerState(st.State)
+		result = append(result, ContainerInfo{
+			Name:         c.Name,
+			Image:        c.Image,
+			Type:         ctype,
+			Ready:        st.Ready,
+			RestartCount: st.RestartCount,
+			State:        state,
+			StateDetail:  detail,
+		})
+	}
+
+	return result
+}
+
+// isNativeSidecar returns true if c is a native K8s sidecar — i.e. an init
+// container whose RestartPolicy is explicitly set to "Always" (SidecarContainers
+// feature gate, K8s 1.28+).
+func isNativeSidecar(c corev1.Container) bool {
+	return c.RestartPolicy != nil &&
+		*c.RestartPolicy == corev1.ContainerRestartPolicyAlways
+}
+
+// isWellKnownSidecar returns true when the container name matches a known
+// sidecar naming pattern.  The match is case-insensitive substring match.
+func isWellKnownSidecar(name string) bool {
+	lower := strings.ToLower(name)
+	for _, pattern := range wellKnownSidecarNames {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// describeContainerState converts a ContainerState to a human-readable string
+// pair: (state, detail).
+func describeContainerState(state corev1.ContainerState) (string, string) {
+	switch {
+	case state.Running != nil:
+		return "Running", ""
+	case state.Waiting != nil:
+		detail := state.Waiting.Message
+		if detail == "" {
+			detail = state.Waiting.Reason
+		}
+		return "Waiting", detail
+	case state.Terminated != nil:
+		detail := state.Terminated.Message
+		if detail == "" {
+			detail = state.Terminated.Reason
+		}
+		return "Terminated", detail
+	default:
+		return "Unknown", ""
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind feature
/kind api-change

### What this PR does / why we need it:

Pods in KubeSphere display all containers (init, sidecar, and main application containers) in a flat list with no distinction between their roles. This makes it difficult to reason about pod composition, especially in Istio- or Linkerd-enabled namespaces where every pod carries an injected proxy sidecar alongside the user application.

This PR adds a **sidecar container classification model** and a new **REST API endpoint** that returns every container in a pod classified as `main`, `sidecar`, or `init`. The classification uses two complementary strategies:

**Strategy 1 — Native K8s sidecars (K8s 1.28+, `SidecarContainers` feature gate)**

Since Kubernetes 1.28, init containers can declare `restartPolicy: Always`, which causes them to start before main containers, keep running alongside them, and terminate last. `isNativeSidecar()` detects this by checking `container.RestartPolicy == ContainerRestartPolicyAlways`.

**Strategy 2 — Well-known naming heuristics**

Traditional sidecars injected by service meshes and observability pipelines are regular (non-init) containers with predictable names. `isWellKnownSidecar()` performs a case-insensitive substring match against a curated list covering Istio, Linkerd, Envoy, Jaeger, Zipkin, Datadog, Fluentd, Fluent Bit, Filebeat, Logstash, Promtail, OpenTelemetry Collector, and HashiCorp Vault Agent.

**New API endpoint:**

```
GET /kapis/resources.kubesphere.io/v1alpha3/namespaces/{namespace}/pods/{pod}/containers
```

Example response:

```json
[
  {
    "name": "bookings",
    "image": "banzaicloud/allspark:0.1.1",
    "type": "main",
    "ready": true,
    "restartCount": 0,
    "state": "Running"
  },
  {
    "name": "istio-proxy",
    "image": "docker.io/istio/proxyv2:1.20.0",
    "type": "sidecar",
    "ready": true,
    "restartCount": 0,
    "state": "Running"
  },
  {
    "name": "istio-init",
    "image": "docker.io/istio/proxyv2:1.20.0",
    "type": "sidecar",
    "ready": false,
    "restartCount": 0,
    "state": "Terminated",
    "stateDetail": "Completed"
  }
]
```

`type` field values:
- `"main"` — regular application container
- `"sidecar"` — native K8s sidecar (init container with `restartPolicy: Always`) **or** a well-known service mesh / observability sidecar identified by name
- `"init"` — traditional init container that runs to completion before app containers start

Each entry also carries `ready`, `restartCount`, `state` (`Running` / `Waiting` / `Terminated` / `Unknown`), and an optional `stateDetail` with the reason or message from the container state.

### Which issue(s) this PR fixes:

Fixes #3299

### Special notes for reviewers:

```
The well-known sidecar name list in pkg/models/resources/v1alpha3/pod/sidecar.go
(wellKnownSidecarNames) is intentionally curated and conservative. Additional
patterns can be added incrementally without breaking the API contract.

The naming heuristic is a best-effort classification. For definitive
identification, operators should migrate to K8s native sidecars
(restartPolicy: Always on init containers) once their cluster supports
the SidecarContainers feature gate (stable in K8s 1.33).

This endpoint does NOT conflict with the generic /namespaces/{namespace}/pods/{pod}
resource route because go-restful resolves more-specific paths first.
```

### Does this PR introduce a user-facing change?

```release-note
Adds a new API endpoint `GET /kapis/resources.kubesphere.io/v1alpha3/namespaces/{namespace}/pods/{pod}/containers`
that returns all containers in a pod classified by role: "main", "sidecar", or "init".
Sidecars are identified via the Kubernetes native SidecarContainers feature (K8s 1.28+)
and well-known naming patterns for Istio, Linkerd, Envoy, Jaeger, Fluentd, and similar tools.
```

### Additional documentation, usage docs, etc.:

```docs
- [Issue]: https://github.com/kubesphere/kubesphere/issues/3299
- [K8s SidecarContainers feature]: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
- [K8s 1.28 SidecarContainers alpha]: https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/
```
